### PR TITLE
Fix code style

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -406,9 +406,9 @@ class FunSpec private constructor(builder: Builder) {
   }
 
   companion object {
-    const internal val CONSTRUCTOR = "constructor()"
-    const internal val GETTER = "get()"
-    const internal val SETTER = "set()"
+    internal const val CONSTRUCTOR = "constructor()"
+    internal const val GETTER = "get()"
+    internal const val SETTER = "set()"
 
     @JvmStatic fun builder(name: String): Builder {
       return Builder(name)

--- a/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -189,7 +189,6 @@ abstract class TypeName internal constructor(
       }, null)
     }
 
-
     /** Returns a type name equivalent to `type`.  */
     @JvmStatic fun get(type: KClass<*>) = get(type.java)
 

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -77,7 +77,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
           codeWriter.emit(")")
         }
         if (propertySpecs.isEmpty() && funSpecs.isEmpty() && typeSpecs.isEmpty()) {
-          return  // Avoid unnecessary braces "{}".
+          return // Avoid unnecessary braces "{}".
         }
         codeWriter.emit(" {\n")
       } else if (anonymousTypeArguments != null) {
@@ -120,7 +120,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
         }
 
         (extendsTypes + implementsTypes).forEachIndexed { i, typeName ->
-          codeWriter.emit(if (i == 0)  " :" else ",")
+          codeWriter.emit(if (i == 0) " :" else ",")
           codeWriter.emitCode(" %T", typeName)
         }
         codeWriter.emit(" {\n")
@@ -349,7 +349,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
 
     fun companionObject(companionObject: TypeSpec): Builder {
       check(kind == Kind.CLASS || kind == Kind.INTERFACE) { "$kind can't have a companion object" }
-      require(companionObject.kind == Kind.COMPANION) { "expected a companion object class but was $kind "}
+      require(companionObject.kind == Kind.COMPANION) { "expected a companion object class but was $kind " }
       this.companionObject = companionObject
       return this
     }

--- a/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -63,7 +63,7 @@ class KotlinPoetTest {
       KotlinFile.builder(tacosPackage, "Taco")
           .addFun(FunSpec.constructorBuilder().build())
       fail()
-    } catch(expected: IllegalArgumentException) {
+    } catch (expected: IllegalArgumentException) {
     }
   }
 
@@ -151,7 +151,7 @@ class KotlinPoetTest {
     try {
       PropertySpec.builder("CHEESE", String::class, KModifier.DATA)
       fail()
-    } catch(expected: IllegalArgumentException) {
+    } catch (expected: IllegalArgumentException) {
     }
   }
 

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -802,7 +802,7 @@ class TypeSpecTest {
       TypeSpec.annotationBuilder("Taco")
           .addProperty("v", Int::class)
       fail()
-    } catch(expected: IllegalStateException) {
+    } catch (expected: IllegalStateException) {
     }
   }
 
@@ -811,7 +811,7 @@ class TypeSpecTest {
       TypeSpec.interfaceBuilder("Taco")
           .addProperty("v", Int::class)
       fail()
-    } catch(expected: IllegalStateException) {
+    } catch (expected: IllegalStateException) {
     }
   }
 


### PR DESCRIPTION
Basically a result of executing 2 commands (hopefully will get you interested in [ktlint](https://github.com/shyiko/ktlint) :smile:):

```sh
$ printf '[*.{kt,kts}]\nindent_size=2' > .editorconfig
$ ktlint -F
```
> `.editorconfig` is not included in the PR