### PR TITLE
Implement support for raw strings.

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -15,12 +15,11 @@
  */
 package com.squareup.kotlinpoet
 
-import com.squareup.kotlinpoet.Util.stringLiteralWithDoubleQuotes
+import com.squareup.kotlinpoet.Util.stringLiteralWithQuotes
 import java.io.IOException
 import java.util.EnumSet
 import java.util.Locale
 import javax.lang.model.SourceVersion
-import javax.lang.model.element.Modifier
 
 /** Sentinel value that indicates that no user-provided package has been set.  */
 private val NO_PACKAGE = String()
@@ -218,7 +217,7 @@ internal class CodeWriter @JvmOverloads constructor(
           val string = codeBlock.args[a++] as String?
           // Emit null as a literal null: no quotes.
           emitAndIndent(if (string != null)
-            stringLiteralWithDoubleQuotes(string, indent) else
+            stringLiteralWithQuotes(string, indent) else
             "null")
         }
 

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -43,8 +43,7 @@ class PropertySpec constructor(
     codeWriter.emit(if (mutable) "var " else "val ")
     codeWriter.emit("%L: %T", name, type)
     if (initializer != null) {
-      codeWriter.emit(" = ")
-      codeWriter.emit(initializer)
+      codeWriter.emit(" = %[%L%]", initializer)
     }
     codeWriter.emit("\n")
   }

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -1110,14 +1110,12 @@ class TypeSpecTest {
         .addStatement("return size")
         .build()
     val propertyBlock = CodeBlock.builder()
-        .add("%>%>")
-        .add("%T.<%T, %T>builder()%>%>", ImmutableMap::class, String::class, String::class)
+        .add("%T.<%T, %T>builder()", ImmutableMap::class, String::class, String::class)
         .add("\n.add(%S, %S)", '\'', "&#39;")
         .add("\n.add(%S, %S)", '&', "&amp;")
         .add("\n.add(%S, %S)", '<', "&lt;")
         .add("\n.add(%S, %S)", '>', "&gt;")
-        .add("\n.build()%<%<")
-        .add("%<%<")
+        .add("\n.build()")
         .build()
     val escapeHtml = PropertySpec.builder(ParameterizedTypeName.get(
         Map::class, String::class, String::class), "ESCAPE_HTML")
@@ -1145,11 +1143,11 @@ class TypeSpecTest {
         |
         |class Util {
         |  private val ESCAPE_HTML: Map<String, String> = ImmutableMap.<String, String>builder()
-        |          .add("'", "&#39;")
-        |          .add("&", "&amp;")
-        |          .add("<", "&lt;")
-        |          .add(">", "&gt;")
-        |          .build()
+        |      .add("'", "&#39;")
+        |      .add("&", "&amp;")
+        |      .add("<", "&lt;")
+        |      .add(">", "&gt;")
+        |      .build()
         |
         |  fun commonPrefixLength(listA: List<String>, listB: List<String>): Int {
         |    Int size = Math.min(listA.size(), listB.size())
@@ -1567,10 +1565,12 @@ class TypeSpecTest {
         |import java.lang.String
         |
         |class Taco {
-        |  val toppings: String = "shell\n"
-        |      + "beef\n"
-        |      + "lettuce\n"
-        |      + "cheese\n"
+        |  val toppings: String = ${"\"\"\""}
+        |      |shell
+        |      |beef
+        |      |lettuce
+        |      |cheese
+        |      |${"\"\"\""}.trimMargin()
         |}
         |""".trimMargin())
   }

--- a/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.kotlinpoet
 
+import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.assertEquals
 
 import org.junit.Test
@@ -60,7 +61,8 @@ class UtilTest {
     stringLiteral("abc")
     stringLiteral("♦♥♠♣")
     stringLiteral("€\\t@\\t$", "€\t@\t$", " ")
-    stringLiteral("abc();\\n\"\n  + \"def();", "abc();\ndef();", " ")
+    assertThat(Util.stringLiteralWithQuotes("abc();\ndef();", " "))
+        .isEqualTo("\"\"\"\n|abc();\n|def();\n\"\"\".trimMargin()")
     stringLiteral("This is \\\"quoted\\\"!", "This is \"quoted\"!", " ")
     stringLiteral("e^{i\\\\pi}+1=0", "e^{i\\pi}+1=0", " ")
   }
@@ -70,6 +72,6 @@ class UtilTest {
   }
 
   internal fun stringLiteral(expected: String, value: String, indent: String) {
-    assertEquals("\"" + expected + "\"", Util.stringLiteralWithDoubleQuotes(value, indent))
+    assertEquals("\"" + expected + "\"", Util.stringLiteralWithQuotes(value, indent))
   }
 }


### PR DESCRIPTION
There's one known bug in this: raw strings may have trailing whitespace, and
it's very likely that tools will try to trim this trailing whitespace. I'll
track that as a follow-up fix.