### PR TITLE
Escape (class/property/funtion/variable) names automatically if they contain space, hyphen, or other symbols

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -112,7 +112,7 @@ class FunSpec private constructor(builder: Builder) {
           codeWriter.emitCode("%T.", receiverType)
         }
       }
-      codeWriter.emitCode("%L", escapeIfKeyword(name))
+      codeWriter.emitCode("%L", escapeIfNecessary(name))
     }
 
     parameters.emit(codeWriter) { param ->

--- a/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
@@ -32,7 +32,7 @@ class ParameterSpec private constructor(builder: ParameterSpec.Builder) {
   internal fun emit(codeWriter: CodeWriter, includeType: Boolean = true) {
     codeWriter.emitAnnotations(annotations, true)
     codeWriter.emitModifiers(modifiers)
-    if (name.isNotEmpty()) codeWriter.emitCode("%L", escapeIfKeyword(name))
+    if (name.isNotEmpty()) codeWriter.emitCode("%L", escapeIfNecessary(name))
     if (name.isNotEmpty() && includeType) codeWriter.emit(": ")
     if (includeType) codeWriter.emitCode("%T", type)
     emitDefaultValue(codeWriter)

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -54,7 +54,7 @@ class PropertySpec private constructor(builder: Builder) {
         codeWriter.emitCode("%T.", receiverType)
       }
     }
-    codeWriter.emitCode("%L: %T", name, type)
+    codeWriter.emitCode("%L: %T", escapeIfNecessary(name), type)
     if (withInitializer && initializer != null) {
       if (delegated) {
         codeWriter.emit(" by ")

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -121,7 +121,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
             if (isNestedExternal) setOf(PUBLIC, EXTERNAL) else setOf(PUBLIC))
         codeWriter.emit(kind.declarationKeyword)
         if (name != null) {
-          codeWriter.emitCode(" %L", name)
+          codeWriter.emitCode(" %L", escapeIfNecessary(name))
         }
         codeWriter.emitTypeVariables(typeVariables)
         codeWriter.emitWhereBlock(typeVariables)

--- a/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -132,6 +132,10 @@ internal fun escapeKeywords(canonicalName: String)
 
 internal fun escapeIfKeyword(value: String) = if (value.isKeyword) "`$value`" else value
 
+internal fun escapeIfNotJavaIdentifier(value: String) = if (!Character.isJavaIdentifierStart(value.first()) || value.drop(1).any { !Character.isJavaIdentifierPart(it) }) "`$value`" else value
+
+internal fun escapeIfNecessary(value: String) = escapeIfKeyword(escapeIfNotJavaIdentifier(value))
+
 internal val String.isIdentifier get() = IDENTIFIER_REGEX.matches(this)
 
 internal val String.isKeyword get() = KEYWORDS.contains(this)

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -350,7 +350,7 @@ class FunSpecTest {
 
   @Test fun escapePunctuationInFunctionName() {
     val funSpec = FunSpec.builder("with-hyphen")
-            .build()
+        .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
       |fun `with-hyphen`() {

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -347,4 +347,14 @@ class FunSpecTest {
       |}
       |""".trimMargin())
   }
+
+  @Test fun escapePunctuationInFunctionName() {
+    val funSpec = FunSpec.builder("with-hyphen")
+            .build()
+
+    assertThat(funSpec.toString()).isEqualTo("""
+      |fun `with-hyphen`() {
+      |}
+      |""".trimMargin())
+  }
 }

--- a/src/test/java/com/squareup/kotlinpoet/ParameterSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/ParameterSpecTest.kt
@@ -44,7 +44,7 @@ class ParameterSpecTest {
 
   @Test fun escapePunctuationInParameterName() {
     val parameterSpec = ParameterSpec.builder("with-hyphen", String::class)
-            .build()
+        .build()
     assertThat(parameterSpec.toString()).isEqualTo("`with-hyphen`: kotlin.String")
   }
 }

--- a/src/test/java/com/squareup/kotlinpoet/ParameterSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/ParameterSpecTest.kt
@@ -41,4 +41,10 @@ class ParameterSpecTest {
         .build()
     assertThat(parameterSpec.toString()).isEqualTo("`if`: kotlin.String")
   }
+
+  @Test fun escapePunctuationInParameterName() {
+    val parameterSpec = ParameterSpec.builder("with-hyphen", String::class)
+            .build()
+    assertThat(parameterSpec.toString()).isEqualTo("`with-hyphen`: kotlin.String")
+  }
 }

--- a/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -98,7 +98,7 @@ class PropertySpecTest {
 
   @Test fun escapePunctuationInPropertyName() {
     val prop = PropertySpec.builder("with-hyphen", String::class)
-            .build()
+        .build()
 
     assertThat(prop.toString()).isEqualTo("""
       |val `with-hyphen`: kotlin.String

--- a/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -95,4 +95,13 @@ class PropertySpecTest {
       |external val foo: kotlin.String
       |""".trimMargin())
   }
+
+  @Test fun escapePunctuationInPropertyName() {
+    val prop = PropertySpec.builder("with-hyphen", String::class)
+            .build()
+
+    assertThat(prop.toString()).isEqualTo("""
+      |val `with-hyphen`: kotlin.String
+      |""".trimMargin())
+  }
 }

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -3110,6 +3110,13 @@ class TypeSpecTest {
       |""".trimMargin())
   }
 
+  @Test fun escapePunctuationInTypeName() {
+    assertThat(TypeSpec.classBuilder("With-Hyphen").build().toString()).isEqualTo("""
+      |class `With-Hyphen`
+      |
+      """.trimMargin())
+  }
+
   companion object {
     private val donutsPackage = "com.squareup.donuts"
   }

--- a/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
@@ -88,6 +88,13 @@ class UtilTest {
     assertThat("".isIdentifier).isFalse()
   }
 
+  @Test fun escapeNonJavaIdentifiers() {
+    assertThat(escapeIfNotJavaIdentifier("8startWithNumber")).isEqualTo("`8startWithNumber`")
+    assertThat(escapeIfNotJavaIdentifier("with-hyphen")).isEqualTo("`with-hyphen`")
+    assertThat(escapeIfNotJavaIdentifier("with space")).isEqualTo("`with space`")
+    assertThat(escapeIfNotJavaIdentifier("with_unicode_punctuation\u2026")).isEqualTo("`with_unicode_punctuation\u2026`")
+  }
+
   private fun stringLiteral(string: String) = stringLiteral(string, string)
 
   private fun stringLiteral(expected: String, value: String)


### PR DESCRIPTION
Changes for issue #369 