### PR TITLE
Use extension and invoke functions for creating TypeName and subclasses.

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import java.io.IOException
 import java.io.StringWriter
 import java.lang.reflect.Array
@@ -217,7 +218,7 @@ class AnnotationSpec private constructor(builder: AnnotationSpec.Builder) {
 
     @JvmStatic fun get(annotation: AnnotationMirror): AnnotationSpec {
       val element = annotation.annotationType.asElement() as TypeElement
-      val builder = AnnotationSpec.builder(ClassName.get(element))
+      val builder = AnnotationSpec.builder(element.asClassName())
       val visitor = Visitor(builder)
       for (executableElement in annotation.elementValues.keys) {
         val name = executableElement.simpleName.toString()
@@ -232,11 +233,11 @@ class AnnotationSpec private constructor(builder: AnnotationSpec.Builder) {
     }
 
     @JvmStatic fun builder(type: Class<*>): Builder {
-      return builder(ClassName.get(type))
+      return builder(type.asClassName())
     }
 
     @JvmStatic fun builder(type: KClass<*>): Builder {
-      return builder(ClassName.get(type))
+      return builder(type.asClassName())
     }
   }
 }

--- a/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import java.io.IOException
 import java.io.StringWriter
 import java.lang.reflect.Type
@@ -315,10 +316,10 @@ class CodeBlock private constructor(
     private fun argToType(o: Any?): TypeName {
       when (o) {
         is TypeName -> return o
-        is TypeMirror -> return TypeName.get(o)
-        is Element -> return TypeName.get(o.asType())
-        is Type -> return TypeName.get(o)
-        is KClass<*> -> return TypeName.get(o)
+        is TypeMirror -> return o.asTypeName()
+        is Element -> return o.asType().asTypeName()
+        is Type -> return o.asTypeName()
+        is KClass<*> -> return o.asTypeName()
         else -> throw IllegalArgumentException("expected type but was " + o)
       }
     }

--- a/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -375,7 +375,7 @@ internal class CodeWriter @JvmOverloads constructor(
 
     // Match the top-level class.
     if (typeSpecStack.size > 0 && typeSpecStack[0].name == simpleName) {
-      return ClassName.get(packageName, simpleName)
+      return ClassName(packageName, simpleName)
     }
 
     // Match an imported type.
@@ -388,7 +388,7 @@ internal class CodeWriter @JvmOverloads constructor(
 
   /** Returns the class named `simpleName` when nested in the class at `stackDepth`.  */
   private fun stackClassName(stackDepth: Int, simpleName: String): ClassName {
-    var className = ClassName.get(packageName, typeSpecStack[0].name!!)
+    var className = ClassName(packageName, typeSpecStack[0].name!!)
     for (i in 1..stackDepth) {
       className = className.nestedClass(typeSpecStack[i].name!!)
     }

--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -15,9 +15,12 @@
  */
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import com.squareup.kotlinpoet.FunSpec.Companion.CONSTRUCTOR
 import com.squareup.kotlinpoet.FunSpec.Companion.GETTER
 import com.squareup.kotlinpoet.FunSpec.Companion.SETTER
+import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
+import com.squareup.kotlinpoet.TypeVariableName.Companion.asTypeVariableName
 import java.io.IOException
 import java.io.StringWriter
 import java.lang.reflect.Type
@@ -242,9 +245,9 @@ class FunSpec private constructor(builder: Builder) {
       return this
     }
 
-    fun addAnnotation(annotation: Class<*>) = addAnnotation(ClassName.get(annotation))
+    fun addAnnotation(annotation: Class<*>) = addAnnotation(annotation.asClassName())
 
-    fun addAnnotation(annotation: KClass<*>) = addAnnotation(ClassName.get(annotation))
+    fun addAnnotation(annotation: KClass<*>) = addAnnotation(annotation.asClassName())
 
     fun addModifiers(vararg modifiers: KModifier): Builder {
       this.modifiers += modifiers
@@ -294,9 +297,9 @@ class FunSpec private constructor(builder: Builder) {
       return this
     }
 
-    fun receiver(receiverType: Type) = receiver(TypeName.get(receiverType))
+    fun receiver(receiverType: Type) = receiver(receiverType.asTypeName())
 
-    fun receiver(receiverType: KClass<*>) = receiver(TypeName.get(receiverType))
+    fun receiver(receiverType: KClass<*>) = receiver(receiverType.asTypeName())
 
     fun returns(returnType: TypeName): Builder {
       check(!name.isConstructor && !name.isAccessor) { "$name cannot have a return type" }
@@ -304,9 +307,9 @@ class FunSpec private constructor(builder: Builder) {
       return this
     }
 
-    fun returns(returnType: Type) = returns(TypeName.get(returnType))
+    fun returns(returnType: Type) = returns(returnType.asTypeName())
 
-    fun returns(returnType: KClass<*>) = returns(TypeName.get(returnType))
+    fun returns(returnType: KClass<*>) = returns(returnType.asTypeName())
 
     fun addParameters(parameterSpecs: Iterable<ParameterSpec>): Builder {
       for (parameterSpec in parameterSpecs) {
@@ -326,10 +329,10 @@ class FunSpec private constructor(builder: Builder) {
         = addParameter(ParameterSpec.builder(name, type, *modifiers).build())
 
     fun addParameter(name: String, type: Type, vararg modifiers: KModifier)
-        = addParameter(name, TypeName.get(type), *modifiers)
+        = addParameter(name, type.asTypeName(), *modifiers)
 
     fun addParameter(name: String, type: KClass<*>, vararg modifiers: KModifier)
-        = addParameter(name, TypeName.get(type), *modifiers)
+        = addParameter(name, type.asTypeName(), *modifiers)
 
     @JvmOverloads fun varargs(varargs: Boolean = true): Builder {
       check(!name.isAccessor) { "$name cannot have varargs" }
@@ -347,9 +350,9 @@ class FunSpec private constructor(builder: Builder) {
       return this
     }
 
-    fun addException(exception: Type) = addException(TypeName.get(exception))
+    fun addException(exception: Type) = addException(exception.asTypeName())
 
-    fun addException(exception: KClass<*>) = addException(TypeName.get(exception))
+    fun addException(exception: KClass<*>) = addException(exception.asTypeName())
 
     fun addCode(format: String, vararg args: Any): Builder {
       code.add(format, *args)
@@ -460,15 +463,15 @@ class FunSpec private constructor(builder: Builder) {
 
       for (typeParameterElement in method.typeParameters) {
         val typeVariable = typeParameterElement.asType() as TypeVariable
-        funBuilder.addTypeVariable(TypeVariableName.get(typeVariable))
+        funBuilder.addTypeVariable(typeVariable.asTypeVariableName())
       }
 
-      funBuilder.returns(TypeName.get(method.returnType))
+      funBuilder.returns(method.returnType.asTypeName())
       funBuilder.addParameters(ParameterSpec.parametersOf(method))
       funBuilder.varargs(method.isVarArgs)
 
       for (thrownType in method.thrownTypes) {
-        funBuilder.addException(TypeName.get(thrownType))
+        funBuilder.addException(thrownType.asTypeName())
       }
 
       return funBuilder
@@ -489,12 +492,12 @@ class FunSpec private constructor(builder: Builder) {
       val resolvedReturnType = executableType.returnType
 
       val builder = overriding(method)
-      builder.returns(TypeName.get(resolvedReturnType))
+      builder.returns(resolvedReturnType.asTypeName())
       var i = 0
       val size = builder.parameters.size
       while (i < size) {
         val parameter = builder.parameters[i]
-        val type = TypeName.get(resolvedParameterTypes[i])
+        val type = resolvedParameterTypes[i].asTypeName()
         builder.parameters[i] = parameter.toBuilder(parameter.name, type).build()
         i++
       }

--- a/src/main/java/com/squareup/kotlinpoet/KotlinFile.kt
+++ b/src/main/java/com/squareup/kotlinpoet/KotlinFile.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.IOException
@@ -222,14 +223,14 @@ class KotlinFile private constructor(builder: KotlinFile.Builder) {
     }
 
     fun addStaticImport(constant: Enum<*>)
-        = addStaticImport(ClassName.get(
-        (constant as java.lang.Enum<*>).getDeclaringClass()), constant.name)
+        = addStaticImport(
+        (constant as java.lang.Enum<*>).getDeclaringClass().asClassName(), constant.name)
 
     fun addStaticImport(clazz: Class<*>, vararg names: String)
-        = addStaticImport(ClassName.get(clazz), *names)
+        = addStaticImport(clazz.asClassName(), *names)
 
     fun addStaticImport(clazz: KClass<*>, vararg names: String)
-        = addStaticImport(ClassName.get(clazz), *names)
+        = addStaticImport(clazz.asClassName(), *names)
 
     fun addStaticImport(className: ClassName, vararg names: String): Builder {
       check(names.isNotEmpty()) { "names array is empty" }

--- a/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
@@ -15,6 +15,8 @@
  */
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
+import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import java.io.IOException
 import java.io.StringWriter
 import java.lang.reflect.Type
@@ -96,7 +98,9 @@ class ParameterSpec private constructor(builder: ParameterSpec.Builder) {
       return this
     }
 
-    fun addAnnotation(annotation: Class<*>) = addAnnotation(ClassName.get(annotation))
+    fun addAnnotation(annotation: Class<*>) = addAnnotation(annotation.asClassName())
+
+    fun addAnnotation(annotation: KClass<*>) = addAnnotation(annotation.asClassName())
 
     fun addModifiers(vararg modifiers: KModifier): Builder {
       this.modifiers += modifiers
@@ -132,7 +136,7 @@ class ParameterSpec private constructor(builder: ParameterSpec.Builder) {
   companion object {
     @JvmStatic fun get(element: VariableElement): ParameterSpec {
       val name = element.simpleName.toString()
-      val type = TypeName.get(element.asType())
+      val type = element.asType().asTypeName()
       return ParameterSpec.builder(name, type)
           .jvmModifiers(element.modifiers)
           .build()
@@ -147,9 +151,9 @@ class ParameterSpec private constructor(builder: ParameterSpec.Builder) {
     }
 
     @JvmStatic fun builder(name: String, type: Type, vararg modifiers: KModifier)
-        = builder(name, TypeName.get(type), *modifiers)
+        = builder(name, type.asTypeName(), *modifiers)
 
     @JvmStatic fun builder(name: String, type: KClass<*>, vararg modifiers: KModifier)
-        = builder(name, TypeName.get(type), *modifiers)
+        = builder(name, type.asTypeName(), *modifiers)
   }
 }

--- a/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import java.io.IOException
 import java.lang.reflect.Modifier
 import java.lang.reflect.ParameterizedType
@@ -88,21 +89,22 @@ class ParameterizedTypeName internal constructor(
 
     /** Returns a parameterized type, applying `typeArguments` to `rawType`.  */
     @JvmStatic fun get(rawType: KClass<*>, vararg typeArguments: KClass<*>)
-        = ParameterizedTypeName(null, ClassName.get(rawType),
-        typeArguments.map { TypeName.get(it) })
+        = ParameterizedTypeName(null, rawType.asClassName(),
+        typeArguments.map { it.asTypeName() })
 
     /** Returns a parameterized type, applying `typeArguments` to `rawType`.  */
     @JvmStatic fun get(rawType: Class<*>, vararg typeArguments: Type) = ParameterizedTypeName(
-        null, ClassName.get(rawType), typeArguments.map { TypeName.get(it) })
+        null, rawType.asClassName(), typeArguments.map { it.asTypeName() })
 
     /** Returns a parameterized type equivalent to `type`.  */
-    @JvmStatic fun get(type: ParameterizedType) = get(type, mutableMapOf())
+    @JvmStatic @JvmName("get")
+    fun ParameterizedType.asParameterizedTypeName() = get(this, mutableMapOf())
 
     /** Returns a parameterized type equivalent to `type`.  */
     internal fun get(
         type: ParameterizedType,
         map: MutableMap<Type, TypeVariableName>): ParameterizedTypeName {
-      val rawType = ClassName.get(type.rawType as Class<*>)
+      val rawType = (type.rawType as Class<*>).asClassName()
       val ownerType = if (type.ownerType is ParameterizedType
           && !Modifier.isStatic((type.rawType as Class<*>).modifiers))
         type.ownerType as ParameterizedType else

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -15,8 +15,10 @@
  */
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import com.squareup.kotlinpoet.FunSpec.Companion.GETTER
 import com.squareup.kotlinpoet.FunSpec.Companion.SETTER
+import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import java.io.IOException
 import java.io.StringWriter
 import java.lang.reflect.Type
@@ -136,7 +138,9 @@ class PropertySpec private constructor(builder: Builder) {
       return this
     }
 
-    fun addAnnotation(annotation: Class<*>) = addAnnotation(ClassName.get(annotation))
+    fun addAnnotation(annotation: Class<*>) = addAnnotation(annotation.asClassName())
+
+    fun addAnnotation(annotation: KClass<*>) = addAnnotation(annotation.asClassName())
 
     fun addModifiers(vararg modifiers: KModifier): Builder {
       for (modifier in modifiers) {
@@ -188,10 +192,10 @@ class PropertySpec private constructor(builder: Builder) {
     }
 
     @JvmStatic fun builder(name: String, type: Type, vararg modifiers: KModifier)
-        = builder(name, TypeName.get(type), *modifiers)
+        = builder(name, type.asTypeName(), *modifiers)
 
     @JvmStatic fun builder(name: String, type: KClass<*>, vararg modifiers: KModifier)
-        = builder(name, TypeName.get(type), *modifiers)
+        = builder(name, type.asTypeName(), *modifiers)
 
     @JvmStatic fun varBuilder(name: String, type: TypeName, vararg modifiers: KModifier): Builder {
       require(SourceVersion.isName(name)) { "not a valid name: $name" }
@@ -201,9 +205,9 @@ class PropertySpec private constructor(builder: Builder) {
     }
 
     @JvmStatic fun varBuilder(name: String, type: Type, vararg modifiers: KModifier)
-        = varBuilder(name, TypeName.get(type), *modifiers)
+        = varBuilder(name, type.asTypeName(), *modifiers)
 
     @JvmStatic fun varBuilder(name: String, type: KClass<*>, vararg modifiers: KModifier)
-        = varBuilder(name, TypeName.get(type), *modifiers)
+        = varBuilder(name, type.asTypeName(), *modifiers)
   }
 }

--- a/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import java.io.IOException
 import java.io.StringWriter
 import java.lang.reflect.Type
@@ -84,8 +85,8 @@ class TypeAliasSpec private constructor(builder: TypeAliasSpec.Builder) {
 
     @JvmStatic fun builder(name: String, type: TypeName) = Builder(name, type)
 
-    @JvmStatic fun builder(name: String, type: Type) = builder(name, TypeName.get(type))
+    @JvmStatic fun builder(name: String, type: Type) = builder(name, type.asTypeName())
 
-    @JvmStatic fun builder(name: String, type: KClass<*>) = builder(name, TypeName.get(type))
+    @JvmStatic fun builder(name: String, type: KClass<*>) = builder(name, type.asTypeName())
   }
 }

--- a/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import java.io.IOException
 import java.lang.reflect.GenericArrayType
 import java.lang.reflect.ParameterizedType
@@ -122,10 +123,13 @@ abstract class TypeName internal constructor(
   }
 
   companion object {
-    /** Returns a type name equivalent to `mirror`.  */
-    @JvmOverloads @JvmStatic fun get(
+    /** Returns a [TypeName] equivalent to this [TypeMirror]. */
+    @JvmStatic @JvmName("get")
+    fun TypeMirror.asTypeName() = get(this, mutableMapOf())
+
+    internal fun get(
         mirror: TypeMirror,
-        typeVariables: MutableMap<TypeParameterElement, TypeVariableName> = mutableMapOf())
+        typeVariables: MutableMap<TypeParameterElement, TypeVariableName>)
         : TypeName {
       return mirror.accept(object : SimpleTypeVisitor7<TypeName, Void?>() {
         override fun visitPrimitive(t: PrimitiveType, p: Void?): TypeName {
@@ -143,7 +147,7 @@ abstract class TypeName internal constructor(
         }
 
         override fun visitDeclared(t: DeclaredType, p: Void?): TypeName {
-          val rawType: ClassName = ClassName.get(t.asElement() as TypeElement)
+          val rawType: ClassName = (t.asElement() as TypeElement).asClassName()
           val enclosingType = t.enclosingType
           val enclosing = if (enclosingType.kind != TypeKind.NONE
               && !t.asElement().modifiers.contains(Modifier.STATIC))
@@ -189,14 +193,15 @@ abstract class TypeName internal constructor(
       }, null)
     }
 
-    /** Returns a type name equivalent to `type`.  */
-    @JvmStatic fun get(type: KClass<*>) = ClassName.get(type)
+    /** Returns a [TypeName] equivalent to this [KClass].  */
+    @JvmStatic @JvmName("get")
+    fun KClass<*>.asTypeName() = asClassName()
 
-    /** Returns a type name equivalent to `type`.  */
-    @JvmOverloads @JvmStatic fun get(
-        type: Type,
-        map: MutableMap<Type, TypeVariableName> = mutableMapOf())
-        : TypeName {
+    /** Returns a [TypeName] equivalent to this [Type].  */
+    @JvmStatic @JvmName("get")
+    fun Type.asTypeName() = get(this, mutableMapOf())
+
+    internal fun get(type: Type,map: MutableMap<Type, TypeVariableName>): TypeName {
       when (type) {
         is Class<*> -> {
           when {
@@ -210,7 +215,7 @@ abstract class TypeName internal constructor(
             type === Float::class.javaPrimitiveType -> return FLOAT
             type === Double::class.javaPrimitiveType -> return DOUBLE
             type.isArray -> return ParameterizedTypeName.get(ARRAY, get(type.componentType, map))
-            else -> return ClassName.get(type)
+            else -> return type.asClassName()
           }
         }
         is ParameterizedType -> return ParameterizedTypeName.get(type, map)
@@ -231,14 +236,14 @@ abstract class TypeName internal constructor(
   }
 }
 
-@JvmField val ANY = ClassName.get("kotlin", "Any")
-@JvmField val ARRAY = ClassName.get("kotlin", "Array")
-@JvmField val UNIT = ClassName.get(Unit::class)
-@JvmField val BOOLEAN = ClassName.get("kotlin", "Boolean")
-@JvmField val BYTE = ClassName.get("kotlin", "Byte")
-@JvmField val SHORT = ClassName.get("kotlin", "Short")
-@JvmField val INT = ClassName.get("kotlin", "Int")
-@JvmField val LONG = ClassName.get("kotlin", "Long")
-@JvmField val CHAR = ClassName.get("kotlin", "Char")
-@JvmField val FLOAT = ClassName.get("kotlin", "Float")
-@JvmField val DOUBLE = ClassName.get("kotlin", "Double")
+@JvmField val ANY = ClassName("kotlin", "Any")
+@JvmField val ARRAY = ClassName("kotlin", "Array")
+@JvmField val UNIT = Unit::class.asClassName()
+@JvmField val BOOLEAN = ClassName("kotlin", "Boolean")
+@JvmField val BYTE = ClassName("kotlin", "Byte")
+@JvmField val SHORT = ClassName("kotlin", "Short")
+@JvmField val INT = ClassName("kotlin", "Int")
+@JvmField val LONG = ClassName("kotlin", "Long")
+@JvmField val CHAR = ClassName("kotlin", "Char")
+@JvmField val FLOAT = ClassName("kotlin", "Float")
+@JvmField val DOUBLE = ClassName("kotlin", "Double")

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -15,7 +15,9 @@
  */
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import com.squareup.kotlinpoet.KModifier.PUBLIC
+import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import java.io.IOException
 import java.io.StringWriter
 import java.lang.reflect.Type
@@ -325,9 +327,9 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     fun addAnnotation(annotation: ClassName)
         = addAnnotation(AnnotationSpec.builder(annotation).build())
 
-    fun addAnnotation(annotation: Class<*>) = addAnnotation(ClassName.get(annotation))
+    fun addAnnotation(annotation: Class<*>) = addAnnotation(annotation.asClassName())
 
-    fun addAnnotation(annotation: KClass<*>) = addAnnotation(ClassName.get(annotation))
+    fun addAnnotation(annotation: KClass<*>) = addAnnotation(annotation.asClassName())
 
     fun addModifiers(vararg modifiers: KModifier): Builder {
       check(anonymousTypeArguments == null) { "forbidden on anonymous types." }
@@ -375,7 +377,11 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     }
 
     fun superclass(superclass: Type): Builder {
-      return superclass(TypeName.get(superclass))
+      return superclass(superclass.asTypeName())
+    }
+
+    fun superclass(superclass: KClass<*>): Builder {
+      return superclass(superclass.asTypeName())
     }
 
     fun addSuperinterfaces(superinterfaces: Iterable<TypeName>): Builder {
@@ -389,10 +395,10 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     }
 
     fun addSuperinterface(superinterface: Type)
-        = addSuperinterface(TypeName.get(superinterface))
+        = addSuperinterface(superinterface.asTypeName())
 
     fun addSuperinterface(superinterface: KClass<*>)
-        = addSuperinterface(TypeName.get(superinterface))
+        = addSuperinterface(superinterface.asTypeName())
 
     @JvmOverloads fun addEnumConstant(
         name: String,
@@ -422,10 +428,10 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
         = addProperty(PropertySpec.builder(name, type, *modifiers).build())
 
     fun addProperty(name: String, type: Type, vararg modifiers: KModifier)
-        = addProperty(name, TypeName.get(type), *modifiers)
+        = addProperty(name, type.asTypeName(), *modifiers)
 
     fun addProperty(name: String, type: KClass<*>, vararg modifiers: KModifier)
-        = addProperty(name, TypeName.get(type), *modifiers)
+        = addProperty(name, type.asTypeName(), *modifiers)
 
     fun addInitializerBlock(block: CodeBlock): Builder {
       check(kind == Kind.CLASS || kind == Kind.OBJECT || kind == Kind.ENUM) { "$kind can't have initializer blocks" }

--- a/src/main/java/com/squareup/kotlinpoet/TypeVariableName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeVariableName.kt
@@ -42,11 +42,11 @@ class TypeVariableName private constructor(
   }
 
   fun withBounds(vararg bounds: Type): TypeVariableName {
-    return withBounds(bounds.map { get(it) })
+    return withBounds(bounds.map { it.asTypeName() })
   }
 
   fun withBounds(vararg bounds: KClass<*>): TypeVariableName {
-    return withBounds(bounds.map { TypeName.get(it) })
+    return withBounds(bounds.map { it.asTypeName() })
   }
 
   fun withBounds(vararg bounds: TypeName): TypeVariableName {
@@ -69,29 +69,30 @@ class TypeVariableName private constructor(
     }
 
     /** Returns type variable named `name` without bounds.  */
-    @JvmStatic fun get(name: String): TypeVariableName {
-      return TypeVariableName.of(name, emptyList())
-    }
+    @JvmStatic @JvmName("get")
+    operator fun invoke(name: String) = TypeVariableName.of(name, emptyList())
 
     /** Returns type variable named `name` with `bounds`.  */
-    @JvmStatic fun get(name: String, vararg bounds: TypeName): TypeVariableName {
+    @JvmStatic @JvmName("get")
+    operator fun invoke(name: String, vararg bounds: TypeName): TypeVariableName {
       return TypeVariableName.of(name, bounds.toList())
     }
 
     /** Returns type variable named `name` with `bounds`.  */
-    @JvmStatic fun get(name: String, vararg bounds: KClass<*>): TypeVariableName {
-      return TypeVariableName.of(name, bounds.map { TypeName.get(it) })
+    @JvmStatic @JvmName("get")
+    operator fun invoke(name: String, vararg bounds: KClass<*>): TypeVariableName {
+      return TypeVariableName.of(name, bounds.map { it.asTypeName() })
     }
 
     /** Returns type variable named `name` with `bounds`.  */
-    @JvmStatic fun get(name: String, vararg bounds: Type): TypeVariableName {
-      return TypeVariableName.of(name, bounds.map { get(it) })
+    @JvmStatic @JvmName("get")
+    operator fun invoke(name: String, vararg bounds: Type): TypeVariableName {
+      return TypeVariableName.of(name, bounds.map { it.asTypeName() })
     }
 
     /** Returns type variable equivalent to `mirror`.  */
-    @JvmStatic fun get(mirror: TypeVariable): TypeVariableName {
-      return get(mirror.asElement() as TypeParameterElement)
-    }
+    @JvmStatic @JvmName("get")
+    fun TypeVariable.asTypeVariableName() = get(asElement() as TypeParameterElement)
 
     /**
      * Make a TypeVariableName for the given TypeMirror. This form is used internally to avoid
@@ -101,7 +102,7 @@ class TypeVariableName private constructor(
      * constructing the bounds, we can just return it from the map. And, the code that put the entry
      * in `variables` will make sure that the bounds are filled in before returning.
      */
-    @JvmStatic internal fun get(
+    internal fun get(
         mirror: TypeVariable,
         typeVariables: MutableMap<TypeParameterElement, TypeVariableName>): TypeVariableName {
       val element = mirror.asElement() as TypeParameterElement
@@ -124,13 +125,7 @@ class TypeVariableName private constructor(
     /** Returns type variable equivalent to `element`.  */
     @JvmStatic fun get(element: TypeParameterElement): TypeVariableName {
       val name = element.simpleName.toString()
-      val boundsMirrors = element.bounds
-
-      val boundsTypeNames = mutableListOf<TypeName>()
-      for (typeMirror in boundsMirrors) {
-        boundsTypeNames += TypeName.get(typeMirror)
-      }
-
+      val boundsTypeNames = element.bounds.map { it.asTypeName() }
       return TypeVariableName.of(name, boundsTypeNames)
     }
 

--- a/src/main/java/com/squareup/kotlinpoet/WildcardTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/WildcardTypeName.kt
@@ -67,11 +67,11 @@ class WildcardTypeName private constructor(
     }
 
     @JvmStatic fun subtypeOf(upperBound: Type): WildcardTypeName {
-      return subtypeOf(TypeName.get(upperBound))
+      return subtypeOf(upperBound.asTypeName())
     }
 
     @JvmStatic fun subtypeOf(upperBound: KClass<*>): WildcardTypeName {
-      return subtypeOf(TypeName.get(upperBound))
+      return subtypeOf(upperBound.asTypeName())
     }
 
     /**
@@ -83,16 +83,19 @@ class WildcardTypeName private constructor(
     }
 
     @JvmStatic fun supertypeOf(lowerBound: Type): WildcardTypeName {
-      return supertypeOf(TypeName.get(lowerBound))
+      return supertypeOf(lowerBound.asTypeName())
     }
 
     @JvmStatic fun supertypeOf(lowerBound: KClass<*>): WildcardTypeName {
-      return supertypeOf(TypeName.get(lowerBound))
+      return supertypeOf(lowerBound.asTypeName())
     }
 
-    @JvmOverloads @JvmStatic fun get(
+    @JvmStatic @JvmName("get")
+    fun javax.lang.model.type.WildcardType.asWildcardTypeName() = get(this, mutableMapOf())
+
+    internal fun get(
         mirror: javax.lang.model.type.WildcardType,
-        typeVariables: MutableMap<TypeParameterElement, TypeVariableName> = mutableMapOf())
+        typeVariables: MutableMap<TypeParameterElement, TypeVariableName>)
         : TypeName {
       val extendsBound = mirror.extendsBound
       if (extendsBound == null) {
@@ -105,9 +108,12 @@ class WildcardTypeName private constructor(
       }
     }
 
-    @JvmStatic fun get(
+    @JvmStatic @JvmName("get")
+    fun WildcardType.asWildcardTypeName() = get(this, mutableMapOf())
+
+    internal fun get(
         wildcardName: WildcardType,
-        map: MutableMap<Type, TypeVariableName> = mutableMapOf())
+        map: MutableMap<Type, TypeVariableName>)
         : TypeName {
       return WildcardTypeName(
           wildcardName.upperBounds.map { TypeName.get(it, map = map) },

--- a/src/test/java/com/squareup/kotlinpoet/AbstractTypesTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/AbstractTypesTest.kt
@@ -16,6 +16,8 @@
 package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
+import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import org.junit.Assert.fail
 import org.junit.Ignore
 import org.junit.Test
@@ -37,24 +39,24 @@ abstract class AbstractTypesTest {
   private fun getMirror(clazz: Class<*>) = getElement(clazz).asType()
 
   @Test fun getBasicTypeMirror() {
-    assertThat(TypeName.get(getMirror(Any::class.java)))
-        .isEqualTo(ClassName.get(Any::class.java))
-    assertThat(TypeName.get(getMirror(Charset::class.java)))
-        .isEqualTo(ClassName.get(Charset::class))
-    assertThat(TypeName.get(getMirror(AbstractTypesTest::class.java)))
-        .isEqualTo(ClassName.get(AbstractTypesTest::class))
+    assertThat(getMirror(Any::class.java).asTypeName())
+        .isEqualTo(Any::class.java.asClassName())
+    assertThat(getMirror(Charset::class.java).asTypeName())
+        .isEqualTo(Charset::class.asClassName())
+    assertThat(getMirror(AbstractTypesTest::class.java).asTypeName())
+        .isEqualTo(AbstractTypesTest::class.asClassName())
   }
 
   @Test fun getParameterizedTypeMirror() {
     val setType = types.getDeclaredType(getElement(Set::class.java), getMirror(String::class.java))
-    assertThat(TypeName.get(setType))
+    assertThat(setType.asTypeName())
         .isEqualTo(
-            ParameterizedTypeName.get(ClassName.get(Set::class), ClassName.get(String::class)))
+            ParameterizedTypeName.get(Set::class.asClassName(), String::class.asClassName()))
   }
 
   @Test fun getErrorType() {
     val errorType = DeclaredTypeAsErrorType(types.getDeclaredType(getElement(Set::class.java)))
-    assertThat(TypeName.get(errorType)).isEqualTo(ClassName.get(Set::class))
+    assertThat(errorType.asTypeName()).isEqualTo(Set::class.asClassName())
   }
 
   internal class Parameterized<
@@ -70,23 +72,23 @@ abstract class AbstractTypesTest {
     val typeVariables = getElement(Parameterized::class.java).typeParameters
 
     // Members of converted types use ClassName and not Class<?>.
-    val number = ClassName.get(Number::class)
-    val runnable = ClassName.get(Runnable::class)
-    val serializable = ClassName.get(Serializable::class)
+    val number = Number::class.asClassName()
+    val runnable = Runnable::class.asClassName()
+    val serializable = Serializable::class.asClassName()
 
-    assertThat(TypeName.get(typeVariables[0].asType()))
-        .isEqualTo(TypeVariableName.get("Simple"))
-    assertThat(TypeName.get(typeVariables[1].asType()))
-        .isEqualTo(TypeVariableName.get("ExtendsClass", number))
-    assertThat(TypeName.get(typeVariables[2].asType()))
-        .isEqualTo(TypeVariableName.get("ExtendsInterface", runnable))
-    assertThat(TypeName.get(typeVariables[3].asType()))
-        .isEqualTo(TypeVariableName.get("ExtendsTypeVariable", TypeVariableName.get("Simple")))
-    assertThat(TypeName.get(typeVariables[4].asType()))
-        .isEqualTo(TypeVariableName.get("Intersection", number, runnable))
-    assertThat(TypeName.get(typeVariables[5].asType()))
-        .isEqualTo(TypeVariableName.get("IntersectionOfInterfaces", runnable, serializable))
-    assertThat((TypeName.get(typeVariables[4].asType()) as TypeVariableName).bounds)
+    assertThat(typeVariables[0].asType().asTypeName())
+        .isEqualTo(TypeVariableName("Simple"))
+    assertThat(typeVariables[1].asType().asTypeName())
+        .isEqualTo(TypeVariableName("ExtendsClass", number))
+    assertThat(typeVariables[2].asType().asTypeName())
+        .isEqualTo(TypeVariableName("ExtendsInterface", runnable))
+    assertThat(typeVariables[3].asType().asTypeName())
+        .isEqualTo(TypeVariableName("ExtendsTypeVariable", TypeVariableName("Simple")))
+    assertThat(typeVariables[4].asType().asTypeName())
+        .isEqualTo(TypeVariableName("Intersection", number, runnable))
+    assertThat(typeVariables[5].asType().asTypeName())
+        .isEqualTo(TypeVariableName("IntersectionOfInterfaces", runnable, serializable))
+    assertThat((typeVariables[4].asType().asTypeName() as TypeVariableName).bounds)
         .containsExactly(number, runnable)
   }
 
@@ -94,7 +96,7 @@ abstract class AbstractTypesTest {
 
   @Test fun getTypeVariableTypeMirrorRecursive() {
     val typeMirror = getElement(Recursive::class.java).asType()
-    val typeName = TypeName.get(typeMirror) as ParameterizedTypeName
+    val typeName = typeMirror.asTypeName() as ParameterizedTypeName
     val className = Recursive::class.java.canonicalName
     assertThat(typeName.toString()).isEqualTo(className + "<T>")
 
@@ -105,28 +107,28 @@ abstract class AbstractTypesTest {
   }
 
   @Test fun getPrimitiveTypeMirror() {
-    assertThat(TypeName.get(types.getPrimitiveType(TypeKind.BOOLEAN))).isEqualTo(BOOLEAN)
-    assertThat(TypeName.get(types.getPrimitiveType(TypeKind.BYTE))).isEqualTo(BYTE)
-    assertThat(TypeName.get(types.getPrimitiveType(TypeKind.SHORT))).isEqualTo(SHORT)
-    assertThat(TypeName.get(types.getPrimitiveType(TypeKind.INT))).isEqualTo(INT)
-    assertThat(TypeName.get(types.getPrimitiveType(TypeKind.LONG))).isEqualTo(LONG)
-    assertThat(TypeName.get(types.getPrimitiveType(TypeKind.CHAR))).isEqualTo(CHAR)
-    assertThat(TypeName.get(types.getPrimitiveType(TypeKind.FLOAT))).isEqualTo(FLOAT)
-    assertThat(TypeName.get(types.getPrimitiveType(TypeKind.DOUBLE))).isEqualTo(DOUBLE)
+    assertThat(types.getPrimitiveType(TypeKind.BOOLEAN).asTypeName()).isEqualTo(BOOLEAN)
+    assertThat(types.getPrimitiveType(TypeKind.BYTE).asTypeName()).isEqualTo(BYTE)
+    assertThat(types.getPrimitiveType(TypeKind.SHORT).asTypeName()).isEqualTo(SHORT)
+    assertThat(types.getPrimitiveType(TypeKind.INT).asTypeName()).isEqualTo(INT)
+    assertThat(types.getPrimitiveType(TypeKind.LONG).asTypeName()).isEqualTo(LONG)
+    assertThat(types.getPrimitiveType(TypeKind.CHAR).asTypeName()).isEqualTo(CHAR)
+    assertThat(types.getPrimitiveType(TypeKind.FLOAT).asTypeName()).isEqualTo(FLOAT)
+    assertThat(types.getPrimitiveType(TypeKind.DOUBLE).asTypeName()).isEqualTo(DOUBLE)
   }
 
   @Test fun getArrayTypeMirror() {
-    assertThat(TypeName.get(types.getArrayType(getMirror(String::class.java))))
-        .isEqualTo(ParameterizedTypeName.get(ARRAY, ClassName.get(String::class)))
+    assertThat(types.getArrayType(getMirror(String::class.java)).asTypeName())
+        .isEqualTo(ParameterizedTypeName.get(ARRAY, String::class.asClassName()))
   }
 
   @Test fun getVoidTypeMirror() {
-    assertThat(TypeName.get(types.getNoType(TypeKind.VOID))).isEqualTo(UNIT)
+    assertThat(types.getNoType(TypeKind.VOID).asTypeName()).isEqualTo(UNIT)
   }
 
   @Test fun getNullTypeMirror() {
     try {
-      TypeName.get(types.nullType)
+      types.nullType.asTypeName()
       fail()
     } catch (expected: IllegalArgumentException) {
     }
@@ -145,7 +147,7 @@ abstract class AbstractTypesTest {
   @Ignore("Figure out what this maps to in Kotlin.")
   @Test fun starProjectionFromMirror() {
     val wildcard = types.getWildcardType(null, null)
-    val type = TypeName.get(wildcard)
+    val type = wildcard.asTypeName()
     assertThat(type.toString()).isEqualTo("*")
   }
 
@@ -159,7 +161,7 @@ abstract class AbstractTypesTest {
     val elements = elements
     val charSequence = elements.getTypeElement(CharSequence::class.java.name).asType()
     val wildcard = types.getWildcardType(charSequence, null)
-    val type = TypeName.get(wildcard)
+    val type = wildcard.asTypeName()
     assertThat(type.toString()).isEqualTo("out java.lang.CharSequence")
   }
 
@@ -173,12 +175,12 @@ abstract class AbstractTypesTest {
     val elements = elements
     val string = elements.getTypeElement(String::class.java.name).asType()
     val wildcard = types.getWildcardType(null, string)
-    val type = TypeName.get(wildcard)
+    val type = wildcard.asTypeName()
     assertThat(type.toString()).isEqualTo("in kotlin.String")
   }
 
   @Test fun typeVariable() {
-    val type = TypeVariableName.get("T", CharSequence::class)
+    val type = TypeVariableName("T", CharSequence::class)
     assertThat(type.toString()).isEqualTo("T") // (Bounds are only emitted in declaration.)
   }
 

--- a/src/test/java/com/squareup/kotlinpoet/AnnotatedTypeNameTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/AnnotatedTypeNameTest.kt
@@ -15,6 +15,8 @@
  */
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
+import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -29,9 +31,9 @@ class AnnotatedTypeNameTest {
   annotation class NeverNull
 
   @Test fun annotated() {
-    val simpleString = TypeName.get(String::class)
+    val simpleString = String::class.asTypeName()
     assertFalse(simpleString.isAnnotated)
-    assertEquals(simpleString, TypeName.get(String::class))
+    assertEquals(simpleString, String::class.asTypeName())
     val annotated = simpleString.annotated(NEVER_NULL)
     assertTrue(annotated.isAnnotated)
     assertEquals(annotated, annotated.annotated())
@@ -39,14 +41,14 @@ class AnnotatedTypeNameTest {
 
   @Test fun annotatedType() {
     val expected = "@$NN kotlin.String"
-    val type = TypeName.get(String::class)
+    val type = String::class.asTypeName()
     val actual = type.annotated(NEVER_NULL).toString()
     assertEquals(expected, actual)
   }
 
   @Test fun annotatedTwice() {
     val expected = "@$NN @java.lang.Override kotlin.String"
-    val type = TypeName.get(String::class)
+    val type = String::class.asTypeName()
     val actual = type.annotated(NEVER_NULL)
         .annotated(AnnotationSpec.builder(Override::class).build())
         .toString()
@@ -62,31 +64,31 @@ class AnnotatedTypeNameTest {
 
   @Test fun annotatedArgumentOfParameterizedType() {
     val expected = "kotlin.collections.List<@$NN kotlin.String>"
-    val type = TypeName.get(String::class).annotated(NEVER_NULL)
-    val list = ClassName.get(List::class)
+    val type = String::class.asTypeName().annotated(NEVER_NULL)
+    val list = List::class.asClassName()
     val actual = ParameterizedTypeName.get(list, type).toString()
     assertEquals(expected, actual)
   }
 
   @Test fun annotatedWildcardTypeNameWithSuper() {
     val expected = "in @$NN kotlin.String"
-    val type = TypeName.get(String::class).annotated(NEVER_NULL)
+    val type = String::class.asTypeName().annotated(NEVER_NULL)
     val actual = WildcardTypeName.supertypeOf(type).toString()
     assertEquals(expected, actual)
   }
 
   @Test fun annotatedWildcardTypeNameWithExtends() {
     val expected = "out @$NN kotlin.String"
-    val type = TypeName.get(String::class).annotated(NEVER_NULL)
+    val type = String::class.asTypeName().annotated(NEVER_NULL)
     val actual = WildcardTypeName.subtypeOf(type).toString()
     assertEquals(expected, actual)
   }
 
   @Test fun annotatedEquivalence() {
     annotatedEquivalence(UNIT)
-    annotatedEquivalence(ClassName.get(Any::class))
+    annotatedEquivalence(Any::class.asClassName())
     annotatedEquivalence(ParameterizedTypeName.get(List::class, Any::class))
-    annotatedEquivalence(TypeVariableName.get("A"))
+    annotatedEquivalence(TypeVariableName("A"))
     annotatedEquivalence(WildcardTypeName.subtypeOf(Object::class))
   }
 
@@ -108,7 +110,7 @@ class AnnotatedTypeNameTest {
   @Ignore @Test fun annotatedNestedType() {
     val expected = "kotlin.collections.Map.@" + TypeUseAnnotation::class.java.canonicalName + " Entry"
     val typeUseAnnotation = AnnotationSpec.builder(TypeUseAnnotation::class).build()
-    val type = TypeName.get(Map.Entry::class).annotated(typeUseAnnotation)
+    val type = Map.Entry::class.asTypeName().annotated(typeUseAnnotation)
     val actual = type.toString()
     assertEquals(expected, actual)
   }

--- a/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
@@ -17,6 +17,7 @@ package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.compile.CompilationRule
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
 import org.junit.Rule
@@ -27,7 +28,7 @@ class ClassNameTest {
 
   @Test fun bestGuessForString_simpleClass() {
     assertThat(ClassName.bestGuess(String::class.java.name))
-        .isEqualTo(ClassName.get("java.lang", "String"))
+        .isEqualTo(ClassName("java.lang", "String"))
   }
 
   @Test fun bestGuessNonAscii() {
@@ -43,19 +44,19 @@ class ClassNameTest {
 
   @Test fun bestGuessForString_nestedClass() {
     assertThat(ClassName.bestGuess(Map.Entry::class.java.canonicalName))
-        .isEqualTo(ClassName.get("java.util", "Map", "Entry"))
+        .isEqualTo(ClassName("java.util", "Map", "Entry"))
     assertThat(ClassName.bestGuess(OuterClass.InnerClass::class.java.canonicalName))
-        .isEqualTo(ClassName.get("com.squareup.kotlinpoet",
+        .isEqualTo(ClassName("com.squareup.kotlinpoet",
             "ClassNameTest", "OuterClass", "InnerClass"))
   }
 
   @Test fun bestGuessForString_defaultPackage() {
     assertThat(ClassName.bestGuess("SomeClass"))
-        .isEqualTo(ClassName.get("", "SomeClass"))
+        .isEqualTo(ClassName("", "SomeClass"))
     assertThat(ClassName.bestGuess("SomeClass.Nested"))
-        .isEqualTo(ClassName.get("", "SomeClass", "Nested"))
+        .isEqualTo(ClassName("", "SomeClass", "Nested"))
     assertThat(ClassName.bestGuess("SomeClass.Nested.EvenMore"))
-        .isEqualTo(ClassName.get("", "SomeClass", "Nested", "EvenMore"))
+        .isEqualTo(ClassName("", "SomeClass", "Nested", "EvenMore"))
   }
 
   @Test fun bestGuessForString_confusingInput() {
@@ -82,64 +83,64 @@ class ClassNameTest {
   }
 
   @Test fun createNestedClass() {
-    val foo = ClassName.get("com.example", "Foo")
+    val foo = ClassName("com.example", "Foo")
     val bar = foo.nestedClass("Bar")
-    assertThat(bar).isEqualTo(ClassName.get("com.example", "Foo", "Bar"))
+    assertThat(bar).isEqualTo(ClassName("com.example", "Foo", "Bar"))
     val baz = bar.nestedClass("Baz")
-    assertThat(baz).isEqualTo(ClassName.get("com.example", "Foo", "Bar", "Baz"))
+    assertThat(baz).isEqualTo(ClassName("com.example", "Foo", "Bar", "Baz"))
   }
 
   @Test fun classNameFromTypeElement() {
     val elements = compilationRule.elements
     val element = elements.getTypeElement(Any::class.java.canonicalName)
-    assertThat(ClassName.get(element).toString()).isEqualTo("java.lang.Object")
+    assertThat(element.asClassName().toString()).isEqualTo("java.lang.Object")
   }
 
   @Test fun classNameFromClass() {
-    assertThat(ClassName.get(Any::class.java).toString())
+    assertThat(Any::class.java.asClassName().toString())
         .isEqualTo("java.lang.Object")
-    assertThat(ClassName.get(OuterClass.InnerClass::class.java).toString())
+    assertThat(OuterClass.InnerClass::class.java.asClassName().toString())
         .isEqualTo("com.squareup.kotlinpoet.ClassNameTest.OuterClass.InnerClass")
   }
 
   @Test fun classNameFromKClass() {
-    assertThat(ClassName.get(Any::class).toString())
+    assertThat(Any::class.asClassName().toString())
         .isEqualTo("kotlin.Any")
-    assertThat(ClassName.get(OuterClass.InnerClass::class).toString())
+    assertThat(OuterClass.InnerClass::class.asClassName().toString())
         .isEqualTo("com.squareup.kotlinpoet.ClassNameTest.OuterClass.InnerClass")
   }
 
   @Test fun peerClass() {
-    assertThat(ClassName.get(java.lang.Double::class).peerClass("Short"))
-        .isEqualTo(ClassName.get(java.lang.Short::class))
-    assertThat(ClassName.get("", "Double").peerClass("Short"))
-        .isEqualTo(ClassName.get("", "Short"))
-    assertThat(ClassName.get("a.b", "Combo", "Taco").peerClass("Burrito"))
-        .isEqualTo(ClassName.get("a.b", "Combo", "Burrito"))
+    assertThat(java.lang.Double::class.asClassName().peerClass("Short"))
+        .isEqualTo(java.lang.Short::class.asClassName())
+    assertThat(ClassName("", "Double").peerClass("Short"))
+        .isEqualTo(ClassName("", "Short"))
+    assertThat(ClassName("a.b", "Combo", "Taco").peerClass("Burrito"))
+        .isEqualTo(ClassName("a.b", "Combo", "Burrito"))
   }
 
   @Test fun fromClassRejectionTypes() {
     try {
-      ClassName.get(java.lang.Integer.TYPE)
+      java.lang.Integer.TYPE.asClassName()
       fail()
     } catch (expected: IllegalArgumentException) {
     }
 
     try {
-      ClassName.get(Void.TYPE)
+      Void.TYPE.asClassName()
       fail()
     } catch (expected: IllegalArgumentException) {
     }
 
     try {
-      ClassName.get(Array<Any>::class.java)
+      Array<Any>::class.java.asClassName()
       fail()
     } catch (expected: IllegalArgumentException) {
     }
 
     // TODO
     //try {
-    //  ClassName.get(Array<Int>::class)
+    //  Array<Int>::class.asClassName()
     //  fail()
     //} catch (expected: IllegalArgumentException) {
     //}
@@ -148,15 +149,15 @@ class ClassNameTest {
   @Test fun reflectionName() {
     assertThat(ANY.reflectionName())
         .isEqualTo("kotlin.Any")
-    assertThat(ClassName.get(Thread.State::class).reflectionName())
+    assertThat(Thread.State::class.asClassName().reflectionName())
         .isEqualTo("java.lang.Thread\$State")
-    assertThat(ClassName.get(Map.Entry::class).reflectionName())
+    assertThat(Map.Entry::class.asClassName().reflectionName())
         .isEqualTo("kotlin.collections.Map\$Entry")
-    assertThat(ClassName.get("", "Foo").reflectionName())
+    assertThat(ClassName("", "Foo").reflectionName())
         .isEqualTo("Foo")
-    assertThat(ClassName.get("", "Foo", "Bar", "Baz").reflectionName())
+    assertThat(ClassName("", "Foo", "Bar", "Baz").reflectionName())
         .isEqualTo("Foo\$Bar\$Baz")
-    assertThat(ClassName.get("a.b.c", "Foo", "Bar", "Baz").reflectionName())
+    assertThat(ClassName("a.b.c", "Foo", "Bar", "Baz").reflectionName())
         .isEqualTo("a.b.c.Foo\$Bar\$Baz")
   }
 }

--- a/src/test/java/com/squareup/kotlinpoet/CodeBlockTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/CodeBlockTest.kt
@@ -16,6 +16,8 @@
 package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
+import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import org.junit.Assert.fail
 import org.junit.Test
 
@@ -268,7 +270,7 @@ class CodeBlockTest {
 
   @Test fun sameIndexCanBeUsedWithDifferentFormats() {
     val block = CodeBlock.builder()
-        .add("%1T.out.println(%1S)", ClassName.get(System::class))
+        .add("%1T.out.println(%1S)", System::class.asClassName())
         .build()
     assertThat(block.toString()).isEqualTo("java.lang.System.out.println(\"java.lang.System\")")
   }
@@ -297,22 +299,22 @@ class CodeBlockTest {
   }
 
   @Test fun nullableType() {
-    val type = TypeName.get(String::class).asNullable()
+    val type = String::class.asTypeName().asNullable()
     val typeBlock = CodeBlock.of("%T", type)
     assertThat(typeBlock.toString()).isEqualTo("kotlin.String?")
 
-    val list = ParameterizedTypeName.get(ClassName.get(List::class).asNullable(),
-        TypeName.get(Int::class).asNullable()).asNullable()
+    val list = ParameterizedTypeName.get(List::class.asClassName().asNullable(),
+        Int::class.asTypeName().asNullable()).asNullable()
     val listBlock = CodeBlock.of("%T", list)
     assertThat(listBlock.toString()).isEqualTo("kotlin.collections.List<kotlin.Int?>?")
 
-    val map = ParameterizedTypeName.get(ClassName.get(Map::class).asNullable(),
-        TypeName.get(String::class).asNullable(), list).asNullable()
+    val map = ParameterizedTypeName.get(Map::class.asClassName().asNullable(),
+        String::class.asTypeName().asNullable(), list).asNullable()
     val mapBlock = CodeBlock.of("%T", map)
     assertThat(mapBlock.toString())
         .isEqualTo("kotlin.collections.Map<kotlin.String?, kotlin.collections.List<kotlin.Int?>?>?")
 
-    val rarr = WildcardTypeName.subtypeOf(TypeName.get(String::class).asNullable())
+    val rarr = WildcardTypeName.subtypeOf(String::class.asTypeName().asNullable())
     val rarrBlock = CodeBlock.of("%T", rarr)
     assertThat(rarrBlock.toString()).isEqualTo("out kotlin.String?")
   }

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -19,6 +19,8 @@ import com.google.common.collect.ImmutableSet
 import com.google.common.collect.Iterables.getOnlyElement
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.compile.CompilationRule
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
+import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
@@ -152,7 +154,7 @@ class FunSpecTest {
 
   @Test fun nullableParam() {
     val funSpec = FunSpec.builder("foo")
-        .addParameter(ParameterSpec.builder("string", TypeName.get(String::class).asNullable())
+        .addParameter(ParameterSpec.builder("string", String::class.asTypeName().asNullable())
             .build())
         .build()
     assertThat(funSpec.toString()).isEqualTo("""
@@ -163,7 +165,7 @@ class FunSpecTest {
 
   @Test fun nullableReturnType() {
     val funSpec = FunSpec.builder("foo")
-        .returns(TypeName.get(String::class).asNullable())
+        .returns(String::class.asTypeName().asNullable())
         .build()
     assertThat(funSpec.toString()).isEqualTo("""
       |fun foo(): kotlin.String? {
@@ -175,7 +177,7 @@ class FunSpecTest {
     val unitType = UNIT
     val funSpec = FunSpec.builder("foo")
         .addParameter(ParameterSpec.builder("f", LambdaTypeName.get(returnType = unitType)).build())
-        .returns(TypeName.Companion.get(String::class))
+        .returns(String::class)
         .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
@@ -189,7 +191,7 @@ class FunSpecTest {
     val lambdaTypeName = LambdaTypeName.get(receiver = INT, returnType = unitType)
     val funSpec = FunSpec.builder("foo")
         .addParameter(ParameterSpec.builder("f", lambdaTypeName).build())
-        .returns(TypeName.Companion.get(String::class))
+        .returns(String::class)
         .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
@@ -204,7 +206,7 @@ class FunSpecTest {
     val funSpec = FunSpec.builder("foo")
         .addParameter(ParameterSpec.builder("f", LambdaTypeName.get(parameters = booleanType, returnType = unitType))
             .build())
-        .returns(TypeName.Companion.get(String::class))
+        .returns(String::class)
         .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
@@ -216,11 +218,11 @@ class FunSpecTest {
   @Test fun functionParamMultipleLambdaParam() {
     val unitType = UNIT
     val booleanType = BOOLEAN
-    val stringType = ClassName.get(String::class)
+    val stringType = String::class.asClassName()
     val lambdaType = LambdaTypeName.get(parameters = *arrayOf(booleanType, stringType), returnType = unitType)
     val funSpec = FunSpec.builder("foo")
         .addParameter(ParameterSpec.builder("f", lambdaType).build())
-        .returns(TypeName.Companion.get(String::class))
+        .returns(String::class)
         .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
@@ -230,14 +232,14 @@ class FunSpecTest {
   }
 
   @Test fun functionParamMultipleLambdaParamNullableLambda() {
-    val unitType = ClassName.get(Unit::class)
-    val booleanType = ClassName.get(Boolean::class)
-    val stringType = ClassName.get(String::class)
+    val unitType = Unit::class.asClassName()
+    val booleanType = Boolean::class.asClassName()
+    val stringType = String::class.asClassName()
     val lambdaTypeName = LambdaTypeName.get(parameters = *arrayOf(booleanType, stringType), returnType = unitType)
         .asNullable()
     val funSpec = FunSpec.builder("foo")
         .addParameter(ParameterSpec.builder("f", lambdaTypeName) .build())
-        .returns(TypeName.Companion.get(String::class))
+        .returns(String::class)
         .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
@@ -247,13 +249,13 @@ class FunSpecTest {
   }
 
   @Test fun functionParamMultipleNullableLambdaParam() {
-    val unitType = ClassName.get(Unit::class)
-    val booleanType = ClassName.get(Boolean::class)
-    val stringType = ClassName.get(String::class).asNullable()
+    val unitType = Unit::class.asClassName()
+    val booleanType = Boolean::class.asClassName()
+    val stringType = String::class.asClassName().asNullable()
     val lambdaTypeName = LambdaTypeName.get(parameters = *arrayOf(booleanType, stringType), returnType = unitType).asNullable()
     val funSpec = FunSpec.builder("foo")
         .addParameter(ParameterSpec.builder("f", lambdaTypeName).build())
-        .returns(TypeName.Companion.get(String::class))
+        .returns(String::class)
         .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
@@ -280,8 +282,8 @@ class FunSpecTest {
   }
 
   @Test fun duplicateExceptionsIgnored() {
-    val ioException = ClassName.get(IOException::class)
-    val timeoutException = ClassName.get(TimeoutException::class)
+    val ioException = IOException::class.asClassName()
+    val timeoutException = TimeoutException::class.asClassName()
     val funSpec = FunSpec.builder("duplicateExceptions")
         .addException(ioException)
         .addException(timeoutException)

--- a/src/test/java/com/squareup/kotlinpoet/KotlinFileTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/KotlinFileTest.kt
@@ -16,6 +16,7 @@
 package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import org.junit.Ignore
 import org.junit.Test
 import java.util.Collections
@@ -24,10 +25,10 @@ import java.util.concurrent.TimeUnit
 
 class KotlinFileTest {
   @Test fun importStaticReadmeExample() {
-    val hoverboard = ClassName.get("com.mattel", "Hoverboard")
-    val namedBoards = ClassName.get("com.mattel", "Hoverboard", "Boards")
-    val list = ClassName.get(List::class)
-    val arrayList = ClassName.get("java.util", "ArrayList")
+    val hoverboard = ClassName("com.mattel", "Hoverboard")
+    val namedBoards = ClassName("com.mattel", "Hoverboard", "Boards")
+    val list = List::class.asClassName()
+    val arrayList = ClassName("java.util", "ArrayList")
     val listOfHoverboards = ParameterizedTypeName.get(list, hoverboard)
     val beyond = FunSpec.builder("beyond")
         .returns(listOfHoverboards)
@@ -103,7 +104,7 @@ class KotlinFileTest {
                 .addStatement("%1T.out.println(%1T.nanoTime())", System::class)
                 .build())
             .addFun(FunSpec.constructorBuilder()
-                .addParameter("states", ParameterizedTypeName.get(ARRAY, ClassName.get(Thread.State::class)))
+                .addParameter("states", ParameterizedTypeName.get(ARRAY, Thread.State::class.asClassName()))
                 .varargs(true)
                 .build())
             .build())
@@ -287,7 +288,7 @@ class KotlinFileTest {
     val source = KotlinFile.builder("com.squareup.tacos", "Taco")
         .addType(TypeSpec.classBuilder("Taco")
             .addProperty("madeFreshDate", Date::class)
-            .addProperty("madeFreshDatabaseDate", ClassName.get("java.sql", "Date"))
+            .addProperty("madeFreshDatabaseDate", ClassName("java.sql", "Date"))
             .build())
         .build()
     assertThat(source.toString()).isEqualTo("""
@@ -307,8 +308,8 @@ class KotlinFileTest {
     // Whatever is used first wins! In this case the Float in java.lang is imported.
     val source = KotlinFile.builder("com.squareup.tacos", "Taco")
         .addType(TypeSpec.classBuilder("Taco")
-            .addProperty("litres", ClassName.get("java.lang", "Float"))
-            .addProperty("beverage", ClassName.get("com.squareup.soda", "Float"))
+            .addProperty("litres", ClassName("java.lang", "Float"))
+            .addProperty("beverage", ClassName("com.squareup.soda", "Float"))
             .build())
         .skipJavaLangImports(true)
         .build()
@@ -327,8 +328,8 @@ class KotlinFileTest {
     // Whatever is used first wins! In this case the Float in com.squareup.soda is imported.
     val source = KotlinFile.builder("com.squareup.tacos", "Taco")
         .addType(TypeSpec.classBuilder("Taco")
-            .addProperty("beverage", ClassName.get("com.squareup.soda", "Float"))
-            .addProperty("litres", ClassName.get("java.lang", "Float"))
+            .addProperty("beverage", ClassName("com.squareup.soda", "Float"))
+            .addProperty("litres", ClassName("java.lang", "Float"))
             .build())
         .skipJavaLangImports(true)
         .build()
@@ -351,7 +352,7 @@ class KotlinFileTest {
             .addType(TypeSpec.classBuilder("B")
                 .addType(TypeSpec.classBuilder("Twin").build())
                 .addType(TypeSpec.classBuilder("C")
-                    .addProperty("d", ClassName.get("com.squareup.tacos", "A", "Twin", "D"))
+                    .addProperty("d", ClassName("com.squareup.tacos", "A", "Twin", "D"))
                     .build())
                 .build())
             .addType(TypeSpec.classBuilder("Twin")
@@ -386,7 +387,7 @@ class KotlinFileTest {
         .addType(TypeSpec.classBuilder("A")
             .addType(TypeSpec.classBuilder("B")
                 .addType(TypeSpec.classBuilder("C")
-                    .addProperty("d", ClassName.get("com.squareup.tacos", "A", "Twin", "D"))
+                    .addProperty("d", ClassName("com.squareup.tacos", "A", "Twin", "D"))
                     .addType(TypeSpec.classBuilder("Twin").build())
                     .build())
                 .build())
@@ -422,7 +423,7 @@ class KotlinFileTest {
         .addType(TypeSpec.classBuilder("A")
             .addType(TypeSpec.classBuilder("B")
                 .addType(TypeSpec.classBuilder("C")
-                    .addProperty("d", ClassName.get("com.squareup.tacos", "A", "Twin", "D"))
+                    .addProperty("d", ClassName("com.squareup.tacos", "A", "Twin", "D"))
                     .addType(TypeSpec.classBuilder("Nested")
                         .addType(TypeSpec.classBuilder("Twin").build())
                         .build())
@@ -460,9 +461,9 @@ class KotlinFileTest {
   @Test fun nestedClassAndSuperclassShareName() {
     val source = KotlinFile.builder("com.squareup.tacos", "Taco")
         .addType(TypeSpec.classBuilder("Taco")
-            .superclass(ClassName.get("com.squareup.wire", "Message"))
+            .superclass(ClassName("com.squareup.wire", "Message"))
             .addType(TypeSpec.classBuilder("Builder")
-                .superclass(ClassName.get("com.squareup.wire", "Message", "Builder"))
+                .superclass(ClassName("com.squareup.wire", "Message", "Builder"))
                 .build())
             .build())
         .build()
@@ -482,9 +483,9 @@ class KotlinFileTest {
   @Test fun annotationIsNestedClass() {
     val source = KotlinFile.builder("com.squareup.tacos", "TestComponent")
         .addType(TypeSpec.classBuilder("TestComponent")
-            .addAnnotation(ClassName.get("dagger", "Component"))
+            .addAnnotation(ClassName("dagger", "Component"))
             .addType(TypeSpec.classBuilder("Builder")
-                .addAnnotation(ClassName.get("dagger", "Component", "Builder"))
+                .addAnnotation(ClassName("dagger", "Component", "Builder"))
                 .build())
             .build())
         .build()
@@ -507,7 +508,7 @@ class KotlinFileTest {
         .addType(TypeSpec.classBuilder("HelloWorld")
             .addFun(FunSpec.builder("main")
                 .addModifiers(KModifier.PUBLIC)
-                .addParameter("args", ParameterizedTypeName.get(ARRAY, ClassName.get(String::class)))
+                .addParameter("args", ParameterizedTypeName.get(ARRAY, String::class.asClassName()))
                 .addCode("%T.out.println(%S);\n", System::class, "Hello World!")
                 .build())
             .build())
@@ -528,7 +529,7 @@ class KotlinFileTest {
   @Test fun defaultPackageTypesAreNotImported() {
     val source = KotlinFile.builder("hello", "World")
         .addType(TypeSpec.classBuilder("World")
-            .addSuperinterface(ClassName.get("", "Test"))
+            .addSuperinterface(ClassName("", "Test"))
             .build())
         .build()
     assertThat(source.toString()).isEqualTo("""
@@ -574,7 +575,7 @@ class KotlinFileTest {
   @Test fun packageClassConflictsWithNestedClass() {
     val source = KotlinFile.builder("com.squareup.tacos", "Taco")
         .addType(TypeSpec.classBuilder("Taco")
-            .addProperty("a", ClassName.get("com.squareup.tacos", "A"))
+            .addProperty("a", ClassName("com.squareup.tacos", "A"))
             .addType(TypeSpec.classBuilder("A").build())
             .build())
         .build()

--- a/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -16,6 +16,7 @@
 package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import org.junit.Test
 import kotlin.test.fail
 
@@ -309,8 +310,8 @@ class KotlinPoetTest {
   }
 
   @Test fun nullableTypes() {
-    val list = ParameterizedTypeName.get(ClassName.get(List::class).asNullable(),
-        TypeName.get(Int::class).asNullable()).asNullable()
+    val list = ParameterizedTypeName.get(List::class.asClassName().asNullable(),
+        Int::class.asClassName().asNullable()).asNullable()
     assertThat(list.toString()).isEqualTo("kotlin.collections.List<kotlin.Int?>?")
   }
 
@@ -359,7 +360,7 @@ class KotlinPoetTest {
             .initializer("%S", "a")
             .build())
         .addType(TypeSpec.classBuilder("B")
-            .superclass(ClassName.get("", "A"))
+            .superclass(ClassName("", "A"))
             .addModifiers(KModifier.ABSTRACT)
             .addProperty(PropertySpec.varBuilder("q", String::class)
                 .addModifiers(

--- a/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -16,11 +16,12 @@
 package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import org.junit.Test
 
 class PropertySpecTest {
   @Test fun nullable() {
-    val type = TypeName.get(String::class).asNullable()
+    val type = String::class.asClassName().asNullable()
     val a = PropertySpec.builder("foo", type).build()
     assertThat(a.toString()).isEqualTo("val foo: kotlin.String?\n")
   }

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -18,6 +18,8 @@ package com.squareup.kotlinpoet
 import com.google.common.collect.ImmutableMap
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.compile.CompilationRule
+import com.squareup.kotlinpoet.ClassName.Companion.asClassName
+import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
 import org.junit.Rule
@@ -73,10 +75,10 @@ class TypeSpecTest {
 
   @Test fun interestingTypes() {
     val listOfAny = ParameterizedTypeName.get(
-        ClassName.get(List::class), WildcardTypeName.subtypeOf(ANY))
+        List::class.asClassName(), WildcardTypeName.subtypeOf(ANY))
     val listOfExtends = ParameterizedTypeName.get(
-        ClassName.get(List::class), WildcardTypeName.subtypeOf(Serializable::class))
-    val listOfSuper = ParameterizedTypeName.get(ClassName.get(List::class),
+        List::class.asClassName(), WildcardTypeName.subtypeOf(Serializable::class))
+    val listOfSuper = ParameterizedTypeName.get(List::class.asClassName(),
         WildcardTypeName.supertypeOf(String::class))
     val taco = TypeSpec.classBuilder("Taco")
         .addProperty("star", listOfAny)
@@ -101,12 +103,12 @@ class TypeSpecTest {
   }
 
   @Test fun anonymousInnerClass() {
-    val foo = ClassName.get(tacosPackage, "Foo")
-    val bar = ClassName.get(tacosPackage, "Bar")
-    val thingThang = ClassName.get(tacosPackage, "Thing", "Thang")
+    val foo = ClassName(tacosPackage, "Foo")
+    val bar = ClassName(tacosPackage, "Bar")
+    val thingThang = ClassName(tacosPackage, "Thing", "Thang")
     val thingThangOfFooBar = ParameterizedTypeName.get(thingThang, foo, bar)
-    val thung = ClassName.get(tacosPackage, "Thung")
-    val simpleThung = ClassName.get(tacosPackage, "SimpleThung")
+    val thung = ClassName(tacosPackage, "Thung")
+    val simpleThung = ClassName(tacosPackage, "SimpleThung")
     val thungOfSuperBar = ParameterizedTypeName.get(thung, WildcardTypeName.supertypeOf(bar))
     val thungOfSuperFoo = ParameterizedTypeName.get(thung, WildcardTypeName.supertypeOf(foo))
     val simpleThungOfBar = ParameterizedTypeName.get(simpleThung, bar)
@@ -160,18 +162,18 @@ class TypeSpecTest {
             .addModifiers(KModifier.PUBLIC)
             .addParameter("id", Long::class)
             .addParameter(ParameterSpec.builder("one", String::class)
-                .addAnnotation(ClassName.get(tacosPackage, "Ping"))
+                .addAnnotation(ClassName(tacosPackage, "Ping"))
                 .build())
             .addParameter(ParameterSpec.builder("two", String::class)
-                .addAnnotation(ClassName.get(tacosPackage, "Ping"))
+                .addAnnotation(ClassName(tacosPackage, "Ping"))
                 .build())
             .addParameter(ParameterSpec.builder("three", String::class)
-                .addAnnotation(AnnotationSpec.builder(ClassName.get(tacosPackage, "Pong"))
+                .addAnnotation(AnnotationSpec.builder(ClassName(tacosPackage, "Pong"))
                     .addMember("value", "%S", "pong")
                     .build())
                 .build())
             .addParameter(ParameterSpec.builder("four", String::class)
-                .addAnnotation(ClassName.get(tacosPackage, "Ping"))
+                .addAnnotation(ClassName(tacosPackage, "Ping"))
                 .build())
             .addCode("/* code snippets */\n")
             .build())
@@ -197,9 +199,9 @@ class TypeSpecTest {
    * imports. https://github.com/square/javapoet/issues/422
    */
   @Test fun annotationsAndJavaLangTypes() {
-    val freeRange = ClassName.get("javax.annotation", "FreeRange")
+    val freeRange = ClassName("javax.annotation", "FreeRange")
     val taco = TypeSpec.classBuilder("EthicalTaco")
-        .addProperty("meat", ClassName.get(String::class)
+        .addProperty("meat", String::class.asClassName()
             .annotated(AnnotationSpec.builder(freeRange).build()))
         .build()
 
@@ -216,17 +218,17 @@ class TypeSpecTest {
   }
 
   @Test fun retrofitStyleInterface() {
-    val observable = ClassName.get(tacosPackage, "Observable")
-    val fooBar = ClassName.get(tacosPackage, "FooBar")
-    val thing = ClassName.get(tacosPackage, "Thing")
-    val things = ClassName.get(tacosPackage, "Things")
-    val map = ClassName.get(Map::class)
-    val string = ClassName.get(String::class)
-    val headers = ClassName.get(tacosPackage, "Headers")
-    val post = ClassName.get(tacosPackage, "POST")
-    val body = ClassName.get(tacosPackage, "Body")
-    val queryMap = ClassName.get(tacosPackage, "QueryMap")
-    val header = ClassName.get(tacosPackage, "Header")
+    val observable = ClassName(tacosPackage, "Observable")
+    val fooBar = ClassName(tacosPackage, "FooBar")
+    val thing = ClassName(tacosPackage, "Thing")
+    val things = ClassName(tacosPackage, "Things")
+    val map = Map::class.asClassName()
+    val string = String::class.asClassName()
+    val headers = ClassName(tacosPackage, "Headers")
+    val post = ClassName(tacosPackage, "POST")
+    val body = ClassName(tacosPackage, "Body")
+    val queryMap = ClassName(tacosPackage, "QueryMap")
+    val header = ClassName(tacosPackage, "Header")
     val service = TypeSpec.interfaceBuilder("Service")
         .addFun(FunSpec.builder("fooBar")
             .addModifiers(KModifier.PUBLIC, KModifier.ABSTRACT)
@@ -276,8 +278,8 @@ class TypeSpecTest {
   @Test fun annotatedProperty() {
     val taco = TypeSpec.classBuilder("Taco")
         .addProperty(PropertySpec.builder("thing", String::class, KModifier.PRIVATE)
-            .addAnnotation(AnnotationSpec.builder(ClassName.get(tacosPackage, "JsonAdapter"))
-                .addMember("value", "%T::class", ClassName.get(tacosPackage, "Foo"))
+            .addAnnotation(AnnotationSpec.builder(ClassName(tacosPackage, "JsonAdapter"))
+                .addMember("value", "%T::class", ClassName(tacosPackage, "Foo"))
                 .build())
             .build())
         .build()
@@ -294,9 +296,9 @@ class TypeSpecTest {
   }
 
   @Test fun annotatedClass() {
-    val someType = ClassName.get(tacosPackage, "SomeType")
+    val someType = ClassName(tacosPackage, "SomeType")
     val taco = TypeSpec.classBuilder("Foo")
-        .addAnnotation(AnnotationSpec.builder(ClassName.get(tacosPackage, "Something"))
+        .addAnnotation(AnnotationSpec.builder(ClassName(tacosPackage, "Something"))
             .addMember("hi", "%T.%N", someType, "PROPERTY")
             .addMember("hey", "%L", 12)
             .addMember("hello", "%S", "goodbye")
@@ -474,7 +476,7 @@ class TypeSpecTest {
             .build())
         .addFun(FunSpec.builder("throwTwo")
             .addException(IOException::class)
-            .addException(ClassName.get(tacosPackage, "SourCreamException"))
+            .addException(ClassName(tacosPackage, "SourCreamException"))
             .build())
         .addFun(FunSpec.builder("abstractThrow")
             .addModifiers(KModifier.ABSTRACT)
@@ -505,13 +507,13 @@ class TypeSpecTest {
   }
 
   @Test fun typeVariables() {
-    val t = TypeVariableName.get("T")
-    val p = TypeVariableName.get("P", Number::class)
-    val location = ClassName.get(tacosPackage, "Location")
+    val t = TypeVariableName("T")
+    val p = TypeVariableName("P", Number::class)
+    val location = ClassName(tacosPackage, "Location")
     val typeSpec = TypeSpec.classBuilder("Location")
         .addTypeVariable(t)
         .addTypeVariable(p)
-        .addSuperinterface(ParameterizedTypeName.get(ClassName.get(Comparable::class), p))
+        .addSuperinterface(ParameterizedTypeName.get(Comparable::class.asClassName(), p))
         .addProperty("label", t)
         .addProperty("x", p)
         .addProperty("y", p)
@@ -557,9 +559,9 @@ class TypeSpecTest {
   }
 
   @Test fun typeVariableWithBounds() {
-    val a = AnnotationSpec.builder(ClassName.get("com.squareup.tacos", "A")).build()
-    val p = TypeVariableName.get("P", Number::class)
-    val q = TypeVariableName.get("Q", Number::class).annotated(a) as TypeVariableName
+    val a = AnnotationSpec.builder(ClassName("com.squareup.tacos", "A")).build()
+    val p = TypeVariableName("P", Number::class)
+    val q = TypeVariableName("Q", Number::class).annotated(a) as TypeVariableName
     val typeSpec = TypeSpec.classBuilder("Location")
         .addTypeVariable(p.withBounds(Comparable::class))
         .addTypeVariable(q.withBounds(Comparable::class))
@@ -581,13 +583,13 @@ class TypeSpecTest {
   }
 
   @Test fun classImplementsExtends() {
-    val taco = ClassName.get(tacosPackage, "Taco")
-    val food = ClassName.get("com.squareup.tacos", "Food")
+    val taco = ClassName(tacosPackage, "Taco")
+    val food = ClassName("com.squareup.tacos", "Food")
     val typeSpec = TypeSpec.classBuilder("Taco")
         .addModifiers(KModifier.ABSTRACT)
-        .superclass(ParameterizedTypeName.get(ClassName.get(AbstractSet::class), food))
+        .superclass(ParameterizedTypeName.get(AbstractSet::class.asClassName(), food))
         .addSuperinterface(Serializable::class)
-        .addSuperinterface(ParameterizedTypeName.get(ClassName.get(Comparable::class), taco))
+        .addSuperinterface(ParameterizedTypeName.get(Comparable::class.asClassName(), taco))
         .build()
     assertThat(toString(typeSpec)).isEqualTo("""
         |package com.squareup.tacos
@@ -602,12 +604,12 @@ class TypeSpecTest {
   }
 
   @Test fun classImplementsExtendsSameName() {
-    val javapoetTaco = ClassName.get(tacosPackage, "Taco")
-    val tacoBellTaco = ClassName.get("com.taco.bell", "Taco")
-    val fishTaco = ClassName.get("org.fish.taco", "Taco")
+    val javapoetTaco = ClassName(tacosPackage, "Taco")
+    val tacoBellTaco = ClassName("com.taco.bell", "Taco")
+    val fishTaco = ClassName("org.fish.taco", "Taco")
     val typeSpec = TypeSpec.classBuilder("Taco")
         .superclass(fishTaco)
-        .addSuperinterface(ParameterizedTypeName.get(ClassName.get(Comparable::class), javapoetTaco))
+        .addSuperinterface(ParameterizedTypeName.get(Comparable::class.asClassName(), javapoetTaco))
         .addSuperinterface(tacoBellTaco)
         .build()
     assertThat(toString(typeSpec)).isEqualTo("""
@@ -621,9 +623,9 @@ class TypeSpecTest {
   }
 
   @Test fun classImplementsInnerClass() {
-    val outer = ClassName.get(tacosPackage, "Outer")
+    val outer = ClassName(tacosPackage, "Outer")
     val inner = outer.nestedClass("Inner")
-    val callable = ClassName.get(Callable::class)
+    val callable = Callable::class.asClassName()
     val typeSpec = TypeSpec.classBuilder("Outer")
         .superclass(ParameterizedTypeName.get(callable,
             inner))
@@ -666,10 +668,10 @@ class TypeSpecTest {
   }
 
   @Test fun interfaceExtends() {
-    val taco = ClassName.get(tacosPackage, "Taco")
+    val taco = ClassName(tacosPackage, "Taco")
     val typeSpec = TypeSpec.interfaceBuilder("Taco")
         .addSuperinterface(Serializable::class)
-        .addSuperinterface(ParameterizedTypeName.get(ClassName.get(Comparable::class), taco))
+        .addSuperinterface(ParameterizedTypeName.get(Comparable::class.asClassName(), taco))
         .build()
     assertThat(toString(typeSpec)).isEqualTo("""
         |package com.squareup.tacos
@@ -683,15 +685,15 @@ class TypeSpecTest {
   }
 
   @Test fun nestedClasses() {
-    val taco = ClassName.get(tacosPackage, "Combo", "Taco")
-    val topping = ClassName.get(tacosPackage, "Combo", "Taco", "Topping")
-    val chips = ClassName.get(tacosPackage, "Combo", "Chips")
-    val sauce = ClassName.get(tacosPackage, "Combo", "Sauce")
+    val taco = ClassName(tacosPackage, "Combo", "Taco")
+    val topping = ClassName(tacosPackage, "Combo", "Taco", "Topping")
+    val chips = ClassName(tacosPackage, "Combo", "Chips")
+    val sauce = ClassName(tacosPackage, "Combo", "Sauce")
     val typeSpec = TypeSpec.classBuilder("Combo")
         .addProperty("taco", taco)
         .addProperty("chips", chips)
         .addType(TypeSpec.classBuilder(taco.simpleName())
-            .addProperty("toppings", ParameterizedTypeName.get(ClassName.get(List::class), topping))
+            .addProperty("toppings", ParameterizedTypeName.get(List::class.asClassName(), topping))
             .addProperty("sauce", sauce)
             .addType(TypeSpec.enumBuilder(topping.simpleName())
                 .addEnumConstant("SHREDDED_CHEESE")
@@ -830,13 +832,13 @@ class TypeSpecTest {
 
   @Test fun referencedAndDeclaredSimpleNamesConflict() {
     val internalTop = PropertySpec.builder(
-        "internalTop", ClassName.get(tacosPackage, "Top")).build()
+        "internalTop", ClassName(tacosPackage, "Top")).build()
     val internalBottom = PropertySpec.builder(
-        "internalBottom", ClassName.get(tacosPackage, "Top", "Middle", "Bottom")).build()
+        "internalBottom", ClassName(tacosPackage, "Top", "Middle", "Bottom")).build()
     val externalTop = PropertySpec.builder(
-        "externalTop", ClassName.get(donutsPackage, "Top")).build()
+        "externalTop", ClassName(donutsPackage, "Top")).build()
     val externalBottom = PropertySpec.builder(
-        "externalBottom", ClassName.get(donutsPackage, "Bottom")).build()
+        "externalBottom", ClassName(donutsPackage, "Bottom")).build()
     val top = TypeSpec.classBuilder("Top")
         .addProperty(internalTop)
         .addProperty(internalBottom)
@@ -894,9 +896,9 @@ class TypeSpecTest {
 
   @Test fun simpleNamesConflictInThisAndOtherPackage() {
     val internalOther = PropertySpec.builder(
-        "internalOther", ClassName.get(tacosPackage, "Other")).build()
+        "internalOther", ClassName(tacosPackage, "Other")).build()
     val externalOther = PropertySpec.builder(
-        "externalOther", ClassName.get(donutsPackage, "Other")).build()
+        "externalOther", ClassName(donutsPackage, "Other")).build()
     val gen = TypeSpec.classBuilder("Gen")
         .addProperty(internalOther)
         .addProperty(externalOther)
@@ -913,7 +915,7 @@ class TypeSpecTest {
   }
 
   @Test fun intersectionType() {
-    val typeVariable = TypeVariableName.get("T", Comparator::class, Serializable::class)
+    val typeVariable = TypeVariableName("T", Comparator::class, Serializable::class)
     val taco = TypeSpec.classBuilder("Taco")
         .addFun(FunSpec.builder("getComparator")
             .addTypeVariable(typeVariable)
@@ -996,10 +998,10 @@ class TypeSpecTest {
   }
 
   @Test fun annotationsInAnnotations() {
-    val beef = ClassName.get(tacosPackage, "Beef")
-    val chicken = ClassName.get(tacosPackage, "Chicken")
-    val option = ClassName.get(tacosPackage, "Option")
-    val mealDeal = ClassName.get(tacosPackage, "MealDeal")
+    val beef = ClassName(tacosPackage, "Beef")
+    val chicken = ClassName(tacosPackage, "Chicken")
+    val option = ClassName(tacosPackage, "Option")
+    val mealDeal = ClassName(tacosPackage, "MealDeal")
     val menu = TypeSpec.classBuilder("Menu")
         .addAnnotation(AnnotationSpec.builder(mealDeal)
             .addMember("price", "%L", 500)
@@ -1032,7 +1034,7 @@ class TypeSpecTest {
     val taqueria = TypeSpec.classBuilder("Taqueria")
         .addFun(FunSpec.builder("prepare")
             .addParameter("workers", Int::class)
-            .addParameter("jobs", ParameterizedTypeName.get(ARRAY, ClassName.get(Runnable::class)))
+            .addParameter("jobs", ParameterizedTypeName.get(ARRAY, Runnable::class.asClassName()))
             .varargs()
             .build())
         .build()
@@ -1349,7 +1351,7 @@ class TypeSpecTest {
   @Test fun constructorToString() {
     val constructor = FunSpec.constructorBuilder()
         .addModifiers(KModifier.PUBLIC)
-        .addParameter("taco", ClassName.get(tacosPackage, "Taco"))
+        .addParameter("taco", ClassName(tacosPackage, "Taco"))
         .addStatement("this.%N = %N", "taco", "taco")
         .build()
     assertThat(constructor.toString()).isEqualTo(""
@@ -1359,9 +1361,9 @@ class TypeSpecTest {
   }
 
   @Test fun parameterToString() {
-    val parameter = ParameterSpec.builder("taco", ClassName.get(tacosPackage, "Taco"))
+    val parameter = ParameterSpec.builder("taco", ClassName(tacosPackage, "Taco"))
         .addModifiers(KModifier.FINAL)
-        .addAnnotation(ClassName.get("javax.annotation", "Nullable"))
+        .addAnnotation(ClassName("javax.annotation", "Nullable"))
         .build()
     assertThat(parameter.toString())
         .isEqualTo("@javax.annotation.Nullable final taco: com.squareup.tacos.Taco")
@@ -1620,8 +1622,8 @@ class TypeSpecTest {
   @Test fun multipleSuperinterfaceAddition() {
     val taco = TypeSpec.classBuilder("Taco")
         .addSuperinterfaces(Arrays.asList(
-            TypeName.get(Serializable::class),
-            TypeName.get(EventListener::class)))
+            Serializable::class.asTypeName(),
+            EventListener::class.asTypeName()))
         .build()
     assertThat(toString(taco)).isEqualTo("""
         |package com.squareup.tacos
@@ -1637,8 +1639,8 @@ class TypeSpecTest {
   @Test fun multipleTypeVariableAddition() {
     val location = TypeSpec.classBuilder("Location")
         .addTypeVariables(Arrays.asList(
-            TypeVariableName.get("T"),
-            TypeVariableName.get("P", Number::class)))
+            TypeVariableName("T"),
+            TypeVariableName("P", Number::class)))
         .build()
     assertThat(toString(location)).isEqualTo("""
         |package com.squareup.tacos
@@ -1672,11 +1674,11 @@ class TypeSpecTest {
   @Test fun tryCatch() {
     val taco = TypeSpec.classBuilder("Taco")
         .addFun(FunSpec.builder("addTopping")
-            .addParameter("topping", ClassName.get("com.squareup.tacos", "Topping"))
+            .addParameter("topping", ClassName("com.squareup.tacos", "Topping"))
             .beginControlFlow("try")
             .addCode("/* do something tricky with the topping */\n")
             .nextControlFlow("catch (e: %T)",
-                ClassName.get("com.squareup.tacos", "IllegalToppingException"))
+                ClassName("com.squareup.tacos", "IllegalToppingException"))
             .endControlFlow()
             .build())
         .build()
@@ -1784,7 +1786,7 @@ class TypeSpecTest {
   }
 
   @Test fun typeFromTypeName() {
-    val typeName = TypeName.get(String::class)
+    val typeName = String::class.asTypeName()
     assertThat(CodeBlock.of("%T", typeName).toString()).isEqualTo("kotlin.String")
   }
 
@@ -1858,19 +1860,19 @@ class TypeSpecTest {
 
   @Test fun superClassOnlyValidForClasses() {
     try {
-      TypeSpec.annotationBuilder("A").superclass(ClassName.get(Any::class))
+      TypeSpec.annotationBuilder("A").superclass(Any::class.asClassName())
       fail()
     } catch (expected: IllegalStateException) {
     }
 
     try {
-      TypeSpec.enumBuilder("E").superclass(ClassName.get(Any::class))
+      TypeSpec.enumBuilder("E").superclass(Any::class.asClassName())
       fail()
     } catch (expected: IllegalStateException) {
     }
 
     try {
-      TypeSpec.interfaceBuilder("I").superclass(ClassName.get(Any::class))
+      TypeSpec.interfaceBuilder("I").superclass(Any::class.asClassName())
       fail()
     } catch (expected: IllegalStateException) {
     }
@@ -1880,8 +1882,8 @@ class TypeSpecTest {
   @Test fun invalidSuperClass() {
     try {
       TypeSpec.classBuilder("foo")
-          .superclass(ClassName.get(List::class))
-          .superclass(ClassName.get(Map::class))
+          .superclass(List::class)
+          .superclass(Map::class)
       fail()
     } catch (expected: IllegalStateException) {
     }
@@ -2067,7 +2069,7 @@ class TypeSpecTest {
   }
 
   @Test fun classNameFactories() {
-    val className = ClassName.get("com.example", "Example")
+    val className = ClassName("com.example", "Example")
     assertThat(TypeSpec.classBuilder(className).build().name).isEqualTo("Example")
     assertThat(TypeSpec.interfaceBuilder(className).build().name).isEqualTo("Example")
     assertThat(TypeSpec.enumBuilder(className).addEnumConstant("A").build().name).isEqualTo("Example")
@@ -2097,7 +2099,7 @@ class TypeSpecTest {
   }
 
   @Test fun objectClassWithSupertype() {
-    val superclass = ClassName.get("com.squareup.wire", "Message")
+    val superclass = ClassName("com.squareup.wire", "Message")
     val type = TypeSpec.objectBuilder("MyObject")
         .addModifiers(KModifier.PUBLIC)
         .superclass(superclass)
@@ -2222,7 +2224,7 @@ class TypeSpecTest {
   }
 
   @Test fun companionObjectSuper() {
-    val superclass = ClassName.get("com.squareup.wire", "Message")
+    val superclass = ClassName("com.squareup.wire", "Message")
     val companion = TypeSpec.companionObjectBuilder()
         .superclass(superclass)
         .addFun(FunSpec.builder("test")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-15286 makes this a bit annoying, currently. Alternatively we could make these top-level functions and not worry about Java interop as much...

Closes #36.