### PR TITLE
Improve FunSpecTest for invalid modifiers.

### DIFF
--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -73,7 +73,7 @@ class FunSpecTest {
     }
 
     companion object {
-      @JvmStatic fun staticMethod() {
+      @JvmStatic open fun staticMethod() {
       }
     }
   }
@@ -132,7 +132,7 @@ class FunSpecTest {
 
     assertThrows<IllegalArgumentException> {
       FunSpec.overriding(findFirst(methods, "staticMethod"))
-    }.hasMessageThat().isEqualTo("cannot override method with modifiers: [public, static, final]")
+    }.hasMessageThat().isEqualTo("cannot override method with modifiers: [public, static]")
   }
 
   @Test fun nullableParam() {


### PR DESCRIPTION
The test should fail because it's static, not because it's final.

doesn't matter much, though.