### PR TITLE
Replace deprecated 'kotlin-stdlib-jre7' dependency with 'kotlin-stdlib-jdk7'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-jre7</artifactId>
+      <artifactId>kotlin-stdlib-jdk7</artifactId>
       <version>${kotlin.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
http://kotlinlang.org/docs/reference/whatsnew12.html#kotlin-standard-library-artifacts-and-split-packages