### PR TITLE
primary constructors w/ modifiers and annotations

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -99,6 +99,26 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
         codeWriter.emitWhereBlock(typeVariables)
 
         primaryConstructor?.let {
+          var useKeyword = false
+          var emittedAnnotations = false
+
+          if (it.annotations.isNotEmpty()) {
+            codeWriter.emit(" ")
+            codeWriter.emitAnnotations(it.annotations, true)
+            useKeyword = true
+            emittedAnnotations = true
+          }
+
+          if (it.modifiers.isNotEmpty()) {
+            if (!emittedAnnotations) codeWriter.emit(" ")
+            codeWriter.emitModifiers(it.modifiers)
+            useKeyword = true
+          }
+
+          if (useKeyword) {
+            codeWriter.emit("constructor")
+          }
+
           codeWriter.emit("(")
           it.parameters.forEachIndexed { index, param ->
             if (index > 0) codeWriter.emit(",").emitWrappingSpace()

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.compile.CompilationRule
 import com.squareup.kotlinpoet.ClassName.Companion.asClassName
+import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.VARARG
 import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import org.junit.Assert.assertEquals
@@ -2288,6 +2289,80 @@ class TypeSpecTest {
         |
         |class Taco(val a: Int, val b: String)
         |""".trimMargin())
+  }
+
+  @Test fun annotatedConstructor() {
+    val injectAnnotation = ClassName("javax.inject", "Inject")
+    val taco = TypeSpec.classBuilder("Taco")
+        .primaryConstructor(FunSpec.constructorBuilder()
+            .addAnnotation(AnnotationSpec.builder(injectAnnotation).build())
+            .build())
+        .build()
+
+    assertThat(toString(taco)).isEqualTo("""
+    |package com.squareup.tacos
+    |
+    |import javax.inject.Inject
+    |
+    |class Taco @Inject constructor()
+    |
+    """.trimMargin())
+  }
+
+  @Test fun internalConstructor() {
+    val taco = TypeSpec.classBuilder("Taco")
+        .primaryConstructor(FunSpec.constructorBuilder()
+            .addModifiers(INTERNAL)
+            .build())
+        .build()
+
+    assertThat(toString(taco)).isEqualTo("""
+    |package com.squareup.tacos
+    |
+    |class Taco internal constructor()
+    |
+    """.trimMargin())
+  }
+
+  @Test fun annotatedInternalConstructor() {
+    val injectAnnotation = ClassName("javax.inject", "Inject")
+    val taco = TypeSpec.classBuilder("Taco")
+        .primaryConstructor(FunSpec.constructorBuilder()
+            .addAnnotation(AnnotationSpec.builder(injectAnnotation).build())
+            .addModifiers(INTERNAL)
+            .build())
+        .build()
+
+    assertThat(toString(taco)).isEqualTo("""
+    |package com.squareup.tacos
+    |
+    |import javax.inject.Inject
+    |
+    |class Taco @Inject internal constructor()
+    |
+    """.trimMargin())
+  }
+
+  @Test fun multipleAnnotationsInternalConstructor() {
+    val injectAnnotation = ClassName("javax.inject", "Inject")
+    val namedAnnotation = ClassName("javax.inject", "Named")
+    val taco = TypeSpec.classBuilder("Taco")
+        .primaryConstructor(FunSpec.constructorBuilder()
+            .addAnnotation(AnnotationSpec.builder(injectAnnotation).build())
+            .addAnnotation(AnnotationSpec.builder(namedAnnotation).build())
+            .addModifiers(INTERNAL)
+            .build())
+        .build()
+
+    assertThat(toString(taco)).isEqualTo("""
+    |package com.squareup.tacos
+    |
+    |import javax.inject.Inject
+    |import javax.inject.Named
+    |
+    |class Taco @Inject @Named internal constructor()
+    |
+    """.trimMargin())
   }
 
   companion object {


### PR DESCRIPTION
Adds the ability to emit primary constructors with modifiers and
annotations, using the `constructor` keyword.

Fixes #116