### PR TITLE
Make arrayComponent method internal.

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -228,7 +228,7 @@ abstract class TypeName internal constructor(
     }
 
     /** Returns the array component of this [TypeName], or null if it is not an array.  */
-    @JvmStatic fun TypeName.arrayComponent(): TypeName? {
+    internal fun TypeName.arrayComponent(): TypeName? {
       return if (this is ParameterizedTypeName && rawType == ARRAY)
         typeArguments.single() else
         null


### PR DESCRIPTION
Kotlin's arrays are normal parameterized types and thus don't need a special function. Currently this is only used for varargs support which needs re-done anyway.

Refs #110 