### PR TITLE
Move Java reflect specific extensions into a separate package

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.jvm.asClassName
 import java.lang.reflect.Array
 import java.util.Objects
 import javax.lang.model.element.AnnotationMirror

--- a/src/main/java/com/squareup/kotlinpoet/ClassName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ClassName.kt
@@ -17,12 +17,6 @@
 
 package com.squareup.kotlinpoet
 
-import javax.lang.model.element.Element
-import javax.lang.model.element.ElementKind
-import javax.lang.model.element.NestingKind.MEMBER
-import javax.lang.model.element.NestingKind.TOP_LEVEL
-import javax.lang.model.element.PackageElement
-import javax.lang.model.element.TypeElement
 import kotlin.reflect.KClass
 
 /** A fully-qualified class name for top-level and member classes.  */
@@ -157,54 +151,7 @@ class ClassName internal constructor(
 }
 
 @JvmName("get")
-fun Class<*>.asClassName(): ClassName {
-  require(!isPrimitive) { "primitive types cannot be represented as a ClassName" }
-  require(Void.TYPE != this) { "'void' type cannot be represented as a ClassName" }
-  require(!isArray) { "array types cannot be represented as a ClassName" }
-  val names = mutableListOf<String>()
-  var c = this
-  while (true) {
-    names += c.simpleName
-    val enclosing = c.enclosingClass ?: break
-    c = enclosing
-  }
-  // Avoid unreliable Class.getPackage(). https://github.com/square/javapoet/issues/295
-  val lastDot = c.name.lastIndexOf('.')
-  if (lastDot != -1) names += c.name.substring(0, lastDot)
-  names.reverse()
-  return ClassName(names)
-}
-
-@JvmName("get")
 fun KClass<*>.asClassName(): ClassName {
   qualifiedName?.let { return ClassName.bestGuess(it) }
   throw IllegalArgumentException("$this cannot be represented as a ClassName")
-}
-
-/** Returns the class name for `element`.  */
-@JvmName("get")
-fun TypeElement.asClassName(): ClassName {
-  fun isClassOrInterface(e: Element) = e.kind.isClass || e.kind.isInterface
-
-  fun getPackage(type: Element): PackageElement {
-    var t = type
-    while (t.kind != ElementKind.PACKAGE) {
-      t = t.enclosingElement
-    }
-    return t as PackageElement
-  }
-
-  val names = mutableListOf<String>()
-  var e: Element = this
-  while (isClassOrInterface(e)) {
-    val eType = e as TypeElement
-    require(eType.nestingKind.isOneOf(TOP_LEVEL, MEMBER)) {
-      "unexpected type testing"
-    }
-    names += eType.simpleName.toString()
-    e = eType.enclosingElement
-  }
-  names += getPackage(this).qualifiedName.toString()
-  names.reverse()
-  return ClassName(names)
 }

--- a/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
@@ -17,6 +17,7 @@
 
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.jvm.asTypeName
 import java.lang.reflect.Type
 import javax.lang.model.element.Element
 import javax.lang.model.type.TypeMirror

--- a/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -16,6 +16,7 @@
 package com.squareup.kotlinpoet
 
 import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget.FILE
+import com.squareup.kotlinpoet.jvm.asClassName
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.IOException

--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -20,6 +20,9 @@ import com.squareup.kotlinpoet.KModifier.EXPECT
 import com.squareup.kotlinpoet.KModifier.EXTERNAL
 import com.squareup.kotlinpoet.KModifier.INLINE
 import com.squareup.kotlinpoet.KModifier.VARARG
+import com.squareup.kotlinpoet.jvm.asClassName
+import com.squareup.kotlinpoet.jvm.asTypeName
+import com.squareup.kotlinpoet.jvm.asTypeVariableName
 import java.lang.reflect.Type
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.Modifier

--- a/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
@@ -15,6 +15,8 @@
  */
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.jvm.asClassName
+import com.squareup.kotlinpoet.jvm.asTypeName
 import java.lang.reflect.Type
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.Modifier

--- a/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:JvmName("ParameterizedTypeNames")
-
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.jvm.asClassName
+import com.squareup.kotlinpoet.jvm.asTypeName
 import java.lang.reflect.Modifier
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
@@ -109,7 +109,3 @@ class ParameterizedTypeName internal constructor(
     }
   }
 }
