### PR TITLE
Rename addFun() to addFunction() in KotlinFile

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/KotlinFile.kt
+++ b/src/main/java/com/squareup/kotlinpoet/KotlinFile.kt
@@ -214,7 +214,7 @@ class KotlinFile private constructor(builder: KotlinFile.Builder) {
       members += typeSpec
     }
 
-    fun addFun(funSpec: FunSpec) = apply {
+    fun addFunction(funSpec: FunSpec) = apply {
       require(!funSpec.isConstructor && !funSpec.isAccessor) {
         "cannot add ${funSpec.name} to file $fileName"
       }

--- a/src/test/java/com/squareup/kotlinpoet/KotlinFileTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/KotlinFileTest.kt
@@ -139,7 +139,7 @@ class KotlinFileTest {
   @Test fun importTopLevel() {
     val source = KotlinFile.builder("com.squareup.tacos", "Taco")
         .addStaticImport("com.squareup.tacos.internal", "INGREDIENTS", "wrap")
-        .addFun(FunSpec.builder("prepareTacos")
+        .addFunction(FunSpec.builder("prepareTacos")
             .returns(ParameterizedTypeName.get(List::class.asClassName(),
                 ClassName("com.squareup.tacos", "Taco")))
             .addCode("return wrap(INGREDIENTS)\n")

--- a/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -24,12 +24,12 @@ class KotlinPoetTest {
 
   @Test fun topLevelMembersRetainOrder() {
     val source = KotlinFile.builder(tacosPackage, "Taco")
-        .addFun(FunSpec.builder("a").addModifiers(KModifier.PUBLIC).build())
+        .addFunction(FunSpec.builder("a").addModifiers(KModifier.PUBLIC).build())
         .addType(TypeSpec.classBuilder("B").build())
         .addProperty(PropertySpec.builder("c", String::class, KModifier.PUBLIC)
             .initializer("%S", "C")
             .build())
-        .addFun(FunSpec.builder("d").build())
+        .addFunction(FunSpec.builder("d").build())
         .addType(TypeSpec.classBuilder("E").build())
         .addProperty(PropertySpec.builder("f", String::class, KModifier.PUBLIC)
             .initializer("%S", "F")
@@ -59,7 +59,7 @@ class KotlinPoetTest {
   @Test fun noTopLevelConstructor() {
     try {
       KotlinFile.builder(tacosPackage, "Taco")
-          .addFun(FunSpec.constructorBuilder().build())
+          .addFunction(FunSpec.constructorBuilder().build())
       fail()
     } catch (expected: IllegalArgumentException) {
     }
@@ -291,7 +291,7 @@ class KotlinPoetTest {
 
   @Test fun extensionFunction() {
     val source = KotlinFile.builder(tacosPackage, "Taco")
-        .addFun(FunSpec.builder("shrink")
+        .addFunction(FunSpec.builder("shrink")
             .returns(String::class)
             .receiver(String::class)
             .addStatement("return substring(0, length - 1)")
@@ -412,7 +412,7 @@ class KotlinPoetTest {
 
   @Test fun basicExpressionBody() {
     val source = KotlinFile.builder(tacosPackage, "Taco")
-        .addFun(FunSpec.builder("addA")
+        .addFunction(FunSpec.builder("addA")
             .addParameter("s", String::class)
             .returns(String::class)
             .addStatement("return s + %S", "a")


### PR DESCRIPTION
I accidentally broke README with #195 by replacing `addFun` with `addFunction`, as `KotlinFile` also had a method with this name. Since we renamed it in `FunSpec`, I think it makes sense to rename it in `KotlinFile` for consistency.