### PR TITLE
Move extensions to top-level functions.

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.kotlinpoet
 
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import java.io.IOException
 import java.lang.reflect.Array
 import java.util.Arrays

--- a/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.kotlinpoet
 
-import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import java.io.IOException
 import java.lang.reflect.Type
 import javax.lang.model.element.Element

--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -15,13 +15,10 @@
  */
 package com.squareup.kotlinpoet
 
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import com.squareup.kotlinpoet.FunSpec.Companion.CONSTRUCTOR
 import com.squareup.kotlinpoet.FunSpec.Companion.GETTER
 import com.squareup.kotlinpoet.FunSpec.Companion.SETTER
 import com.squareup.kotlinpoet.KModifier.VARARG
-import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
-import com.squareup.kotlinpoet.TypeVariableName.Companion.asTypeVariableName
 import java.io.IOException
 import java.lang.reflect.Type
 import javax.lang.model.SourceVersion

--- a/src/main/java/com/squareup/kotlinpoet/KotlinFile.kt
+++ b/src/main/java/com/squareup/kotlinpoet/KotlinFile.kt
@@ -16,7 +16,6 @@
 package com.squareup.kotlinpoet
 
 import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget.FILE
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.IOException

--- a/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
@@ -15,8 +15,6 @@
  */
 package com.squareup.kotlinpoet
 
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
-import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import java.io.IOException
 import java.lang.reflect.Type
 import javax.lang.model.SourceVersion

--- a/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:JvmName("ParameterizedTypeNames")
+
 package com.squareup.kotlinpoet
 
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import java.io.IOException
 import java.lang.reflect.Modifier
 import java.lang.reflect.ParameterizedType
@@ -97,10 +98,6 @@ class ParameterizedTypeName internal constructor(
         null, rawType.asClassName(), typeArguments.map { it.asTypeName() })
 
     /** Returns a parameterized type equivalent to `type`.  */
-    @JvmStatic @JvmName("get")
-    fun ParameterizedType.asParameterizedTypeName() = get(this, mutableMapOf())
-
-    /** Returns a parameterized type equivalent to `type`.  */
     internal fun get(
         type: ParameterizedType,
         map: MutableMap<Type, TypeVariableName>): ParameterizedTypeName {
@@ -117,3 +114,7 @@ class ParameterizedTypeName internal constructor(
     }
   }
 }
+
+/** Returns a parameterized type equivalent to `type`.  */
+@JvmName("get")
+fun ParameterizedType.asParameterizedTypeName() = ParameterizedTypeName.get(this, mutableMapOf())

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -15,10 +15,8 @@
  */
 package com.squareup.kotlinpoet
 
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import com.squareup.kotlinpoet.FunSpec.Companion.GETTER
 import com.squareup.kotlinpoet.FunSpec.Companion.SETTER
-import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import java.io.IOException
 import java.lang.reflect.Type
 import javax.lang.model.SourceVersion

--- a/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.kotlinpoet
 
-import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import java.io.IOException
 import java.lang.reflect.Type
 import javax.lang.model.SourceVersion

--- a/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:JvmName("TypeNames")
+
 package com.squareup.kotlinpoet
 
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import java.io.IOException
 import java.lang.reflect.GenericArrayType
 import java.lang.reflect.ParameterizedType
@@ -51,7 +52,7 @@ import kotlin.reflect.KClass
  * --------------------------
  *
  * In an annotation processor you can get a type name instance for a type mirror by calling
- * [TypeName.get]. In reflection code, you can use [TypeName.get].
+ * [asTypeName]. In reflection code, you can use [asTypeName].
 
  * Defining new types
  * ------------------
@@ -123,10 +124,6 @@ abstract class TypeName internal constructor(
   }
 
   companion object {
-    /** Returns a [TypeName] equivalent to this [TypeMirror]. */
-    @JvmStatic @JvmName("get")
-    fun TypeMirror.asTypeName() = get(this, mutableMapOf())
-
     internal fun get(
         mirror: TypeMirror,
         typeVariables: MutableMap<TypeParameterElement, TypeVariableName>)
@@ -193,14 +190,6 @@ abstract class TypeName internal constructor(
       }, null)
     }
 
