### PR TITLE
Make varargs a property of the parameter.

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
@@ -16,7 +16,6 @@
 package com.squareup.kotlinpoet
 
 import com.squareup.kotlinpoet.ClassName.Companion.asClassName
-import com.squareup.kotlinpoet.TypeName.Companion.arrayComponent
 import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import java.io.IOException
 import java.io.StringWriter
@@ -36,14 +35,10 @@ class ParameterSpec private constructor(builder: ParameterSpec.Builder) {
   val defaultValue = builder.defaultValue
 
   @Throws(IOException::class)
-  internal fun emit(codeWriter: CodeWriter, varargs: Boolean) {
+  internal fun emit(codeWriter: CodeWriter) {
     codeWriter.emitAnnotations(annotations, true)
     codeWriter.emitModifiers(modifiers)
-    if (varargs) {
-      codeWriter.emitCode("vararg %L: %T", name, type.arrayComponent())
-    } else {
-      codeWriter.emitCode("%L: %T", name, type)
-    }
+    codeWriter.emitCode("%L: %T", name, type)
     if (defaultValue != null) {
       codeWriter.emitCode(" = %[%L%]", defaultValue)
     }
@@ -61,8 +56,7 @@ class ParameterSpec private constructor(builder: ParameterSpec.Builder) {
   override fun toString(): String {
     val out = StringWriter()
     try {
-      val codeWriter = CodeWriter(out)
-      emit(codeWriter, false)
+      emit(CodeWriter(out))
       return out.toString()
     } catch (e: IOException) {
       throw AssertionError()

--- a/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -226,13 +226,6 @@ abstract class TypeName internal constructor(
         else -> throw IllegalArgumentException("unexpected type: " + type)
       }
     }
-
-    /** Returns the array component of this [TypeName], or null if it is not an array.  */
-    internal fun TypeName.arrayComponent(): TypeName? {
-      return if (this is ParameterizedTypeName && rawType == ARRAY)
-        typeArguments.single() else
-        null
-    }
   }
 }
 

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -105,7 +105,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
             if (property != null) {
               property.emit(codeWriter, setOf(PUBLIC), withInitializer = false, inline = true)
             } else {
-              param.emit(codeWriter, index == it.parameters.lastIndex && primaryConstructor.varargs)
+              param.emit(codeWriter)
             }
           }
           codeWriter.emit(")")

--- a/src/test/java/com/squareup/kotlinpoet/KotlinFileTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/KotlinFileTest.kt
@@ -17,6 +17,7 @@ package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
 import com.squareup.kotlinpoet.ClassName.Companion.asClassName
+import com.squareup.kotlinpoet.KModifier.VARARG
 import org.junit.Ignore
 import org.junit.Test
 import java.util.Collections
@@ -104,8 +105,7 @@ class KotlinFileTest {
                 .addStatement("%1T.out.println(%1T.nanoTime())", System::class)
                 .build())
             .addFun(FunSpec.constructorBuilder()
-                .addParameter("states", ParameterizedTypeName.get(ARRAY, Thread.State::class.asClassName()))
-                .varargs(true)
+                .addParameter("states", Thread.State::class.asClassName(), VARARG)
                 .build())
             .build())
         .addStaticImport(Thread.State.BLOCKED)

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.compile.CompilationRule
 import com.squareup.kotlinpoet.ClassName.Companion.asClassName
+import com.squareup.kotlinpoet.KModifier.VARARG
 import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
@@ -1034,8 +1035,7 @@ class TypeSpecTest {
     val taqueria = TypeSpec.classBuilder("Taqueria")
         .addFun(FunSpec.builder("prepare")
             .addParameter("workers", Int::class)
-            .addParameter("jobs", ParameterizedTypeName.get(ARRAY, Runnable::class.asClassName()))
-            .varargs()
+            .addParameter("jobs", Runnable::class.asClassName(), VARARG)
             .build())
         .build()
     assertThat(toString(taqueria)).isEqualTo("""
@@ -1046,6 +1046,28 @@ class TypeSpecTest {
         |
         |class Taqueria {
         |  fun prepare(workers: Int, vararg jobs: Runnable) {
+        |  }
+        |}
+        |""".trimMargin())
+  }
+
+  @Test fun varargsNotLast() {
+    val taqueria = TypeSpec.classBuilder("Taqueria")
+        .addFun(FunSpec.builder("prepare")
+            .addParameter("workers", Int::class)
+            .addParameter("jobs", Runnable::class.asClassName(), VARARG)
+            .addParameter("start", Boolean::class.asClassName())
+            .build())
+        .build()
+    assertThat(toString(taqueria)).isEqualTo("""
+        |package com.squareup.tacos
+        |
+        |import java.lang.Runnable
+        |import kotlin.Boolean
+        |import kotlin.Int
+        |
+        |class Taqueria {
+        |  fun prepare(workers: Int, vararg jobs: Runnable, start: Boolean) {
         |  }
         |}
         |""".trimMargin())


### PR DESCRIPTION
This removes the array specialization from the type and allows for multiple and different positions in the list.

Closes #110. 