### PR TITLE
Allow for adding an initializer block inside a companion object

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -489,7 +489,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
         = addProperty(name, type.asTypeName(), *modifiers)
 
     fun addInitializerBlock(block: CodeBlock) = apply {
-      check(kind.isOneOf(Kind.CLASS, Kind.OBJECT, Kind.ENUM)) {
+      check(kind.isOneOf(Kind.CLASS, Kind.OBJECT, Kind.ENUM, Kind.COMPANION)) {
         "$kind can't have initializer blocks"
       }
       initializerBlock.add("init {\n")

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -2268,6 +2268,39 @@ class TypeSpecTest {
         |""".trimMargin())
   }
 
+  @Test fun companionObjectWithInitializer() {
+    val companion = TypeSpec.companionObjectBuilder()
+            .addProperty(PropertySpec.builder("tacos", Int::class)
+                    .mutable(true)
+                    .initializer("%L", 24)
+                    .build())
+            .addInitializerBlock(CodeBlock.builder()
+                    .addStatement("tacos = %L", 42)
+                    .build())
+            .build()
+
+    val type = TypeSpec.classBuilder("MyClass")
+            .addModifiers(KModifier.PUBLIC)
+            .companionObject(companion)
+            .build()
+
+    assertThat(toString(type)).isEqualTo("""
+        |package com.squareup.tacos
+        |
+        |import kotlin.Int
+        |
+        |class MyClass {
+        |    companion object {
+        |        var tacos: Int = 24
+        |
+        |        init {
+        |            tacos = 42
+        |        }
+        |    }
+        |}
+        |""".trimMargin())
+  }
+
   @Test fun companionObjectWithName() {
     val companion = TypeSpec.companionObjectBuilder("Factory")
         .addFunction(FunSpec.builder("tacos").build())


### PR DESCRIPTION
Kotlin allows for putting `init {}` blocks inside a `companion object` but KotlinPoet didin't support that. For example generating code like:
```
class Foo {
    companion object {
        var bar: String = "a"
        
        init {
            bar = "b"
        }
    }
}
```

was impossible before. This change enables `init` blocks inside a `companion object`.