-    /** Returns a [TypeName] equivalent to this [KClass].  */
-    @JvmStatic @JvmName("get")
-    fun KClass<*>.asTypeName() = asClassName()
-
-    /** Returns a [TypeName] equivalent to this [Type].  */
-    @JvmStatic @JvmName("get")
-    fun Type.asTypeName() = get(this, mutableMapOf())
-
     internal fun get(type: Type, map: MutableMap<Type, TypeVariableName>): TypeName {
       when (type) {
         is Class<*> -> {
@@ -240,3 +229,15 @@ abstract class TypeName internal constructor(
 @JvmField val CHAR = ClassName("kotlin", "Char")
 @JvmField val FLOAT = ClassName("kotlin", "Float")
 @JvmField val DOUBLE = ClassName("kotlin", "Double")
+
+/** Returns a [TypeName] equivalent to this [TypeMirror]. */
+@JvmName("get")
+fun TypeMirror.asTypeName() = TypeName.get(this, mutableMapOf())
+
+/** Returns a [TypeName] equivalent to this [KClass].  */
+@JvmName("get")
+fun KClass<*>.asTypeName() = asClassName()
+
+/** Returns a [TypeName] equivalent to this [Type].  */
+@JvmName("get")
+fun Type.asTypeName() = TypeName.get(this, mutableMapOf())

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -15,9 +15,7 @@
  */
 package com.squareup.kotlinpoet
 
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import com.squareup.kotlinpoet.KModifier.PUBLIC
-import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import java.io.IOException
 import java.lang.reflect.Type
 import javax.lang.model.SourceVersion

--- a/src/main/java/com/squareup/kotlinpoet/TypeVariableName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeVariableName.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:JvmName("TypeVariableNames")
+
 package com.squareup.kotlinpoet
 
 import java.io.IOException
@@ -63,7 +65,7 @@ class TypeVariableName private constructor(
   }
 
   companion object {
-    private fun of(name: String, bounds: List<TypeName>): TypeVariableName {
+    internal fun of(name: String, bounds: List<TypeName>): TypeVariableName {
       // Strip java.lang.Object from bounds if it is present.
       return TypeVariableName(name, bounds.filter { it != ANY })
     }
@@ -89,11 +91,6 @@ class TypeVariableName private constructor(
     operator fun invoke(name: String, vararg bounds: Type): TypeVariableName {
       return TypeVariableName.of(name, bounds.map { it.asTypeName() })
     }
-
-    /** Returns type variable equivalent to `mirror`.  */
-    @JvmStatic @JvmName("get")
-    fun TypeVariable.asTypeVariableName()
-        = (asElement() as TypeParameterElement).asTypeVariableName()
 
     /**
      * Make a TypeVariableName for the given TypeMirror. This form is used internally to avoid
@@ -123,16 +120,8 @@ class TypeVariableName private constructor(
       return typeVariableName
     }
 
-    /** Returns type variable equivalent to `element`.  */
-    @JvmStatic @JvmName("get")
-    fun TypeParameterElement.asTypeVariableName(): TypeVariableName {
-      val name = simpleName.toString()
-      val boundsTypeNames = bounds.map { it.asTypeName() }
-      return TypeVariableName.of(name, boundsTypeNames)
-    }
-
     /** Returns type variable equivalent to `type`.  */
-    @JvmOverloads @JvmStatic internal fun get(
+    internal fun get(
         type: java.lang.reflect.TypeVariable<*>,
         map: MutableMap<Type, TypeVariableName> = mutableMapOf())
         : TypeVariableName {
@@ -150,4 +139,17 @@ class TypeVariableName private constructor(
       return result
     }
   }
+}
+
+/** Returns type variable equivalent to `mirror`.  */
+@JvmName("get")
+fun TypeVariable.asTypeVariableName()
+    = (asElement() as TypeParameterElement).asTypeVariableName()
+
+/** Returns type variable equivalent to `element`.  */
+@JvmName("get")
+fun TypeParameterElement.asTypeVariableName(): TypeVariableName {
+  val name = simpleName.toString()
+  val boundsTypeNames = bounds.map { it.asTypeName() }
+  return TypeVariableName.of(name, boundsTypeNames)
 }

--- a/src/main/java/com/squareup/kotlinpoet/WildcardTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/WildcardTypeName.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:JvmName("WildcardTypeNames")
+
 package com.squareup.kotlinpoet
 
 import java.io.IOException
@@ -90,9 +92,6 @@ class WildcardTypeName private constructor(
       return supertypeOf(lowerBound.asTypeName())
     }
 
-    @JvmStatic @JvmName("get")
-    fun javax.lang.model.type.WildcardType.asWildcardTypeName() = get(this, mutableMapOf())
-
     internal fun get(
         mirror: javax.lang.model.type.WildcardType,
         typeVariables: MutableMap<TypeParameterElement, TypeVariableName>)
@@ -108,9 +107,6 @@ class WildcardTypeName private constructor(
       }
     }
 
-    @JvmStatic @JvmName("get")
-    fun WildcardType.asWildcardTypeName() = get(this, mutableMapOf())
-
     internal fun get(
         wildcardName: WildcardType,
         map: MutableMap<Type, TypeVariableName>)
@@ -121,3 +117,10 @@ class WildcardTypeName private constructor(
     }
   }
 }
+
+@JvmName("get")
+fun javax.lang.model.type.WildcardType.asWildcardTypeName()
+    = WildcardTypeName.get(this, mutableMapOf())
+
+@JvmName("get")
+fun WildcardType.asWildcardTypeName() = WildcardTypeName.get(this, mutableMapOf())

--- a/src/test/java/com/squareup/kotlinpoet/AbstractTypesTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/AbstractTypesTest.kt
@@ -16,8 +16,6 @@
 package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
-import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import org.junit.Assert.fail
 import org.junit.Ignore
 import org.junit.Test

--- a/src/test/java/com/squareup/kotlinpoet/AnnotatedTypeNameTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/AnnotatedTypeNameTest.kt
@@ -15,8 +15,6 @@
  */
 package com.squareup.kotlinpoet
 
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
-import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals

--- a/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
@@ -17,7 +17,6 @@ package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.compile.CompilationRule
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
 import org.junit.Rule

--- a/src/test/java/com/squareup/kotlinpoet/CodeBlockTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/CodeBlockTest.kt
@@ -16,8 +16,6 @@
 package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
-import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import org.junit.Assert.fail
 import org.junit.Test
 

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -19,8 +19,6 @@ import com.google.common.collect.ImmutableSet
 import com.google.common.collect.Iterables.getOnlyElement
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.compile.CompilationRule
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
-import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule

--- a/src/test/java/com/squareup/kotlinpoet/KotlinFileTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/KotlinFileTest.kt
@@ -18,7 +18,6 @@ package com.squareup.kotlinpoet
 import com.google.common.truth.Truth.assertThat
 import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget.FILE
 import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget.SET
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import com.squareup.kotlinpoet.KModifier.VARARG
 import org.junit.Ignore
 import org.junit.Test

--- a/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -16,7 +16,6 @@
 package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import org.junit.Test
 import kotlin.test.fail
 

--- a/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -16,7 +16,6 @@
 package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import org.junit.Test
 
 class PropertySpecTest {

--- a/src/test/java/com/squareup/kotlinpoet/TypeNameTest.java
+++ b/src/test/java/com/squareup/kotlinpoet/TypeNameTest.java
@@ -64,10 +64,10 @@ public class TypeNameTest {
 
   @Test public void genericType() throws Exception {
     Method recursiveEnum = getClass().getDeclaredMethod("generic", Enum[].class);
-    TypeName.get(recursiveEnum.getReturnType());
-    TypeName.get(recursiveEnum.getGenericReturnType());
-    TypeName genericTypeName = TypeName.get(recursiveEnum.getParameterTypes()[0]);
-    TypeName.get(recursiveEnum.getGenericParameterTypes()[0]);
+    TypeNames.get(recursiveEnum.getReturnType());
+    TypeNames.get(recursiveEnum.getGenericReturnType());
+    TypeName genericTypeName = TypeNames.get(recursiveEnum.getParameterTypes()[0]);
+    TypeNames.get(recursiveEnum.getGenericParameterTypes()[0]);
 
     // Make sure the generic argument is present
     assertThat(genericTypeName.toString()).contains("Enum");
@@ -75,10 +75,10 @@ public class TypeNameTest {
 
   @Test public void innerClassInGenericType() throws Exception {
     Method genericStringInner = getClass().getDeclaredMethod("testGenericStringInner");
-    TypeName.get(genericStringInner.getReturnType());
-    TypeName genericTypeName = TypeName.get(genericStringInner.getGenericReturnType());
-    assertNotEquals(TypeName.get(genericStringInner.getGenericReturnType()),
-        TypeName.get(getClass().getDeclaredMethod("testGenericIntInner").getGenericReturnType()));
+    TypeNames.get(genericStringInner.getReturnType());
+    TypeName genericTypeName = TypeNames.get(genericStringInner.getGenericReturnType());
+    assertNotEquals(TypeNames.get(genericStringInner.getGenericReturnType()),
+        TypeNames.get(getClass().getDeclaredMethod("testGenericIntInner").getGenericReturnType()));
 
     // Make sure the generic argument is present
     assertThat(genericTypeName.toString()).isEqualTo(
@@ -87,10 +87,10 @@ public class TypeNameTest {
 
   @Test public void innerGenericInGenericType() throws Exception {
     Method genericStringInner = getClass().getDeclaredMethod("testGenericInnerLong");
-    TypeName.get(genericStringInner.getReturnType());
-    TypeName genericTypeName = TypeName.get(genericStringInner.getGenericReturnType());
-    assertNotEquals(TypeName.get(genericStringInner.getGenericReturnType()),
-        TypeName.get(getClass().getDeclaredMethod("testGenericInnerInt").getGenericReturnType()));
+    TypeNames.get(genericStringInner.getReturnType());
+    TypeName genericTypeName = TypeNames.get(genericStringInner.getGenericReturnType());
+    assertNotEquals(TypeNames.get(genericStringInner.getGenericReturnType()),
+        TypeNames.get(getClass().getDeclaredMethod("testGenericInnerInt").getGenericReturnType()));
 
     // Make sure the generic argument is present
     assertThat(genericTypeName.toString()).isEqualTo(
@@ -99,8 +99,8 @@ public class TypeNameTest {
 
   @Test public void innerStaticInGenericType() throws Exception {
     Method staticInGeneric = getClass().getDeclaredMethod("testNestedNonGeneric");
-    TypeName.get(staticInGeneric.getReturnType());
-    TypeName typeName = TypeName.get(staticInGeneric.getGenericReturnType());
+    TypeNames.get(staticInGeneric.getReturnType());
+    TypeName typeName = TypeNames.get(staticInGeneric.getGenericReturnType());
 
     // Make sure there are no generic arguments
     assertThat(typeName.toString()).isEqualTo(
@@ -108,22 +108,22 @@ public class TypeNameTest {
   }
 
   @Test public void equalsAndHashCodePrimitive() {
-    assertEqualsHashCodeAndToString(TypeNameKt.BOOLEAN, TypeNameKt.BOOLEAN);
-    assertEqualsHashCodeAndToString(TypeNameKt.BYTE, TypeNameKt.BYTE);
-    assertEqualsHashCodeAndToString(TypeNameKt.CHAR, TypeNameKt.CHAR);
-    assertEqualsHashCodeAndToString(TypeNameKt.DOUBLE, TypeNameKt.DOUBLE);
-    assertEqualsHashCodeAndToString(TypeNameKt.FLOAT, TypeNameKt.FLOAT);
-    assertEqualsHashCodeAndToString(TypeNameKt.INT, TypeNameKt.INT);
-    assertEqualsHashCodeAndToString(TypeNameKt.LONG, TypeNameKt.LONG);
-    assertEqualsHashCodeAndToString(TypeNameKt.SHORT, TypeNameKt.SHORT);
-    assertEqualsHashCodeAndToString(TypeNameKt.UNIT, TypeNameKt.UNIT);
+    assertEqualsHashCodeAndToString(TypeNames.BOOLEAN, TypeNames.BOOLEAN);
+    assertEqualsHashCodeAndToString(TypeNames.BYTE, TypeNames.BYTE);
+    assertEqualsHashCodeAndToString(TypeNames.CHAR, TypeNames.CHAR);
+    assertEqualsHashCodeAndToString(TypeNames.DOUBLE, TypeNames.DOUBLE);
+    assertEqualsHashCodeAndToString(TypeNames.FLOAT, TypeNames.FLOAT);
+    assertEqualsHashCodeAndToString(TypeNames.INT, TypeNames.INT);
+    assertEqualsHashCodeAndToString(TypeNames.LONG, TypeNames.LONG);
+    assertEqualsHashCodeAndToString(TypeNames.SHORT, TypeNames.SHORT);
+    assertEqualsHashCodeAndToString(TypeNames.UNIT, TypeNames.UNIT);
   }
 
   @Test public void equalsAndHashCodeClassName() {
-    assertEqualsHashCodeAndToString(ClassName.get(Object.class), ClassName.get(Object.class));
-    assertEqualsHashCodeAndToString(TypeName.get(Object.class), ClassName.get(Object.class));
+    assertEqualsHashCodeAndToString(ClassNames.get(Object.class), ClassNames.get(Object.class));
+    assertEqualsHashCodeAndToString(TypeNames.get(Object.class), ClassNames.get(Object.class));
     assertEqualsHashCodeAndToString(ClassName.bestGuess("java.lang.Object"),
-        ClassName.get(Object.class));
+        ClassNames.get(Object.class));
   }
 
   @Test public void equalsAndHashCodeParameterizedTypeName() {
@@ -131,7 +131,7 @@ public class TypeNameTest {
         ParameterizedTypeName.get(List.class, Object.class));
     assertEqualsHashCodeAndToString(ParameterizedTypeName.get(Set.class, UUID.class),
         ParameterizedTypeName.get(Set.class, UUID.class));
-    assertNotEquals(ClassName.get(List.class), ParameterizedTypeName.get(List.class,
+    assertNotEquals(ClassNames.get(List.class), ParameterizedTypeName.get(List.class,
         String.class));
   }
 

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -18,10 +18,8 @@ package com.squareup.kotlinpoet
 import com.google.common.collect.ImmutableMap
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.compile.CompilationRule
-import com.squareup.kotlinpoet.ClassName.Companion.asClassName
 import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.VARARG
-import com.squareup.kotlinpoet.TypeName.Companion.asTypeName
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
 import org.junit.Ignore


### PR DESCRIPTION
IntelliJ IDEA cannot currently discover them when embedded inside an companion object. Plus this makes better imports in the consuming code.

Refs #157. 