### PR TITLE
lambda type name

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/LambdaTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/LambdaTypeName.kt
@@ -1,33 +1,52 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.kotlinpoet
 
 class LambdaTypeName internal constructor(
+    private val receiver: TypeName? = null,
     private val parameters: List<TypeName> = emptyList(),
     private val returnType: TypeName = TypeName.get(Unit::class),
     nullable: Boolean = false,
     annotations: List<AnnotationSpec> = emptyList()
 ) : TypeName(nullable, annotations) {
-  override fun asNullable() = LambdaTypeName(parameters, returnType, true, annotations)
+  override fun asNullable() = LambdaTypeName(receiver, parameters, returnType, true, annotations)
 
-  override fun asNonNullable() = LambdaTypeName(parameters, returnType, false, annotations)
+  override fun asNonNullable() = LambdaTypeName(receiver, parameters, returnType, false, annotations)
 
   override fun annotated(annotations: List<AnnotationSpec>): TypeName
-      = LambdaTypeName(parameters, returnType, nullable, annotations)
+      = LambdaTypeName(receiver, parameters, returnType, nullable, annotations)
 
-  override fun withoutAnnotations(): TypeName = LambdaTypeName(parameters, returnType, nullable)
+  override fun withoutAnnotations(): TypeName = LambdaTypeName(receiver, parameters, returnType, nullable)
 
   override fun abstractEmit(out: CodeWriter): CodeWriter {
     annotations.forEach { it.emit(out, true) }
     if (nullable) {
       out.emit("(")
     }
+
+    receiver?.let {
+      out.emit("%T.", it)
+    }
+
     out.emit("(")
-    if (!parameters.isEmpty()) {
-      parameters.forEachIndexed { i, it ->
-        if (i != 0) {
-          out.emit(", ")
-        }
-        out.emit("%T", it)
+    parameters.forEachIndexed { i, it ->
+      if (i != 0) {
+        out.emit(", ")
       }
+      out.emit("%T", it)
     }
     out.emit(") -> %T", returnType)
     if (nullable) {
@@ -38,11 +57,16 @@ class LambdaTypeName internal constructor(
 
   companion object {
     /** Returns a lambda type with `returnType` and parameters of listed in `parameters` **/
-    @JvmStatic fun get(returnType: TypeName, parameters: List<TypeName>)
-        = LambdaTypeName(parameters, returnType)
+    @JvmStatic fun get(receiver: TypeName? = null,
+                       parameters: List<TypeName> = emptyList(),
+                       returnType: TypeName)
+        = LambdaTypeName(receiver, parameters, returnType)
 
     /** Returns a lambda type with `returnType` and parameters of listed in `parameters` **/
-    @JvmStatic fun get(returnType: TypeName, vararg parameters: TypeName)
-        = LambdaTypeName(parameters.toList(), returnType)
+    @JvmStatic fun get(receiver: TypeName? = null,
+                       vararg parameters: TypeName = emptyArray(),
+                       returnType: TypeName)
+        = LambdaTypeName(receiver, parameters.toList(), returnType)
+
   }
 }

--- a/src/main/java/com/squareup/kotlinpoet/LambdaTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/LambdaTypeName.kt
@@ -15,17 +15,33 @@ class LambdaTypeName internal constructor(
 
   override fun withoutAnnotations(): TypeName = LambdaTypeName(parameters, returnType, nullable)
 
-  override fun abstractEmit(out: CodeWriter): CodeWriter = out.apply {
+  override fun abstractEmit(out: CodeWriter): CodeWriter {
     annotations.forEach { it.emit(out, true) }
-    emit("(")
-    parameters.forEach { it.emit(out) }
-    emit(") -> (${returnType.emit(out)})")
+    if (nullable) {
+      out.emit("(")
+    }
+    out.emit("(")
+    if (!parameters.isEmpty()) {
+      parameters.forEachIndexed { i, it ->
+        if (i != 0) {
+          out.emit(", ")
+        }
+        out.emit("%T", it)
+      }
+    }
+    out.emit(") -> %T", returnType)
+    if (nullable) {
+      out.emit(")")
+    }
+    return out
   }
 
   companion object {
+    /** Returns a lambda type with `returnType` and parameters of listed in `parameters` **/
     @JvmStatic fun get(returnType: TypeName, parameters: List<TypeName>)
         = LambdaTypeName(parameters, returnType)
 
+    /** Returns a lambda type with `returnType` and parameters of listed in `parameters` **/
     @JvmStatic fun get(returnType: TypeName, vararg parameters: TypeName)
         = LambdaTypeName(parameters.toList(), returnType)
   }

--- a/src/main/java/com/squareup/kotlinpoet/LambdaTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/LambdaTypeName.kt
@@ -1,0 +1,32 @@
+package com.squareup.kotlinpoet
+
+class LambdaTypeName internal constructor(
+    private val parameters: List<TypeName> = emptyList(),
+    private val returnType: TypeName = TypeName.get(Unit::class),
+    nullable: Boolean = false,
+    annotations: List<AnnotationSpec> = emptyList()
+) : TypeName(nullable, annotations) {
+  override fun asNullable() = LambdaTypeName(parameters, returnType, true, annotations)
+
+  override fun asNonNullable() = LambdaTypeName(parameters, returnType, false, annotations)
+
+  override fun annotated(annotations: List<AnnotationSpec>): TypeName
+      = LambdaTypeName(parameters, returnType, nullable, annotations)
+
+  override fun withoutAnnotations(): TypeName = LambdaTypeName(parameters, returnType, nullable)
+
+  override fun abstractEmit(out: CodeWriter): CodeWriter = out.apply {
+    annotations.forEach { it.emit(out, true) }
+    emit("(")
+    parameters.forEach { it.emit(out) }
+    emit(") -> (${returnType.emit(out)})")
+  }
+
+  companion object {
+    @JvmStatic fun get(returnType: TypeName, parameters: List<TypeName>)
+        = LambdaTypeName(parameters, returnType)
+
+    @JvmStatic fun get(returnType: TypeName, vararg parameters: TypeName)
+        = LambdaTypeName(parameters.toList(), returnType)
+  }
+}

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -176,9 +176,9 @@ class FunSpecTest {
   }
 
   @Test fun functionParamNoLambdaParam() {
-    val unitType = ClassName.get(Unit::class)
+    val unitType = UNIT
     val funSpec = FunSpec.builder("foo")
-        .addParameter(ParameterSpec.builder("f", LambdaTypeName.get(unitType)).build())
+        .addParameter(ParameterSpec.builder("f", LambdaTypeName.get(returnType = unitType)).build())
         .returns(TypeName.Companion.get(String::class))
         .build()
 
@@ -188,11 +188,26 @@ class FunSpecTest {
       |""".trimMargin())
   }
 
-  @Test fun functionParamSingleLambdaParam() {
-    val unitType = ClassName.get(Unit::class)
-    val booleanType = ClassName.get(Boolean::class)
+  @Test fun functionParamNoLambdaParamWithReceiver() {
+    val unitType = UNIT
+    val lambdaTypeName = LambdaTypeName.get(receiver = INT, returnType = unitType)
     val funSpec = FunSpec.builder("foo")
-        .addParameter(ParameterSpec.builder("f", LambdaTypeName.get(unitType, booleanType)).build())
+        .addParameter(ParameterSpec.builder("f", lambdaTypeName).build())
+        .returns(TypeName.Companion.get(String::class))
+        .build()
+
+    assertThat(funSpec.toString()).isEqualTo("""
+      |fun foo(f: kotlin.Int.() -> kotlin.Unit): java.lang.String {
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun functionParamSingleLambdaParam() {
+    val unitType = UNIT
+    val booleanType = BOOLEAN
+    val funSpec = FunSpec.builder("foo")
+        .addParameter(ParameterSpec.builder("f", LambdaTypeName.get(parameters = booleanType, returnType = unitType))
+            .build())
         .returns(TypeName.Companion.get(String::class))
         .build()
 
@@ -203,11 +218,12 @@ class FunSpecTest {
   }
 
   @Test fun functionParamMultipleLambdaParam() {
-    val unitType = ClassName.get(Unit::class)
-    val booleanType = ClassName.get(Boolean::class)
+    val unitType = UNIT
+    val booleanType = BOOLEAN
     val stringType = ClassName.get(String::class)
+    val lambdaType = LambdaTypeName.get(parameters = *arrayOf(booleanType, stringType), returnType = unitType)
     val funSpec = FunSpec.builder("foo")
-        .addParameter(ParameterSpec.builder("f", LambdaTypeName.get(unitType, booleanType, stringType)).build())
+        .addParameter(ParameterSpec.builder("f", lambdaType).build())
         .returns(TypeName.Companion.get(String::class))
         .build()
 
@@ -221,9 +237,10 @@ class FunSpecTest {
     val unitType = ClassName.get(Unit::class)
     val booleanType = ClassName.get(Boolean::class)
     val stringType = ClassName.get(String::class)
+    val lambdaTypeName = LambdaTypeName.get(parameters = *arrayOf(booleanType, stringType), returnType = unitType)
+        .asNullable()
     val funSpec = FunSpec.builder("foo")
-        .addParameter(ParameterSpec.builder("f",
-            LambdaTypeName.get(unitType, booleanType, stringType).asNullable()).build())
+        .addParameter(ParameterSpec.builder("f", lambdaTypeName) .build())
         .returns(TypeName.Companion.get(String::class))
         .build()
 
@@ -237,9 +254,9 @@ class FunSpecTest {
     val unitType = ClassName.get(Unit::class)
     val booleanType = ClassName.get(Boolean::class)
     val stringType = ClassName.get(String::class).asNullable()
+    val lambdaTypeName = LambdaTypeName.get(parameters = *arrayOf(booleanType, stringType), returnType = unitType).asNullable()
     val funSpec = FunSpec.builder("foo")
-        .addParameter(ParameterSpec.builder("f",
-            LambdaTypeName.get(unitType, booleanType, stringType).asNullable()).build())
+        .addParameter(ParameterSpec.builder("f", lambdaTypeName).build())
         .returns(TypeName.Companion.get(String::class))
         .build()
 

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -175,6 +175,80 @@ class FunSpecTest {
       |""".trimMargin())
   }
 
+  @Test fun functionParamNoLambdaParam() {
+    val unitType = ClassName.get(Unit::class)
+    val funSpec = FunSpec.builder("foo")
+        .addParameter(ParameterSpec.builder("f", LambdaTypeName.get(unitType)).build())
+        .returns(TypeName.Companion.get(String::class))
+        .build()
+
+    assertThat(funSpec.toString()).isEqualTo("""
+      |fun foo(f: () -> kotlin.Unit): java.lang.String {
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun functionParamSingleLambdaParam() {
+    val unitType = ClassName.get(Unit::class)
+    val booleanType = ClassName.get(Boolean::class)
+    val funSpec = FunSpec.builder("foo")
+        .addParameter(ParameterSpec.builder("f", LambdaTypeName.get(unitType, booleanType)).build())
+        .returns(TypeName.Companion.get(String::class))
+        .build()
+
+    assertThat(funSpec.toString()).isEqualTo("""
+      |fun foo(f: (kotlin.Boolean) -> kotlin.Unit): java.lang.String {
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun functionParamMultipleLambdaParam() {
+    val unitType = ClassName.get(Unit::class)
+    val booleanType = ClassName.get(Boolean::class)
+    val stringType = ClassName.get(String::class)
+    val funSpec = FunSpec.builder("foo")
+        .addParameter(ParameterSpec.builder("f", LambdaTypeName.get(unitType, booleanType, stringType)).build())
+        .returns(TypeName.Companion.get(String::class))
+        .build()
+
+    assertThat(funSpec.toString()).isEqualTo("""
+      |fun foo(f: (kotlin.Boolean, java.lang.String) -> kotlin.Unit): java.lang.String {
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun functionParamMultipleLambdaParamNullableLambda() {
+    val unitType = ClassName.get(Unit::class)
+    val booleanType = ClassName.get(Boolean::class)
+    val stringType = ClassName.get(String::class)
+    val funSpec = FunSpec.builder("foo")
+        .addParameter(ParameterSpec.builder("f",
+            LambdaTypeName.get(unitType, booleanType, stringType).asNullable()).build())
+        .returns(TypeName.Companion.get(String::class))
+        .build()
+
+    assertThat(funSpec.toString()).isEqualTo("""
+      |fun foo(f: ((kotlin.Boolean, java.lang.String) -> kotlin.Unit)?): java.lang.String {
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun functionParamMultipleNullableLambdaParam() {
+    val unitType = ClassName.get(Unit::class)
+    val booleanType = ClassName.get(Boolean::class)
+    val stringType = ClassName.get(String::class).asNullable()
+    val funSpec = FunSpec.builder("foo")
+        .addParameter(ParameterSpec.builder("f",
+            LambdaTypeName.get(unitType, booleanType, stringType).asNullable()).build())
+        .returns(TypeName.Companion.get(String::class))
+        .build()
+
+    assertThat(funSpec.toString()).isEqualTo("""
+      |fun foo(f: ((kotlin.Boolean, java.lang.String?) -> kotlin.Unit)?): java.lang.String {
+      |}
+      |""".trimMargin())
+  }
+
   @Test fun equalsAndHashCode() {
     var a = FunSpec.constructorBuilder().build()
     var b = FunSpec.constructorBuilder().build()


### PR DESCRIPTION
This adds a `LambdaTypeName` as specified in #76 in order to have lambda parameters for functions.