### PR TITLE
Enums are able to have companion objects.

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -197,7 +197,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
         firstMember = false
         if (i.hasNext()) {
           codeWriter.emit(",\n")
-        } else if (propertySpecs.isNotEmpty() || funSpecs.isNotEmpty() || typeSpecs.isNotEmpty()) {
+        } else if (propertySpecs.isNotEmpty() || funSpecs.isNotEmpty() || typeSpecs.isNotEmpty() || companionObject != null) {
           codeWriter.emit(";\n")
         } else {
           codeWriter.emit("\n")
@@ -441,7 +441,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     }
 
     fun companionObject(companionObject: TypeSpec) = apply {
-      check(kind.isSimpleClass || kind is Interface) {
+      check(kind.isSimpleClass || kind is Interface || kind.isEnum) {
         "$kind can't have a companion object"
       }
       require(companionObject.kind is Object && COMPANION in companionObject.kind.modifiers) {

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -2403,7 +2403,7 @@ class TypeSpecTest {
         |""".trimMargin())
   }
 
-  @Test fun companionObjectOnEnumNotAlowed() {
+  @Test fun companionObjectOnEnum() {
     val companion = TypeSpec.companionObjectBuilder()
         .addFunction(FunSpec.builder("test")
             .addModifiers(KModifier.PUBLIC)
@@ -2411,11 +2411,25 @@ class TypeSpecTest {
         .build()
 
     val enumBuilder = TypeSpec.enumBuilder("MyEnum")
+        .addEnumConstant("FOO")
+        .addEnumConstant("BAR")
         .addModifiers(KModifier.PUBLIC)
+        .companionObject(companion)
+        .build()
 
-    assertThrows<IllegalStateException> {
-      enumBuilder.companionObject(companion)
-    }
+    assertThat(toString(enumBuilder)).isEqualTo("""
+        |package com.squareup.tacos
+        |
+        |enum class MyEnum {
+        |    FOO,
+        |
+        |    BAR;
+        |    companion object {
+        |        fun test() {
+        |        }
+        |    }
+        |}
+        |""".trimMargin())
   }
 
   @Test fun companionObjectOnObjectNotAlowed() {


### PR DESCRIPTION
I noticed that Enums were not allowed to have companion objects when using KotlinPoet but was sure that I saw some enums with companion objects in my day-to-day. Sure enough, you are allowed to have companion objects in Enums!

Let me know if there's anything I should change.

Best,

David (Disney-ABC Spring 2018 Intern)