-
-/** Returns a parameterized type equivalent to `type`.  */
-@JvmName("get")
-fun ParameterizedType.asParameterizedTypeName() = ParameterizedTypeName.get(this, mutableMapOf())

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -17,6 +17,8 @@ package com.squareup.kotlinpoet
 
 import com.squareup.kotlinpoet.FunSpec.Companion.GETTER
 import com.squareup.kotlinpoet.FunSpec.Companion.SETTER
+import com.squareup.kotlinpoet.jvm.asClassName
+import com.squareup.kotlinpoet.jvm.asTypeName
 import java.lang.reflect.Type
 import kotlin.reflect.KClass
 

--- a/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
@@ -19,6 +19,7 @@ import com.squareup.kotlinpoet.KModifier.ACTUAL
 import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.KModifier.PUBLIC
+import com.squareup.kotlinpoet.jvm.asTypeName
 import java.lang.reflect.Type
 import kotlin.reflect.KClass
 

--- a/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -17,6 +17,7 @@
 
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.jvm.asClassName
 import java.lang.reflect.GenericArrayType
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
@@ -217,14 +218,6 @@ abstract class TypeName internal constructor(
 @JvmField val FLOAT = ClassName("kotlin", "Float")
 @JvmField val DOUBLE = ClassName("kotlin", "Double")
 
-/** Returns a [TypeName] equivalent to this [TypeMirror]. */
-@JvmName("get")
-fun TypeMirror.asTypeName() = TypeName.get(this, mutableMapOf())
-
 /** Returns a [TypeName] equivalent to this [KClass].  */
 @JvmName("get")
 fun KClass<*>.asTypeName() = asClassName()
-
-/** Returns a [TypeName] equivalent to this [Type].  */
-@JvmName("get")
-fun Type.asTypeName() = TypeName.get(this, mutableMapOf())

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -16,6 +16,8 @@
 package com.squareup.kotlinpoet
 
 import com.squareup.kotlinpoet.KModifier.PUBLIC
+import com.squareup.kotlinpoet.jvm.asClassName
+import com.squareup.kotlinpoet.jvm.asTypeName
 import java.lang.reflect.Type
 import kotlin.reflect.KClass
 

--- a/src/main/java/com/squareup/kotlinpoet/TypeVariableName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeVariableName.kt
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:JvmName("TypeVariableNames")
-
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.jvm.asTypeName
 import java.lang.reflect.Type
 import java.util.Collections
 import javax.lang.model.element.TypeParameterElement
@@ -131,17 +130,4 @@ class TypeVariableName private constructor(
       return result
     }
   }
-}
-
-/** Returns type variable equivalent to `mirror`.  */
-@JvmName("get")
-fun TypeVariable.asTypeVariableName()
-    = (asElement() as TypeParameterElement).asTypeVariableName()
-
-/** Returns type variable equivalent to `element`.  */
-@JvmName("get")
-fun TypeParameterElement.asTypeVariableName(): TypeVariableName {
-  val name = simpleName.toString()
-  val boundsTypeNames = bounds.map { it.asTypeName() }
-  return TypeVariableName.of(name, boundsTypeNames, variance = null)
 }

--- a/src/main/java/com/squareup/kotlinpoet/WildcardTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/WildcardTypeName.kt
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:JvmName("WildcardTypeNames")
-
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.jvm.asTypeName
 import java.lang.reflect.Type
 import java.lang.reflect.WildcardType
 import javax.lang.model.element.TypeParameterElement
@@ -105,10 +104,3 @@ class WildcardTypeName private constructor(
     }
   }
 }
-
-@JvmName("get")
-fun javax.lang.model.type.WildcardType.asWildcardTypeName()
-    = WildcardTypeName.get(this, mutableMapOf())
-
-@JvmName("get")
-fun WildcardType.asWildcardTypeName() = WildcardTypeName.get(this, mutableMapOf())

--- a/src/main/java/com/squareup/kotlinpoet/jvm/ParameterizedTypeNames.kt
+++ b/src/main/java/com/squareup/kotlinpoet/jvm/ParameterizedTypeNames.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:JvmName("ParameterizedTypeNames")
+
+package com.squareup.kotlinpoet.jvm
+
+import com.squareup.kotlinpoet.ParameterizedTypeName
+import java.lang.reflect.ParameterizedType
+
+/** Returns a parameterized type equivalent to `type`.  */
+@JvmName("get")
+fun ParameterizedType.asParameterizedTypeName() = ParameterizedTypeName.get(this, mutableMapOf())

