### PR TITLE
Set com.squareup.kotlinpoet as automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,17 @@
           </descriptors>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.squareup.kotlinpoet</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>      
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Claim `com.squareup.kotlinpoet` as Automatic-Module-Name in the JAR manifest.

See http://branchandbound.net/blog/java/2017/12/automatic-module-name/ for details and background.

Analog to https://github.com/square/javapoet/commit/03f3a276b2f330c59e549e73542217c6028caed6