### PR TITLE
Support PropertySpecs as CodeBlock literals

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -301,6 +301,7 @@ internal class CodeWriter constructor(
     when (o) {
       is TypeSpec -> o.emit(this, null)
       is AnnotationSpec -> o.emit(this, inline = true, asParameter = true)
+      is PropertySpec -> o.emit(this, emptySet())
       is CodeBlock -> emitCode(o)
       else -> emit(o.toString())
     }

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -2677,6 +2677,36 @@ class TypeSpecTest {
       |""".trimMargin())
   }
 
+  @Test fun literalPropertySpec() {
+    val taco = TypeSpec.classBuilder("Taco")
+        .addFunction(FunSpec.builder("shell")
+            .addCode(CodeBlock.of("%L", PropertySpec.builder("taco1", String::class.asTypeName())
+                .initializer("%S", "Taco!").build()))
+            .addCode(CodeBlock.of("%L",
+                PropertySpec.builder("taco2", String::class.asTypeName().asNullable())
+                    .initializer("null")
+                    .build()))
+            .addCode(CodeBlock.of("%L",
+                PropertySpec.builder("taco3", String::class.asTypeName(), KModifier.LATEINIT)
+                    .mutable(true)
+                    .build()))
+            .build())
+        .build()
+    assertThat(toString(taco)).isEqualTo("""
+        |package com.squareup.tacos
+        |
+        |import kotlin.String
+        |
+        |class Taco {
+        |  fun shell() {
+        |    val taco1: String = "Taco!"
+        |    val taco2: String? = null
+        |    lateinit var taco3: String
+        |  }
+        |}
+        |""".trimMargin())
+  }
+
   companion object {
     private val donutsPackage = "com.squareup.donuts"
   }

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -2698,11 +2698,11 @@ class TypeSpecTest {
         |import kotlin.String
         |
         |class Taco {
-        |  fun shell() {
-        |    val taco1: String = "Taco!"
-        |    val taco2: String? = null
-        |    lateinit var taco3: String
-        |  }
+        |    fun shell() {
+        |        val taco1: String = "Taco!"
+        |        val taco2: String? = null
+        |        lateinit var taco3: String
+        |    }
         |}
         |""".trimMargin())
   }


### PR DESCRIPTION
This adds support for PropertySpecs as CodeBlock literals. I wasn't totally sure where to best test this, so let me know if you're prefer it go somewhere else!