### PR TITLE
Make initializerBlock emit `init {}`

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -399,7 +399,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
 
     fun addInitializerBlock(block: CodeBlock): Builder {
       check(kind == Kind.CLASS || kind == Kind.ENUM) { "$kind can't have initializer blocks" }
-      initializerBlock.add("{\n")
+      initializerBlock.add("init {\n")
           .indent()
           .add(block)
           .unindent()

--- a/src/test/java/com/squareup/kotlinpoet/KotlinFileTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/KotlinFileTest.kt
@@ -120,7 +120,7 @@ class KotlinFileTest {
         |import java.lang.Thread.State.valueOf
         |
         |class Taco {
-        |  {
+        |  init {
         |    assert valueOf("BLOCKED") == BLOCKED
         |    gc()
         |    out.println(nanoTime())

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -2003,7 +2003,7 @@ class TypeSpecTest {
         |
         |  private const val FOO: String = "FOO"
         |
-        |  {
+        |  init {
         |    foo = "FOO"
         |  }
         |
@@ -2054,7 +2054,7 @@ class TypeSpecTest {
         |
         |  private const val FOO: String = "FOO"
         |
-        |  {
+        |  init {
         |    foo = "instanceFoo"
         |  }
         |


### PR DESCRIPTION
Previously, `initializerBlock` emitted `{ }` as a holdover from Java.
This commit makes sure that we're using the `init` prefix as we should
for Kotlin.

Fixes #63 