### PR TITLE
Cleanup use of collections and collections factories.

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -19,9 +19,7 @@ import com.squareup.kotlinpoet.Util.characterLiteralWithoutSingleQuotes
 import java.io.IOException
 import java.io.StringWriter
 import java.lang.reflect.Array
-import java.util.ArrayList
 import java.util.Arrays
-import java.util.LinkedHashMap
 import java.util.Objects
 import javax.lang.model.element.AnnotationMirror
 import javax.lang.model.element.AnnotationValue
@@ -99,7 +97,7 @@ class AnnotationSpec private constructor(builder: AnnotationSpec.Builder) {
   fun toBuilder(): Builder {
     val builder = Builder(type)
     for ((key, value) in members) {
-      builder.members.put(key, ArrayList(value))
+      builder.members.put(key, value.toMutableList())
     }
     return builder
   }
@@ -128,14 +126,14 @@ class AnnotationSpec private constructor(builder: AnnotationSpec.Builder) {
   }
 
   class Builder internal constructor(internal val type: TypeName) {
-    internal val members = LinkedHashMap<String, MutableList<CodeBlock>>()
+    internal val members = mutableMapOf<String, MutableList<CodeBlock>>()
 
     fun addMember(name: String, format: String, vararg args: Any): Builder {
       return addMember(name, CodeBlock.of(format, *args))
     }
 
     fun addMember(name: String, codeBlock: CodeBlock): Builder {
-      members.getOrPut(name, ::ArrayList).add(codeBlock)
+      members.getOrPut(name, { mutableListOf() }).add(codeBlock)
       return this
     }
 

--- a/src/main/java/com/squareup/kotlinpoet/ArrayTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ArrayTypeName.kt
@@ -18,14 +18,12 @@ package com.squareup.kotlinpoet
 import java.io.IOException
 import java.lang.reflect.GenericArrayType
 import java.lang.reflect.Type
-import java.util.ArrayList
-import java.util.LinkedHashMap
 import javax.lang.model.element.TypeParameterElement
 import javax.lang.model.type.ArrayType
 
 class ArrayTypeName private constructor(
     val componentType: TypeName,
-    annotations: List<AnnotationSpec> = ArrayList<AnnotationSpec>()) : TypeName(annotations) {
+    annotations: List<AnnotationSpec> = emptyList()) : TypeName(annotations) {
 
   override fun annotated(annotations: List<AnnotationSpec>): ArrayTypeName {
     return ArrayTypeName(componentType, this.annotations + annotations)
@@ -56,8 +54,7 @@ class ArrayTypeName private constructor(
     /** Returns an array type equivalent to `mirror`.  */
     @JvmStatic internal fun get(
         mirror: ArrayType,
-        typeVariables: MutableMap<TypeParameterElement, TypeVariableName>
-        = LinkedHashMap<TypeParameterElement, TypeVariableName>())
+        typeVariables: MutableMap<TypeParameterElement, TypeVariableName> = mutableMapOf())
         : ArrayTypeName {
       return ArrayTypeName(TypeName.get(mirror.componentType, typeVariables))
     }
@@ -65,7 +62,7 @@ class ArrayTypeName private constructor(
     /** Returns an array type equivalent to `type`.  */
     @JvmStatic internal fun get(
         type: GenericArrayType,
-        map: MutableMap<Type, TypeVariableName> = LinkedHashMap<Type, TypeVariableName>())
+        map: MutableMap<Type, TypeVariableName> = mutableMapOf())
         : ArrayTypeName {
       return ArrayTypeName.of(TypeName.get(type.genericComponentType, map = map))
     }

--- a/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
@@ -18,7 +18,6 @@ package com.squareup.kotlinpoet
 import java.io.IOException
 import java.io.StringWriter
 import java.lang.reflect.Type
-import java.util.ArrayList
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 import javax.lang.model.element.Element
@@ -90,8 +89,8 @@ class CodeBlock private constructor(builder: CodeBlock.Builder) {
   }
 
   class Builder {
-    internal val formatParts: MutableList<String> = ArrayList()
-    internal val args: MutableList<Any?> = ArrayList()
+    internal val formatParts = mutableListOf<String>()
+    internal val args = mutableListOf<Any?>()
 
     /**
      * Adds code using named arguments.
@@ -227,7 +226,7 @@ class CodeBlock private constructor(builder: CodeBlock.Builder) {
             "unused arguments: expected $relativeParameterCount, received ${args.size}" }
       }
       if (hasIndexed) {
-        val unused = ArrayList<String>()
+        val unused = mutableListOf<String>()
         for (i in args.indices) {
           if (indexedParameterCount[i] == 0) {
             unused.add("%" + (i + 1))

--- a/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -17,10 +17,7 @@ package com.squareup.kotlinpoet
 
 import com.squareup.kotlinpoet.Util.stringLiteralWithDoubleQuotes
 import java.io.IOException
-import java.util.ArrayList
 import java.util.EnumSet
-import java.util.LinkedHashMap
-import java.util.LinkedHashSet
 import java.util.Locale
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.Modifier
@@ -54,10 +51,10 @@ internal class CodeWriter @JvmOverloads constructor(
   private var kdoc = false
   private var comment = false
   private var packageName = NO_PACKAGE
-  private val typeSpecStack = ArrayList<TypeSpec>()
-  private val staticImportClassNames = LinkedHashSet<String>()
-  private val importableTypes = LinkedHashMap<String, ClassName>()
-  private val referencedNames = LinkedHashSet<String>()
+  private val typeSpecStack = mutableListOf<TypeSpec>()
+  private val staticImportClassNames = mutableSetOf<String>()
+  private val importableTypes = mutableMapOf<String, ClassName>()
+  private val referencedNames = mutableSetOf<String>()
   private var trailingNewline = false
 
   /**
@@ -455,8 +452,6 @@ internal class CodeWriter @JvmOverloads constructor(
    * collisions, that type's first use is imported.
    */
   fun suggestedImports(): Map<String, ClassName> {
-    val result = LinkedHashMap(importableTypes)
-    result.keys.removeAll(referencedNames)
-    return result
+    return importableTypes.filterKeys { it !in referencedNames }
   }
 }

--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -18,9 +18,7 @@ package com.squareup.kotlinpoet
 import java.io.IOException
 import java.io.StringWriter
 import java.lang.reflect.Type
-import java.util.ArrayList
 import java.util.Collections
-import java.util.LinkedHashSet
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.Modifier
@@ -182,12 +180,12 @@ class FunSpec private constructor(builder: FunSpec.Builder) {
 
   class Builder internal constructor(internal val name: String) {
     internal val kdoc = CodeBlock.builder()
-    internal val annotations = ArrayList<AnnotationSpec>()
-    internal val modifiers = ArrayList<Modifier>()
-    internal val typeVariables = ArrayList<TypeVariableName>()
+    internal val annotations = mutableListOf<AnnotationSpec>()
+    internal val modifiers = mutableListOf<Modifier>()
+    internal val typeVariables = mutableListOf<TypeVariableName>()
     internal var returnType: TypeName? = null
-    internal val parameters = ArrayList<ParameterSpec>()
-    internal val exceptions = LinkedHashSet<TypeName>()
+    internal val parameters = mutableListOf<ParameterSpec>()
+    internal val exceptions = mutableSetOf<TypeName>()
     internal val code = CodeBlock.builder()
     internal var varargs: Boolean = false
     internal var defaultValue: CodeBlock? = null
@@ -395,7 +393,7 @@ class FunSpec private constructor(builder: FunSpec.Builder) {
 
       funBuilder.addAnnotation(Override::class.java)
 
-      modifiers = LinkedHashSet(modifiers)
+      modifiers = modifiers.toMutableSet()
       modifiers.remove(Modifier.ABSTRACT)
       modifiers.remove(Util.DEFAULT) // LinkedHashSet permits null as element for Java 7
       funBuilder.addModifiers(modifiers)

--- a/src/main/java/com/squareup/kotlinpoet/KotlinFile.kt
+++ b/src/main/java/com/squareup/kotlinpoet/KotlinFile.kt
@@ -24,7 +24,6 @@ import java.net.URI
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
 import java.nio.file.Path
-import java.util.TreeSet
 import javax.annotation.processing.Filer
 import javax.lang.model.element.Modifier
 import javax.tools.JavaFileObject
@@ -133,7 +132,7 @@ class KotlinFile private constructor(builder: KotlinFile.Builder) {
     }
 
     var importedTypesCount = 0
-    for (className in TreeSet(codeWriter.importedTypes().values)) {
+    for (className in codeWriter.importedTypes().values.toSortedSet()) {
       if (skipJavaLangImports && className.packageName() == "java.lang") continue
       codeWriter.emit("import %L\n", className)
       importedTypesCount++
@@ -200,7 +199,7 @@ class KotlinFile private constructor(builder: KotlinFile.Builder) {
       internal val packageName: String,
       internal val typeSpec: TypeSpec) {
     internal val fileComment = CodeBlock.builder()
-    internal val staticImports = TreeSet<String>()
+    internal val staticImports = sortedSetOf<String>()
     internal var skipJavaLangImports: Boolean = false
     internal var indent = "  "
 

--- a/src/main/java/com/squareup/kotlinpoet/NameAllocator.kt
+++ b/src/main/java/com/squareup/kotlinpoet/NameAllocator.kt
@@ -15,8 +15,6 @@
  */
 package com.squareup.kotlinpoet
 
-import java.util.LinkedHashMap
-import java.util.LinkedHashSet
 import java.util.UUID
 import javax.lang.model.SourceVersion
 
@@ -81,7 +79,7 @@ class NameAllocator private constructor(
     private val allocatedNames: MutableSet<String>,
     private val tagToName: MutableMap<Any, String>) : Cloneable {
 
-  constructor() : this(LinkedHashSet<String>(), LinkedHashMap<Any, String>())
+  constructor() : this(mutableSetOf(), mutableMapOf())
 
   /**
    * Return a new name using `suggestion` that will not be a Java identifier or clash with other
@@ -116,7 +114,7 @@ class NameAllocator private constructor(
    * @return A deep copy of this NameAllocator.
    */
   public override fun clone(): NameAllocator {
-    return NameAllocator(LinkedHashSet(this.allocatedNames), LinkedHashMap(this.tagToName))
+    return NameAllocator(allocatedNames.toMutableSet(), tagToName.toMutableMap())
   }
 }
 

--- a/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
@@ -18,8 +18,6 @@ package com.squareup.kotlinpoet
 import java.io.IOException
 import java.io.StringWriter
 import java.lang.reflect.Type
-import java.util.ArrayList
-import java.util.Collections
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.Modifier
@@ -79,8 +77,8 @@ class ParameterSpec private constructor(builder: ParameterSpec.Builder) {
   class Builder internal constructor(
       internal val type: TypeName,
       internal val name: String) {
-    internal val annotations = ArrayList<AnnotationSpec>()
-    internal val modifiers = ArrayList<Modifier>()
+    internal val annotations = mutableListOf<AnnotationSpec>()
+    internal val modifiers = mutableListOf<Modifier>()
 
     fun addAnnotations(annotationSpecs: Iterable<AnnotationSpec>): Builder {
       for (annotationSpec in annotationSpecs) {
@@ -102,7 +100,7 @@ class ParameterSpec private constructor(builder: ParameterSpec.Builder) {
     fun addAnnotation(annotation: Class<*>) = addAnnotation(ClassName.get(annotation))
 
     fun addModifiers(vararg modifiers: Modifier): Builder {
-      Collections.addAll(this.modifiers, *modifiers)
+      this.modifiers += modifiers
       return this
     }
 

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -18,8 +18,6 @@ package com.squareup.kotlinpoet
 import java.io.IOException
 import java.io.StringWriter
 import java.lang.reflect.Type
-import java.util.ArrayList
-import java.util.Collections
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.Modifier
 import kotlin.reflect.KClass
@@ -79,8 +77,8 @@ class PropertySpec private constructor(builder: PropertySpec.Builder) {
 
   class Builder internal constructor(internal val type: TypeName, internal val name: String) {
     internal val kdoc = CodeBlock.builder()
-    internal val annotations = ArrayList<AnnotationSpec>()
-    internal val modifiers = ArrayList<Modifier>()
+    internal val annotations = mutableListOf<AnnotationSpec>()
+    internal val modifiers = mutableListOf<Modifier>()
     internal var initializer: CodeBlock? = null
 
     fun addKdoc(format: String, vararg args: Any): Builder {
@@ -113,7 +111,7 @@ class PropertySpec private constructor(builder: PropertySpec.Builder) {
     fun addAnnotation(annotation: Class<*>) = addAnnotation(ClassName.get(annotation))
 
     fun addModifiers(vararg modifiers: Modifier): Builder {
-      Collections.addAll(this.modifiers, *modifiers)
+      this.modifiers += modifiers
       return this
     }
 

--- a/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -21,8 +21,6 @@ import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.lang.reflect.TypeVariable
 import java.lang.reflect.WildcardType
-import java.util.ArrayList
-import java.util.LinkedHashMap
 import javax.lang.model.element.Modifier
 import javax.lang.model.element.TypeElement
 import javax.lang.model.element.TypeParameterElement
@@ -119,8 +117,7 @@ abstract class TypeName internal constructor(annotations: List<AnnotationSpec>) 
     /** Returns a type name equivalent to `mirror`.  */
     @JvmOverloads @JvmStatic fun get(
         mirror: TypeMirror,
-        typeVariables: MutableMap<TypeParameterElement, TypeVariableName>
-        = LinkedHashMap<TypeParameterElement, TypeVariableName>())
+        typeVariables: MutableMap<TypeParameterElement, TypeVariableName> = mutableMapOf())
         : TypeName {
       return mirror.accept(object : SimpleTypeVisitor7<TypeName, Void?>() {
         override fun visitPrimitive(t: PrimitiveType, p: Void?): TypeName {
@@ -148,7 +145,7 @@ abstract class TypeName internal constructor(annotations: List<AnnotationSpec>) 
             return rawType
           }
 
-          val typeArgumentNames = ArrayList<TypeName>()
+          val typeArgumentNames = mutableListOf<TypeName>()
           for (typeArgument in t.typeArguments) {
             typeArgumentNames.add(get(typeArgument, typeVariables))
           }
@@ -186,14 +183,12 @@ abstract class TypeName internal constructor(annotations: List<AnnotationSpec>) 
 
 
     /** Returns a type name equivalent to `type`.  */
-    @JvmStatic fun get(type: KClass<*>): TypeName {
-      return get(type.java)
-    }
+    @JvmStatic fun get(type: KClass<*>) = get(type.java)
 
     /** Returns a type name equivalent to `type`.  */
     @JvmOverloads @JvmStatic fun get(
         type: Type,
-        map: MutableMap<Type, TypeVariableName> = LinkedHashMap<Type, TypeVariableName>())
+        map: MutableMap<Type, TypeVariableName> = mutableMapOf())
         : TypeName {
       when (type) {
         is Class<*> -> {
@@ -217,26 +212,6 @@ abstract class TypeName internal constructor(annotations: List<AnnotationSpec>) 
         is GenericArrayType -> return ArrayTypeName.get(type, map)
         else -> throw IllegalArgumentException("unexpected type: " + type)
       }
-    }
-
-    /** Converts an array of types to a list of type names.  */
-    internal fun list(vararg types: KClass<*>): List<TypeName> {
-      val result = ArrayList<TypeName>(types.size)
-      for (type in types) {
-        result.add(get(type))
-      }
-      return result
-    }
-
-    @JvmOverloads internal fun list(
-        vararg types: Type,
-        map: MutableMap<Type, TypeVariableName> = LinkedHashMap<Type, TypeVariableName>())
-        : List<TypeName> {
-      val result = ArrayList<TypeName>(types.size)
-      for (type in types) {
-        result.add(get(type, map))
-      }
-      return result
     }
 
     /** Returns the array component of `type`, or null if `type` is not an array.  */

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -20,10 +20,7 @@ import com.squareup.kotlinpoet.Util.requireExactlyOneOf
 import java.io.IOException
 import java.io.StringWriter
 import java.lang.reflect.Type
-import java.util.ArrayList
-import java.util.Collections
 import java.util.EnumSet
-import java.util.LinkedHashMap
 import java.util.Locale
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.Element
@@ -50,7 +47,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
   val originatingElements: List<Element>
 
   init {
-    val originatingElementsMutable = ArrayList<Element>()
+    val originatingElementsMutable = mutableListOf<Element>()
     originatingElementsMutable.addAll(builder.originatingElements)
     for (typeSpec in builder.typeSpecs) {
       originatingElementsMutable.addAll(typeSpec.originatingElements)
@@ -290,18 +287,18 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
       internal val name: String?,
       internal val anonymousTypeArguments: CodeBlock?) {
     internal val kdoc = CodeBlock.builder()
-    internal val annotations = ArrayList<AnnotationSpec>()
-    internal val modifiers = ArrayList<Modifier>()
-    internal val typeVariables = ArrayList<TypeVariableName>()
+    internal val annotations = mutableListOf<AnnotationSpec>()
+    internal val modifiers = mutableListOf<Modifier>()
+    internal val typeVariables = mutableListOf<TypeVariableName>()
     internal var superclass: TypeName = OBJECT
-    internal val superinterfaces = ArrayList<TypeName>()
-    internal val enumConstants = LinkedHashMap<String, TypeSpec>()
-    internal val propertySpecs = ArrayList<PropertySpec>()
+    internal val superinterfaces = mutableListOf<TypeName>()
+    internal val enumConstants = mutableMapOf<String, TypeSpec>()
+    internal val propertySpecs = mutableListOf<PropertySpec>()
     internal val staticBlock = CodeBlock.builder()
     internal val initializerBlock = CodeBlock.builder()
-    internal val funSpecs = ArrayList<FunSpec>()
-    internal val typeSpecs = ArrayList<TypeSpec>()
-    internal val originatingElements = ArrayList<Element>()
+    internal val funSpecs = mutableListOf<FunSpec>()
+    internal val typeSpecs = mutableListOf<TypeSpec>()
+    internal val originatingElements = mutableListOf<Element>()
 
     init {
       require(name == null || SourceVersion.isName(name)) { "not a valid name: $name" }
@@ -338,7 +335,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
 
     fun addModifiers(vararg modifiers: Modifier): Builder {
       check(anonymousTypeArguments == null) { "forbidden on anonymous types." }
-      Collections.addAll(this.modifiers, *modifiers)
+      this.modifiers += modifiers
       return this
     }
 

--- a/src/main/java/com/squareup/kotlinpoet/WildcardTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/WildcardTypeName.kt
@@ -18,15 +18,13 @@ package com.squareup.kotlinpoet
 import java.io.IOException
 import java.lang.reflect.Type
 import java.lang.reflect.WildcardType
-import java.util.ArrayList
-import java.util.LinkedHashMap
 import javax.lang.model.element.TypeParameterElement
 import kotlin.reflect.KClass
 
 class WildcardTypeName private constructor(
     upperBounds: List<TypeName>,
     lowerBounds: List<TypeName>,
-    annotations: List<AnnotationSpec> = ArrayList<AnnotationSpec>()) : TypeName(annotations) {
+    annotations: List<AnnotationSpec> = emptyList()) : TypeName(annotations) {
 
   val upperBounds: List<TypeName> = Util.immutableList(upperBounds)
   val lowerBounds: List<TypeName> = Util.immutableList(lowerBounds)
@@ -89,8 +87,7 @@ class WildcardTypeName private constructor(
 
     @JvmOverloads @JvmStatic fun get(
         mirror: javax.lang.model.type.WildcardType,
-        typeVariables: MutableMap<TypeParameterElement, TypeVariableName>
-        = LinkedHashMap<TypeParameterElement, TypeVariableName>())
+        typeVariables: MutableMap<TypeParameterElement, TypeVariableName> = mutableMapOf())
         : TypeName {
       val extendsBound = mirror.extendsBound
       if (extendsBound == null) {
@@ -105,11 +102,11 @@ class WildcardTypeName private constructor(
 
     @JvmStatic fun get(
         wildcardName: WildcardType,
-        map: MutableMap<Type, TypeVariableName> = LinkedHashMap<Type, TypeVariableName>())
+        map: MutableMap<Type, TypeVariableName> = mutableMapOf())
         : TypeName {
       return WildcardTypeName(
-          list(*wildcardName.upperBounds, map = map),
-          list(*wildcardName.lowerBounds, map = map))
+          wildcardName.upperBounds.map { TypeName.get(it, map = map) },
+          wildcardName.lowerBounds.map { TypeName.get(it, map = map) })
     }
   }
 }


### PR DESCRIPTION
Avoid `java.util.*` in favor of Kotlin stdlib functions and types.

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 36.089 s
[INFO] Finished at: 2017-05-11T22:36:36-04:00
[INFO] Final Memory: 58M/876M
[INFO] ------------------------------------------------------------------------
```