### PR TITLE
Fix emitting primary constructor default params

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
@@ -38,6 +38,10 @@ class ParameterSpec private constructor(builder: ParameterSpec.Builder) {
     codeWriter.emitAnnotations(annotations, true)
     codeWriter.emitModifiers(modifiers)
     codeWriter.emitCode("%L: %T", name, type)
+    emitDefaultValue(codeWriter)
+  }
+
+  internal fun emitDefaultValue(codeWriter: CodeWriter) {
     if (defaultValue != null) {
       codeWriter.emitCode(" = %[%L%]", defaultValue)
     }

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -126,8 +126,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
             val property = constructorProperties[param.name]
             if (property != null) {
               property.emit(codeWriter, setOf(PUBLIC), withInitializer = false, inline = true)
-              val parameter = primaryConstructor.parameter(property.name)
-              parameter?.emitDefaultValue(codeWriter)
+              param.emitDefaultValue(codeWriter)
             } else {
               param.emit(codeWriter)
             }

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -126,6 +126,8 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
             val property = constructorProperties[param.name]
             if (property != null) {
               property.emit(codeWriter, setOf(PUBLIC), withInitializer = false, inline = true)
+              val parameter = primaryConstructor.parameter(property.name)
+              parameter?.emitDefaultValue(codeWriter)
             } else {
               param.emit(codeWriter)
             }

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -2433,6 +2433,34 @@ class TypeSpecTest {
     }
   }
 
+  @Test fun constructorWithDefaultParamValue() {
+    val type = TypeSpec.classBuilder("Taco")
+        .primaryConstructor(FunSpec.constructorBuilder()
+            .addParameter(ParameterSpec.builder("a", Int::class)
+                .defaultValue("1")
+                .build())
+            .addParameter(ParameterSpec.builder("b", String::class.asTypeName().asNullable())
+                .defaultValue("null")
+                .build())
+            .build())
+        .addProperty(PropertySpec.builder("a", Int::class)
+            .initializer("a")
+            .build())
+        .addProperty(PropertySpec.builder("b", String::class.asTypeName().asNullable())
+            .initializer("b")
+            .build())
+        .build()
+
+    assertThat(toString(type)).isEqualTo("""
+        |package com.squareup.tacos
+        |
+        |import kotlin.Int
+        |import kotlin.String
+        |
+        |class Taco(val a: Int = 1, val b: String? = null)
+        |""".trimMargin())
+  }
+
   companion object {
     private val donutsPackage = "com.squareup.donuts"
   }


### PR DESCRIPTION
Attempt to fix #133. 

Was initially looking to reassign `initializer` if a `defaultValue` is detected on corresponding `ParameterSpec`, but looks like `PropertySpec` prohibits that. Hope printing `defaultValue` directly makes sense.