### PR TITLE
Fix inconsistent FunSpec validation

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -478,7 +478,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     }
 
     fun addFunctions(funSpecs: Iterable<FunSpec>) = apply {
-      this.funSpecs += funSpecs
+      funSpecs.forEach { addFun(it) }
     }
 
     fun addFun(funSpec: FunSpec) = apply {
@@ -486,7 +486,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
         requireExactlyOneOf(funSpec.modifiers, KModifier.ABSTRACT)
         requireExactlyOneOf(funSpec.modifiers, KModifier.PUBLIC, KModifier.PRIVATE)
       } else if (kind == Kind.ANNOTATION) {
-        check(funSpec.modifiers == kind.implicitFunctionModifiers) {
+        require(funSpec.modifiers == kind.implicitFunctionModifiers) {
           "$kind $name.${funSpec.name} requires modifiers ${kind.implicitFunctionModifiers}"
         }
       }

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -18,6 +18,7 @@ package com.squareup.kotlinpoet
 import com.google.common.collect.ImmutableMap
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.compile.CompilationRule
+import com.squareup.kotlinpoet.KModifier.ABSTRACT
 import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.VARARG
 import org.junit.Assert.assertEquals
@@ -2483,6 +2484,50 @@ class TypeSpecTest {
       fail()
     } catch (expected: IllegalArgumentException) {
       assertThat(expected).hasMessage("not a valid name: when")
+    }
+  }
+
+  @Test fun internalFunForbiddenInInterface() {
+    val type = TypeSpec.interfaceBuilder("ITaco")
+
+    try {
+      type.addFun(FunSpec.builder("eat")
+          .addModifiers(ABSTRACT, INTERNAL)
+          .build())
+      fail()
+    } catch (expected: IllegalArgumentException) {
+      assertThat(expected).hasMessage("modifiers [ABSTRACT, INTERNAL] must contain one of [PUBLIC, PRIVATE]")
+    }
+
+    try {
+      type.addFunctions(listOf(FunSpec.builder("eat")
+          .addModifiers(ABSTRACT, INTERNAL)
+          .build()))
+      fail()
+    } catch (expected: IllegalArgumentException) {
+      assertThat(expected).hasMessage("modifiers [ABSTRACT, INTERNAL] must contain one of [PUBLIC, PRIVATE]")
+    }
+  }
+
+  @Test fun internalFunForbiddenInAnnotation() {
+    val type = TypeSpec.annotationBuilder("Taco")
+
+    try {
+      type.addFun(FunSpec.builder("eat")
+          .addModifiers(INTERNAL)
+          .build())
+      fail()
+    } catch (expected: IllegalArgumentException) {
+      assertThat(expected).hasMessage("ANNOTATION Taco.eat requires modifiers [PUBLIC, ABSTRACT]")
+    }
+
+    try {
+      type.addFunctions(listOf(FunSpec.builder("eat")
+          .addModifiers(INTERNAL)
+          .build()))
+      fail()
+    } catch (expected: IllegalArgumentException) {
+      assertThat(expected).hasMessage("ANNOTATION Taco.eat requires modifiers [PUBLIC, ABSTRACT]")
     }
   }
 


### PR DESCRIPTION
Checks were only performed in `addFun()` and not in `addFunctions()`.