--- a/src/main/java/com/squareup/kotlinpoet/jvm/TypeNames.kt
+++ b/src/main/java/com/squareup/kotlinpoet/jvm/TypeNames.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:JvmName("TypeNamesJvm")
+
+package com.squareup.kotlinpoet.jvm
+
+import com.squareup.kotlinpoet.TypeName
+import java.lang.reflect.Type
+import javax.lang.model.type.TypeMirror
+
+/** Returns a [TypeName] equivalent to this [TypeMirror]. */
+@JvmName("get")
+fun TypeMirror.asTypeName() = TypeName.get(this, mutableMapOf())
+
+/** Returns a [TypeName] equivalent to this [Type].  */
+@JvmName("get")
+fun Type.asTypeName() = TypeName.get(this, mutableMapOf())

--- a/src/main/java/com/squareup/kotlinpoet/jvm/TypeVariableNames.kt
+++ b/src/main/java/com/squareup/kotlinpoet/jvm/TypeVariableNames.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:JvmName("TypeVariableNames")
+
+package com.squareup.kotlinpoet.jvm
+
+import com.squareup.kotlinpoet.TypeVariableName
+import com.squareup.kotlinpoet.asTypeName
+import javax.lang.model.element.TypeParameterElement
+import javax.lang.model.type.TypeVariable
+
+/** Returns type variable equivalent to `mirror`.  */
+@JvmName("get")
+fun TypeVariable.asTypeVariableName()
+    = (asElement() as TypeParameterElement).asTypeVariableName()
+
+/** Returns type variable equivalent to `element`.  */
+@JvmName("get")
+fun TypeParameterElement.asTypeVariableName(): TypeVariableName {
+  val name = simpleName.toString()
+  val boundsTypeNames = bounds.map { it.asTypeName() }
+  return TypeVariableName.of(name, boundsTypeNames, variance = null)
+}

--- a/src/main/java/com/squareup/kotlinpoet/jvm/WildcardTypeNames.kt
+++ b/src/main/java/com/squareup/kotlinpoet/jvm/WildcardTypeNames.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:JvmName("WildcardTypeNames")
+
+package com.squareup.kotlinpoet.jvm
+
+import com.squareup.kotlinpoet.WildcardTypeName
+import java.lang.reflect.WildcardType
+
+@JvmName("get")
+fun javax.lang.model.type.WildcardType.asWildcardTypeName()
+    = WildcardTypeName.get(this, mutableMapOf())
+
+@JvmName("get")
+fun WildcardType.asWildcardTypeName() = WildcardTypeName.get(this, mutableMapOf())

--- a/src/test/java/com/squareup/kotlinpoet/AbstractTypesTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/AbstractTypesTest.kt
@@ -16,6 +16,8 @@
 package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
+import com.squareup.kotlinpoet.jvm.asClassName
+import com.squareup.kotlinpoet.jvm.asTypeName
 import org.junit.Assert.fail
 import org.junit.Ignore
 import org.junit.Test

--- a/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
@@ -17,6 +17,7 @@ package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.compile.CompilationRule
+import com.squareup.kotlinpoet.jvm.asClassName
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test

--- a/src/test/java/com/squareup/kotlinpoet/jvm/TypeNameTest.java
+++ b/src/test/java/com/squareup/kotlinpoet/jvm/TypeNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Square, Inc.
+ * Copyright (C) 2017 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.squareup.kotlinpoet;
+package com.squareup.kotlinpoet.jvm;
 
