### PR TITLE
Generate valid annotation classes

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -46,7 +46,6 @@ class FunSpec private constructor(builder: Builder) {
   val parameters = builder.parameters.toImmutableList()
   val exceptions = builder.exceptions.toImmutableList()
   val code = builder.code.build()
-  val defaultValue = builder.defaultValue
 
   init {
     require(code.isEmpty() || !builder.modifiers.contains(KModifier.ABSTRACT)) {
@@ -99,11 +98,6 @@ class FunSpec private constructor(builder: Builder) {
 
     if (returnType != null) {
       codeWriter.emitCode(": %T", returnType)
-    }
-
-    if (defaultValue != null && !defaultValue.isEmpty()) {
-      codeWriter.emit(" default ")
-      codeWriter.emitCode(defaultValue)
     }
 
     if (exceptions.isNotEmpty()) {
@@ -184,7 +178,6 @@ class FunSpec private constructor(builder: Builder) {
     builder.parameters += parameters
     builder.exceptions += exceptions
     builder.code.add(code)
-    builder.defaultValue = defaultValue
     return builder
   }
 
@@ -198,7 +191,6 @@ class FunSpec private constructor(builder: Builder) {
     internal val parameters = mutableListOf<ParameterSpec>()
     internal val exceptions = mutableSetOf<TypeName>()
     internal val code = CodeBlock.builder()
-    internal var defaultValue: CodeBlock? = null
 
     init {
       require(name.isConstructor || name.isAccessor || SourceVersion.isName(name)) {
@@ -333,15 +325,6 @@ class FunSpec private constructor(builder: Builder) {
 
     fun addComment(format: String, vararg args: Any) = apply {
       code.add("// " + format + "\n", *args)
-    }
-
-    fun defaultValue(format: String, vararg args: Any) =
-        defaultValue(CodeBlock.of(format, *args))
-
-    fun defaultValue(codeBlock: CodeBlock) = apply {
-      check(!name.isAccessor && !name.isConstructor) { "$name cannot have a default value" }
-      check(this.defaultValue == null) { "defaultValue was already set" }
-      this.defaultValue = codeBlock
     }
 
     /**

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -125,7 +125,9 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
           codeWriter.emit(if (i == 0) " :" else ",")
           codeWriter.emitCode(" %T", typeName)
         }
-        codeWriter.emit(" {\n")
+        if (kind != Kind.ANNOTATION) {
+          codeWriter.emit(" {\n")
+        }
       }
 
       codeWriter.pushType(this)
@@ -202,7 +204,9 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
       codeWriter.unindent()
       codeWriter.popType()
 
-      codeWriter.emit("}")
+      if (kind != Kind.ANNOTATION) {
+        codeWriter.emit("}")
+      }
       if (enumName == null && anonymousTypeArguments == null) {
         codeWriter.emit("\n") // If this type isn't also a value, include a trailing newline.
       }
@@ -349,7 +353,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     }
 
     fun primaryConstructor(primaryConstructor: FunSpec?) = apply {
-      check(kind == Kind.CLASS || kind == Kind.ENUM) { "$kind can't have initializer blocks" }
+        check(kind in listOf(Kind.CLASS, Kind.ENUM, Kind.ANNOTATION)) { "$kind can't have initializer blocks" }
       if (primaryConstructor != null) {
         require (primaryConstructor.isConstructor) {
           "expected a constructor but was ${primaryConstructor.name}"
@@ -399,7 +403,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     }
 
     fun addProperty(propertySpec: PropertySpec) = apply {
-      check(kind == Kind.CLASS || kind == Kind.ENUM) {
+        check(kind in listOf(Kind.CLASS, Kind.ENUM, Kind.ANNOTATION)) {
         "cannot add property $propertySpec to $kind"
       }
       propertySpecs += propertySpec
@@ -434,10 +438,6 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
       } else if (kind == Kind.ANNOTATION) {
         check(funSpec.modifiers == kind.implicitFunctionModifiers) {
             "$kind $name.${funSpec.name} requires modifiers ${kind.implicitFunctionModifiers}" }
-      }
-      if (kind != Kind.ANNOTATION) {
-        check(funSpec.defaultValue == null) {
-          "$kind $name.${funSpec.name} cannot have a default value" }
       }
       funSpecs += funSpec
     }

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -23,6 +23,7 @@ import com.squareup.kotlinpoet.KModifier.VARARG
 import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import java.io.IOException
@@ -760,11 +761,13 @@ class TypeSpecTest {
   @Test fun annotation() {
     val annotation = TypeSpec.annotationBuilder("MyAnnotation")
         .addModifiers(KModifier.PUBLIC)
-        .addFun(FunSpec.builder("test")
-            .addModifiers(KModifier.PUBLIC, KModifier.ABSTRACT)
-            .defaultValue("%L", 0)
-            .returns(Int::class)
-            .build())
+            .primaryConstructor(FunSpec.constructorBuilder()
+                .addParameter(ParameterSpec.builder("test", Int::class)
+                    .build())
+                .build())
+            .addProperty(PropertySpec.builder("test", Int::class)
+                    .initializer("test")
+                .build())
         .build()
 
     assertThat(toString(annotation)).isEqualTo("""
@@ -772,18 +775,18 @@ class TypeSpecTest {
         |
         |import kotlin.Int
         |
-        |annotation class MyAnnotation {
-        |  fun test(): Int default 0
-        |}
+        |annotation class MyAnnotation(val test: Int)
         |""".trimMargin())
   }
 
-  @Test fun innerAnnotationInAnnotationDeclaration() {
+  @Ignore @Test fun innerAnnotationInAnnotationDeclaration() {
     val bar = TypeSpec.annotationBuilder("Bar")
-        .addFun(FunSpec.builder("value")
-            .addModifiers(KModifier.PUBLIC, KModifier.ABSTRACT)
-            .defaultValue("@%T", java.lang.Deprecated::class)
-            .returns(java.lang.Deprecated::class)
+        .primaryConstructor(FunSpec.constructorBuilder()
+            .addParameter(ParameterSpec.builder("value", java.lang.Deprecated::class)
+                .build())
+            .build())
+        .addProperty(PropertySpec.builder("value", java.lang.Deprecated::class)
+            .initializer("value")
             .build())
         .build()
 
@@ -798,15 +801,6 @@ class TypeSpecTest {
         |""".trimMargin())
   }
 
-  @Test fun annotationForbidsProperties() {
-    try {
-      TypeSpec.annotationBuilder("Taco")
-          .addProperty("v", Int::class)
-      fail()
-    } catch (expected: IllegalStateException) {
-    }
-  }
-
   @Test fun interfaceForbidsProperties() {
     try {
       TypeSpec.interfaceBuilder("Taco")
@@ -814,21 +808,6 @@ class TypeSpecTest {
       fail()
     } catch (expected: IllegalStateException) {
     }
-  }
-
-  @Test fun classCannotHaveDefaultValueForFunction() {
-    try {
-      TypeSpec.classBuilder("Tacos")
-          .addFun(FunSpec.builder("test")
-              .addModifiers(KModifier.PUBLIC)
-              .defaultValue("0")
-              .returns(Int::class)
-              .build())
-          .build()
-      fail()
-    } catch (expected: IllegalStateException) {
-    }
-
   }
 
   @Test fun referencedAndDeclaredSimpleNamesConflict() {
@@ -1426,8 +1405,7 @@ class TypeSpecTest {
     val type = TypeSpec.annotationBuilder("Taco")
         .build()
     assertThat(type.toString()).isEqualTo("""
-        |annotation class Taco {
-        |}
+        |annotation class Taco
         |""".trimMargin())
   }
 


### PR DESCRIPTION
According to https://kotlinlang.org/docs/reference/annotations.html:

- No `default` keyword

- Can have primary constructor

- Can have properties (only collapsed to primary constructor parameters tho. So at the moment it is possible to add a property to an annotation which won't be collapsed and will generate invalid Kotlin code. Not sure how to prevent it.)

- Can't have body
 
The only problem is that I haven't been able to combine property collapsing with default value yet. Seems like it doesn't play nicely at the moment. That's why I ignored `innerAnnotationInAnnotationDeclaration` test since it doesn't make sense without supplying a default value to annotation.