### PR TITLE
Tests and fixes for crossplatform code

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
@@ -405,3 +405,5 @@ fun Collection<CodeBlock>.joinToCode(separator: CharSequence = ", ", prefix: Cha
   val placeholders = Array(blocks.size, { "%L" })
   return CodeBlock.of(placeholders.joinToString(separator, prefix, suffix), *blocks)
 }
+
+internal fun CodeBlock?.isNullOrEmpty() = this == null || isEmpty()

--- a/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
@@ -405,5 +405,3 @@ fun Collection<CodeBlock>.joinToCode(separator: CharSequence = ", ", prefix: Cha
   val placeholders = Array(blocks.size, { "%L" })
   return CodeBlock.of(placeholders.joinToString(separator, prefix, suffix), *blocks)
 }
-
-internal fun CodeBlock?.isNullOrEmpty() = this == null || isEmpty()

--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -17,6 +17,7 @@ package com.squareup.kotlinpoet
 
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
 import com.squareup.kotlinpoet.KModifier.EXTERNAL
+import com.squareup.kotlinpoet.KModifier.HEADER
 import com.squareup.kotlinpoet.KModifier.VARARG
 import java.lang.reflect.Type
 import javax.lang.model.element.ExecutableElement
@@ -73,7 +74,8 @@ class FunSpec private constructor(builder: Builder) {
     codeWriter.emitWhereBlock(typeVariables)
 
     val isEmptyConstructor = isConstructor && body.isEmpty()
-    if (ABSTRACT in modifiers || EXTERNAL in modifiers || isEmptyConstructor) {
+    if (ABSTRACT in modifiers || EXTERNAL in modifiers || HEADER in implicitModifiers ||
+        isEmptyConstructor) {
       codeWriter.emit("\n")
       return
     }

--- a/src/main/java/com/squareup/kotlinpoet/KModifier.kt
+++ b/src/main/java/com/squareup/kotlinpoet/KModifier.kt
@@ -22,6 +22,10 @@ enum class KModifier(
   // Modifier order defined here:
   // https://github.com/yole/kotlin-style-guide/issues/3.
 
+  // Multiplatform modules.
+  HEADER("header", Target.CLASS),
+  IMPL("impl", Target.CLASS, Target.FUNCTION, Target.PROPERTY),
+
   // Access.
   PUBLIC("public", Target.PROPERTY),
   PROTECTED("protected", Target.PROPERTY),
@@ -62,11 +66,7 @@ enum class KModifier(
   // Type modifiers.
   IN("in", Target.VARIANCE_ANNOTATION),
   OUT("out", Target.VARIANCE_ANNOTATION),
-  VARARG("vararg", Target.PARAMETER),
-
-  // Multiplatform modules.
-  HEADER("header", Target.CLASS),
-  IMPL("impl", Target.CLASS, Target.FUNCTION, Target.PROPERTY);
+  VARARG("vararg", Target.PARAMETER);
 
   internal enum class Target {
     CLASS,

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -286,6 +286,11 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
         setOf(KModifier.PUBLIC),
         setOf(KModifier.PUBLIC)),
 
+    HEADER_CLASS(
+        "class",
+        setOf(KModifier.PUBLIC, KModifier.HEADER),
+        setOf(KModifier.PUBLIC, KModifier.HEADER)),
+
     OBJECT(
         "object",
         setOf(KModifier.PUBLIC),
@@ -381,7 +386,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     }
 
     fun primaryConstructor(primaryConstructor: FunSpec?) = apply {
-      check(kind.isOneOf(Kind.CLASS, Kind.ENUM, Kind.ANNOTATION)) {
+      check(kind.isOneOf(Kind.CLASS, Kind.HEADER_CLASS, Kind.ENUM, Kind.ANNOTATION)) {
         "$kind can't have initializer blocks"
       }
       if (primaryConstructor != null) {
@@ -399,7 +404,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     }
 
     private fun ensureCanHaveSuperclass() {
-      check(kind.isOneOf(Kind.CLASS, Kind.OBJECT, Kind.COMPANION)) {
+      check(kind.isOneOf(Kind.CLASS, Kind.HEADER_CLASS, Kind.OBJECT, Kind.COMPANION)) {
         "only classes can have super classes, not $kind"
       }
     }
@@ -443,10 +448,18 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     }
 
     fun addProperties(propertySpecs: Iterable<PropertySpec>) = apply {
-      this.propertySpecs += propertySpecs
+      propertySpecs.map(this::addProperty)
     }
 
     fun addProperty(propertySpec: PropertySpec) = apply {
+      if (kind == Kind.HEADER_CLASS) {
+        require(propertySpec.initializer.isNullOrEmpty()) {
+          "properties in header classes can't have initializers"
+        }
+        require(propertySpec.getter == null && propertySpec.setter == null) {
+          "properties in header classes can't have getters and setters"
+        }
+      }
       propertySpecs += propertySpec
     }
 
@@ -475,12 +488,16 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     }
 
     fun addFunction(funSpec: FunSpec) = apply {
-      if (kind == Kind.INTERFACE) {
-        requireNoneOf(funSpec.modifiers, KModifier.INTERNAL, KModifier.PROTECTED)
-        requireNoneOrOneOf(funSpec.modifiers, KModifier.ABSTRACT, KModifier.PRIVATE)
-      } else if (kind == Kind.ANNOTATION) {
-        require(funSpec.modifiers == kind.implicitFunctionModifiers) {
+      when (kind) {
+        Kind.INTERFACE -> {
+          requireNoneOf(funSpec.modifiers, KModifier.INTERNAL, KModifier.PROTECTED)
+          requireNoneOrOneOf(funSpec.modifiers, KModifier.ABSTRACT, KModifier.PRIVATE)
+        }
+        Kind.ANNOTATION -> require(funSpec.modifiers == kind.implicitFunctionModifiers) {
           "$kind $name.${funSpec.name} requires modifiers ${kind.implicitFunctionModifiers}"
+        }
+        Kind.HEADER_CLASS -> require(funSpec.body.isEmpty()) {
+          "functions in header classes can't have bodies"
         }
       }
       funSpecs += funSpec
@@ -526,6 +543,12 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     @JvmStatic fun classBuilder(name: String) = Builder(Kind.CLASS, name, null)
 
     @JvmStatic fun classBuilder(className: ClassName) = classBuilder(className.simpleName())
+
+    @JvmStatic fun headerClassBuilder(name: String) = Builder(Kind.HEADER_CLASS, name, null).apply {
+      addModifiers(KModifier.HEADER)
+    }
+
+    @JvmStatic fun headerClassBuilder(className: ClassName) = headerClassBuilder(className.simpleName())
 
     @JvmStatic fun objectBuilder(name: String) = Builder(Kind.OBJECT, name, null)
 

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -453,7 +453,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
 
     fun addProperty(propertySpec: PropertySpec) = apply {
       if (kind == Kind.HEADER_CLASS) {
-        require(propertySpec.initializer.isNullOrEmpty()) {
+        require(propertySpec.initializer == null) {
           "properties in header classes can't have initializers"
         }
         require(propertySpec.getter == null && propertySpec.setter == null) {

--- a/src/test/java/com/squareup/kotlinpoet/CrossplatformTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/CrossplatformTest.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.kotlinpoet
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicReference
+
+class CrossplatformTest {
+
+  @Test fun crossplatform() {
+    val headerTypeParam = TypeVariableName("V")
+    val headerType = "AtomicRef"
+    val headerSpec = TypeSpec.headerClassBuilder(headerType)
+        .addTypeVariable(headerTypeParam)
+        .addModifiers(KModifier.INTERNAL)
+        .primaryConstructor(FunSpec.constructorBuilder()
+            .addParameter("value", headerTypeParam)
+            .build())
+        .addProperty(PropertySpec.builder("value", headerTypeParam).build())
+        .addFunction(FunSpec.builder("get")
+            .returns(headerTypeParam)
+            .build())
+        .addFunction(FunSpec.builder("set")
+            .addParameter("value", headerTypeParam)
+            .build())
+        .addFunction(FunSpec.builder("getAndSet")
+            .addParameter("value", headerTypeParam)
+            .returns(headerTypeParam)
+            .build())
+        .addFunction(FunSpec.builder("compareAndSet")
+            .addParameter("expect", headerTypeParam)
+            .addParameter("update", headerTypeParam)
+            .returns(Boolean::class)
+            .build())
+        .build()
+    val implName = ParameterizedTypeName.get(AtomicReference::class.asTypeName(), headerTypeParam)
+    val implSpec = TypeAliasSpec.builder(headerType, implName)
+        .addTypeVariable(headerTypeParam)
+        .addModifiers(KModifier.IMPL)
+        .build()
+    val fileSpec = FileSpec.builder("", "Test")
+        .addType(headerSpec)
+        .addTypeAlias(implSpec)
+        .build()
+
+    assertThat(fileSpec.toString()).isEqualTo("""
+      |import java.util.concurrent.atomic.AtomicReference
+      |import kotlin.Boolean
+      |
+      |header internal class AtomicRef<V>(value: V) {
+      |  val value: V
+      |
+      |  fun get(): V
+      |
+      |  fun set(value: V)
+      |
+      |  fun getAndSet(value: V): V
+      |
+      |  fun compareAndSet(expect: V, update: V): Boolean
+      |}
+      |
+      |impl typealias AtomicRef<V> = AtomicReference<V>
+      |""".trimMargin())
+  }
+
+  @Test fun headerWithSecondaryConstructors() {
+    val headerSpec = TypeSpec.headerClassBuilder("IoException")
+        .addModifiers(KModifier.OPEN)
+        .superclass(Exception::class)
+        .addFunction(FunSpec.constructorBuilder().build())
+        .addFunction(FunSpec.constructorBuilder()
+            .addParameter("message", String::class)
+            .build())
+        .build()
+    val fileSpec = FileSpec.builder("", "Test")
+        .addType(headerSpec)
+        .build()
+
+    assertThat(fileSpec.toString()).isEqualTo("""
+      |import java.lang.Exception
+      |import kotlin.String
+      |
+      |header open class IoException : Exception {
+      |  constructor()
+      |
+      |  constructor(message: String)
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun initBlockInHeaderForbidden() {
+    assertThrows<IllegalStateException> {
+      TypeSpec.headerClassBuilder("AtomicRef")
+          .addInitializerBlock(CodeBlock.of("println()"))
+    }.hasMessage("HEADER_CLASS can't have initializer blocks")
+  }
+
+  @Test fun headerFunctionBodyForbidden() {
+    assertThrows<IllegalArgumentException> {
+      TypeSpec.headerClassBuilder("AtomicRef")
+          .addFunction(FunSpec.builder("print")
+              .addStatement("println()")
+              .build())
+    }.hasMessage("functions in header classes can't have bodies")
+  }
+
+  @Test fun headerPropertyInitializerForbidden() {
+    assertThrows<IllegalArgumentException> {
+      TypeSpec.headerClassBuilder("AtomicRef")
+          .addProperty(PropertySpec.builder("a", Boolean::class)
+              .initializer("true")
+              .build())
+    }.hasMessage("properties in header classes can't have initializers")
+  }
+
+  @Test fun headerPropertyGetterForbidden() {
+    assertThrows<IllegalArgumentException> {
+      TypeSpec.headerClassBuilder("AtomicRef")
+          .addProperty(PropertySpec.builder("a", Boolean::class)
+              .getter(FunSpec.getterBuilder()
+                  .addStatement("return true")
+                  .build())
+              .build())
+    }.hasMessage("properties in header classes can't have getters and setters")
+  }
+
+  @Test fun headerPropertySetterForbidden() {
+    assertThrows<IllegalArgumentException> {
+      TypeSpec.headerClassBuilder("AtomicRef")
+          .addProperty(PropertySpec.builder("a", Boolean::class)
+              .setter(FunSpec.setterBuilder()
+                  .addParameter("value", Boolean::class)
+                  .addStatement("field = true")
+                  .build())
+              .build())
+    }.hasMessage("properties in header classes can't have getters and setters")
+  }
+}


### PR DESCRIPTION
Some changes are necessary to make this work, since in a default class all methods have to have a body. Solution implemented here:

- Add `KModifier.HEADER` to the list of implicit function modifiers in `Kind.CLASS`
- Mark `TypeSpec` and all `FunSpec`s with `KModifier.HEADER`

An alternative solution would be:

- Introduce a new `Kind` called `HEADER_CLASS` with `KModifier.ABSTRACT` as implicit function modifier
- Mark `FunSpec`s with `KModifier.ABSTRACT`