+import com.squareup.kotlinpoet.ClassName;
+import com.squareup.kotlinpoet.ParameterizedTypeName;
+import com.squareup.kotlinpoet.TypeName;
+import com.squareup.kotlinpoet.TypeNames;
+import com.squareup.kotlinpoet.TypeVariableName;
+import com.squareup.kotlinpoet.WildcardTypeName;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.Comparator;
@@ -64,10 +70,10 @@ public class TypeNameTest {
 
   @Test public void genericType() throws Exception {
     Method recursiveEnum = getClass().getDeclaredMethod("generic", Enum[].class);
-    TypeNames.get(recursiveEnum.getReturnType());
-    TypeNames.get(recursiveEnum.getGenericReturnType());
-    TypeName genericTypeName = TypeNames.get(recursiveEnum.getParameterTypes()[0]);
-    TypeNames.get(recursiveEnum.getGenericParameterTypes()[0]);
+    TypeNamesJvm.get(recursiveEnum.getReturnType());
+    TypeNamesJvm.get(recursiveEnum.getGenericReturnType());
+    TypeName genericTypeName = TypeNamesJvm.get(recursiveEnum.getParameterTypes()[0]);
+    TypeNamesJvm.get(recursiveEnum.getGenericParameterTypes()[0]);
 
     // Make sure the generic argument is present
     assertThat(genericTypeName.toString()).contains("Enum");
@@ -75,10 +81,10 @@ public class TypeNameTest {
 
   @Test public void innerClassInGenericType() throws Exception {
     Method genericStringInner = getClass().getDeclaredMethod("testGenericStringInner");
-    TypeNames.get(genericStringInner.getReturnType());
-    TypeName genericTypeName = TypeNames.get(genericStringInner.getGenericReturnType());
-    assertNotEquals(TypeNames.get(genericStringInner.getGenericReturnType()),
-        TypeNames.get(getClass().getDeclaredMethod("testGenericIntInner").getGenericReturnType()));
+    TypeNamesJvm.get(genericStringInner.getReturnType());
+    TypeName genericTypeName = TypeNamesJvm.get(genericStringInner.getGenericReturnType());
+    assertNotEquals(TypeNamesJvm.get(genericStringInner.getGenericReturnType()),
+        TypeNamesJvm.get(getClass().getDeclaredMethod("testGenericIntInner").getGenericReturnType()));
 
     // Make sure the generic argument is present
     assertThat(genericTypeName.toString()).isEqualTo(
@@ -87,10 +93,10 @@ public class TypeNameTest {
 
   @Test public void innerGenericInGenericType() throws Exception {
     Method genericStringInner = getClass().getDeclaredMethod("testGenericInnerLong");
-    TypeNames.get(genericStringInner.getReturnType());
-    TypeName genericTypeName = TypeNames.get(genericStringInner.getGenericReturnType());
-    assertNotEquals(TypeNames.get(genericStringInner.getGenericReturnType()),
-        TypeNames.get(getClass().getDeclaredMethod("testGenericInnerInt").getGenericReturnType()));
+    TypeNamesJvm.get(genericStringInner.getReturnType());
+    TypeName genericTypeName = TypeNamesJvm.get(genericStringInner.getGenericReturnType());
+    assertNotEquals(TypeNamesJvm.get(genericStringInner.getGenericReturnType()),
+        TypeNamesJvm.get(getClass().getDeclaredMethod("testGenericInnerInt").getGenericReturnType()));
 
     // Make sure the generic argument is present
     assertThat(genericTypeName.toString()).isEqualTo(
@@ -99,8 +105,8 @@ public class TypeNameTest {
 
   @Test public void innerStaticInGenericType() throws Exception {
     Method staticInGeneric = getClass().getDeclaredMethod("testNestedNonGeneric");
-    TypeNames.get(staticInGeneric.getReturnType());
-    TypeName typeName = TypeNames.get(staticInGeneric.getGenericReturnType());
+    TypeNamesJvm.get(staticInGeneric.getReturnType());
+    TypeName typeName = TypeNamesJvm.get(staticInGeneric.getGenericReturnType());
 
     // Make sure there are no generic arguments
     assertThat(typeName.toString()).isEqualTo(
@@ -120,10 +126,10 @@ public class TypeNameTest {
   }
 
   @Test public void equalsAndHashCodeClassName() {
-    assertEqualsHashCodeAndToString(ClassNames.get(Object.class), ClassNames.get(Object.class));
-    assertEqualsHashCodeAndToString(TypeNames.get(Object.class), ClassNames.get(Object.class));
+    assertEqualsHashCodeAndToString(ClassNamesJvm.get(Object.class), ClassNamesJvm.get(Object.class));
+    assertEqualsHashCodeAndToString(TypeNamesJvm.get(Object.class), ClassNamesJvm.get(Object.class));
     assertEqualsHashCodeAndToString(ClassName.bestGuess("java.lang.Object"),
-        ClassNames.get(Object.class));
+        ClassNamesJvm.get(Object.class));
   }
 
   @Test public void equalsAndHashCodeParameterizedTypeName() {
@@ -131,7 +137,7 @@ public class TypeNameTest {
         ParameterizedTypeName.get(List.class, Object.class));
     assertEqualsHashCodeAndToString(ParameterizedTypeName.get(Set.class, UUID.class),
         ParameterizedTypeName.get(Set.class, UUID.class));
-    assertNotEquals(ClassNames.get(List.class), ParameterizedTypeName.get(List.class,
+    assertNotEquals(ClassNamesJvm.get(List.class), ParameterizedTypeName.get(List.class,
         String.class));
   }
 


### PR DESCRIPTION
That's the first part of #157. Next step is to move all factory methods relying on Java reflection classes and transform them into extension functions on companions. The "jvm" package is temporary, there'll be a new module in future.