### PR TITLE
Escape name in FunSpec which is also a Kotlin keyword

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -110,7 +110,7 @@ class FunSpec private constructor(builder: Builder) {
       if (receiverType != null) {
         codeWriter.emitCode("%T.", receiverType)
       }
-      codeWriter.emitCode("%L", name)
+      codeWriter.emitCode("%L", escapeIfKeyword(name))
     }
 
     parameters.emit(codeWriter) { param ->
@@ -179,12 +179,6 @@ class FunSpec private constructor(builder: Builder) {
     internal val delegateConstructorArguments = mutableListOf<CodeBlock>()
     internal val exceptions = mutableSetOf<TypeName>()
     internal val body = CodeBlock.builder()
-
-    init {
-      require(name.isConstructor || name.isAccessor || name.isName) {
-        "not a valid name: $name"
-      }
-    }
 
     fun addKdoc(format: String, vararg args: Any) = apply {
       kdoc.add(format, *args)

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -341,7 +341,7 @@ class FunSpecTest {
     assertThat(funSpec.toString()).isEqualTo("""
     |fun `if`() {
     |}
-	|""".trimMargin())
+    |""".trimMargin())
   }
 
   private fun whenMock(any: Any?) = Mockito.`when`(any)

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -334,5 +334,15 @@ class FunSpecTest {
     assertThat(a.hashCode()).isEqualTo(b.hashCode())
   }
 
+  @Test fun escapeKeywordInFunctionName() {
+    val funSpec = FunSpec.builder("if")
+	    .build()
+
+    assertThat(funSpec.toString()).isEqualTo("""
+    |fun `if`() {
+    |}
+	|""".trimMargin())
+  }
+
   private fun whenMock(any: Any?) = Mockito.`when`(any)
 }

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -336,7 +336,7 @@ class FunSpecTest {
 
   @Test fun escapeKeywordInFunctionName() {
     val funSpec = FunSpec.builder("if")
-	    .build()
+        .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
       |fun `if`() {

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -339,9 +339,9 @@ class FunSpecTest {
 	    .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
-    |fun `if`() {
-    |}
-    |""".trimMargin())
+      |fun `if`() {
+      |}
+      |""".trimMargin())
   }
 
   private fun whenMock(any: Any?) = Mockito.`when`(any)


### PR DESCRIPTION
Fixes #262.