### PR TITLE
Remove a bunch of redundant type declarations.

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -32,7 +32,7 @@ import kotlin.reflect.KClass
 /** A generated annotation on a declaration.  */
 class AnnotationSpec private constructor(builder: AnnotationSpec.Builder) {
   val type: TypeName = builder.type
-  val members: Map<String, List<CodeBlock>> = builder.members.toImmutableMultimap()
+  val members = builder.members.toImmutableMultimap()
   val useSiteTarget: UseSiteTarget? = builder.useSiteTarget
 
   @Throws(IOException::class)

--- a/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -42,8 +42,8 @@ internal class CodeWriter @JvmOverloads constructor(
     private val memberImports: Set<String> = emptySet(),
     private val importedTypes: Map<String, ClassName> = emptyMap()) {
 
-  private val out: LineWrapper = LineWrapper(out, indent, 100)
-  private var indentLevel: Int = 0
+  private val out = LineWrapper(out, indent, 100)
+  private var indentLevel = 0
 
   private var kdoc = false
   private var comment = false

--- a/src/main/java/com/squareup/kotlinpoet/KotlinFile.kt
+++ b/src/main/java/com/squareup/kotlinpoet/KotlinFile.kt
@@ -50,11 +50,11 @@ private val NULL_APPENDABLE = object : Appendable {
  * aliases.
  */
 class KotlinFile private constructor(builder: KotlinFile.Builder) {
-  val fileComment: CodeBlock = builder.fileComment.build()
-  val packageName: String = builder.packageName
-  val fileName: String = builder.fileName
-  val members: List<Any> = builder.members.toList()
-  val skipJavaLangImports: Boolean = builder.skipJavaLangImports
+  val fileComment = builder.fileComment.build()
+  val packageName = builder.packageName
+  val fileName = builder.fileName
+  val members = builder.members.toList()
+  val skipJavaLangImports = builder.skipJavaLangImports
   private val memberImports = builder.memberImports.toImmutableSet()
   private val indent = builder.indent
 

--- a/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
@@ -28,10 +28,10 @@ import kotlin.reflect.KClass
 
 /** A generated parameter declaration.  */
 class ParameterSpec private constructor(builder: ParameterSpec.Builder) {
-  val name: String = builder.name
-  val annotations: List<AnnotationSpec> = builder.annotations.toImmutableList()
-  val modifiers: Set<KModifier> = builder.modifiers.toImmutableSet()
-  val type: TypeName = builder.type
+  val name = builder.name
+  val annotations = builder.annotations.toImmutableList()
+  val modifiers = builder.modifiers.toImmutableSet()
+  val type = builder.type
   val defaultValue = builder.defaultValue
 
   @Throws(IOException::class)

--- a/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
@@ -30,7 +30,7 @@ class ParameterizedTypeName internal constructor(
     annotations: List<AnnotationSpec> = emptyList())
   : TypeName(nullable, annotations) {
 
-  val typeArguments: List<TypeName> = typeArguments.toImmutableList()
+  val typeArguments = typeArguments.toImmutableList()
 
   init {
     require(typeArguments.isNotEmpty() || enclosingType != null) {

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -27,16 +27,16 @@ import kotlin.reflect.KClass
 
 /** A generated property declaration.  */
 class PropertySpec private constructor(builder: Builder) {
-  val mutable: Boolean = builder.mutable
-  val name: String = builder.name
-  val type: TypeName = builder.type
-  val kdoc: CodeBlock = builder.kdoc.build()
-  val annotations: List<AnnotationSpec> = builder.annotations.toImmutableList()
-  val modifiers: Set<KModifier> = builder.modifiers.toImmutableSet()
-  val initializer: CodeBlock? = builder.initializer
-  val delegated: Boolean = builder.delegated
-  val getter: FunSpec? = builder.getter
-  val setter: FunSpec? = builder.setter
+  val mutable = builder.mutable
+  val name = builder.name
+  val type = builder.type
+  val kdoc = builder.kdoc.build()
+  val annotations = builder.annotations.toImmutableList()
+  val modifiers = builder.modifiers.toImmutableSet()
+  val initializer = builder.initializer
+  val delegated = builder.delegated
+  val getter = builder.getter
+  val setter = builder.setter
 
   @Throws(IOException::class)
   internal fun emit(codeWriter: CodeWriter, implicitModifiers: Set<KModifier>,

--- a/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
@@ -24,9 +24,9 @@ import kotlin.reflect.KClass
 
 /** A generated typealias declaration */
 class TypeAliasSpec private constructor(builder: TypeAliasSpec.Builder) {
-  val name: String = builder.name
-  val type: TypeName = builder.type
-  val modifiers: Set<KModifier> = builder.modifiers.toImmutableSet()
+  val name = builder.name
+  val type = builder.type
+  val modifiers = builder.modifiers.toImmutableSet()
 
   @Throws(IOException::class)
   internal fun emit(codeWriter: CodeWriter) {

--- a/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -62,7 +62,7 @@ import kotlin.reflect.KClass
  */
 abstract class TypeName internal constructor(
     val nullable: Boolean, annotations: List<AnnotationSpec>) {
-  val annotations: List<AnnotationSpec> = annotations.toImmutableList()
+  val annotations = annotations.toImmutableList()
 
   /** Lazily-initialized toString of this type name.  */
   internal val cachedString: String by lazy {

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -30,20 +30,19 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
   val name = builder.name
   val anonymousTypeArguments = builder.anonymousTypeArguments
   val kdoc = builder.kdoc.build()
-  val annotations: List<AnnotationSpec> = builder.annotations.toImmutableList()
-  val modifiers: Set<KModifier> = builder.modifiers.toImmutableSet()
-  val typeVariables: List<TypeVariableName> = builder.typeVariables.toImmutableList()
-  val companionObject: TypeSpec? = builder.companionObject
+  val annotations = builder.annotations.toImmutableList()
+  val modifiers = builder.modifiers.toImmutableSet()
+  val typeVariables = builder.typeVariables.toImmutableList()
+  val companionObject = builder.companionObject
   val primaryConstructor = builder.primaryConstructor
   val superclass = builder.superclass
-  val superclassConstructorParameters: List<CodeBlock> =
-      builder.superclassConstructorParameters.toImmutableList()
-  val superinterfaces: List<TypeName> = builder.superinterfaces.toImmutableList()
-  val enumConstants: Map<String, TypeSpec> = builder.enumConstants.toImmutableMap()
-  val propertySpecs: List<PropertySpec> = builder.propertySpecs.toImmutableList()
+  val superclassConstructorParameters = builder.superclassConstructorParameters.toImmutableList()
+  val superinterfaces = builder.superinterfaces.toImmutableList()
+  val enumConstants = builder.enumConstants.toImmutableMap()
+  val propertySpecs = builder.propertySpecs.toImmutableList()
   val initializerBlock = builder.initializerBlock.build()
-  val funSpecs: List<FunSpec> = builder.funSpecs.toImmutableList()
-  val typeSpecs: List<TypeSpec> = builder.typeSpecs.toImmutableList()
+  val funSpecs = builder.funSpecs.toImmutableList()
+  val typeSpecs = builder.typeSpecs.toImmutableList()
 
   fun toBuilder(): Builder {
     val builder = Builder(kind, name, anonymousTypeArguments)

--- a/src/main/java/com/squareup/kotlinpoet/WildcardTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/WildcardTypeName.kt
@@ -27,8 +27,8 @@ class WildcardTypeName private constructor(
     nullable: Boolean = false,
     annotations: List<AnnotationSpec> = emptyList()) : TypeName(nullable, annotations) {
 
-  val upperBounds: List<TypeName> = upperBounds.toImmutableList()
-  val lowerBounds: List<TypeName> = lowerBounds.toImmutableList()
+  val upperBounds = upperBounds.toImmutableList()
+  val lowerBounds = lowerBounds.toImmutableList()
 
   init {
     require(this.upperBounds.size == 1) { "unexpected extends bounds: $upperBounds" }


### PR DESCRIPTION
We were received platform types here before, but now that we're fully Kotlin the specificity is no longer necessary.