### PR TITLE
Rename parameter names from clazz to `class`.

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/KotlinFile.kt
+++ b/src/main/java/com/squareup/kotlinpoet/KotlinFile.kt
@@ -221,11 +221,11 @@ class KotlinFile private constructor(builder: KotlinFile.Builder) {
         = addStaticImport(
         (constant as java.lang.Enum<*>).getDeclaringClass().asClassName(), constant.name)
 
-    fun addStaticImport(clazz: Class<*>, vararg names: String)
-        = addStaticImport(clazz.asClassName(), *names)
+    fun addStaticImport(`class`: Class<*>, vararg names: String)
+        = addStaticImport(`class`.asClassName(), *names)
 
-    fun addStaticImport(clazz: KClass<*>, vararg names: String)
-        = addStaticImport(clazz.asClassName(), *names)
+    fun addStaticImport(`class`: KClass<*>, vararg names: String)
+        = addStaticImport(`class`.asClassName(), *names)
 
     fun addStaticImport(className: ClassName, vararg names: String) = apply {
       check(names.isNotEmpty()) { "names array is empty" }

--- a/src/test/java/com/squareup/kotlinpoet/AbstractTypesTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/AbstractTypesTest.kt
@@ -34,9 +34,9 @@ abstract class AbstractTypesTest {
   protected abstract val elements: Elements
   protected abstract val types: Types
 
-  private fun getElement(clazz: Class<*>) = elements.getTypeElement(clazz.canonicalName)
+  private fun getElement(`class`: Class<*>) = elements.getTypeElement(`class`.canonicalName)
 
-  private fun getMirror(clazz: Class<*>) = getElement(clazz).asType()
+  private fun getMirror(`class`: Class<*>) = getElement(`class`).asType()
 
   @Test fun getBasicTypeMirror() {
     assertThat(getMirror(Any::class.java).asTypeName())

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -52,8 +52,8 @@ class FunSpecTest {
     types = compilation.types
   }
 
-  private fun getElement(clazz: Class<*>): TypeElement {
-    return elements.getTypeElement(clazz.canonicalName)
+  private fun getElement(`class`: Class<*>): TypeElement {
+    return elements.getTypeElement(`class`.canonicalName)
   }
 
   private fun findFirst(elements: Collection<ExecutableElement>, name: String): ExecutableElement {

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -46,12 +46,12 @@ class TypeSpecTest {
 
   @Rule @JvmField val compilation = CompilationRule()
 
-  private fun getElement(clazz: Class<*>): TypeElement {
-    return compilation.elements.getTypeElement(clazz.canonicalName)
+  private fun getElement(`class`: Class<*>): TypeElement {
+    return compilation.elements.getTypeElement(`class`.canonicalName)
   }
 
-  private fun getElement(clazz: KClass<*>): TypeElement {
-    return getElement(clazz.java)
+  private fun getElement(`class`: KClass<*>): TypeElement {
+    return getElement(`class`.java)
   }
 
   @Test fun basic() {


### PR DESCRIPTION
Closes #161.