### PR TITLE
Demo test and (naive) fix for suggested imports on matching type name collisions

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -55,7 +55,9 @@ class FileSpec private constructor(builder: FileSpec.Builder) {
     // First pass: emit the entire class, just to collect the types we'll need to import.
     val importsCollector = CodeWriter(NullAppendable, indent, memberImports)
     emit(importsCollector)
+    val typeSpecs = members.filterIsInstance<TypeSpec>().mapNotNull { it.name }.toSet()
     val suggestedImports = importsCollector.suggestedImports()
+        .filterKeys { it !in typeSpecs }
 
     // Second pass: write the code, taking advantage of the imports.
     val codeWriter = CodeWriter(out, indent, memberImports, suggestedImports)

--- a/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -673,4 +673,36 @@ class FileSpecTest {
         |
         |""".trimMargin())
   }
+
+  @Test fun conflictingImportsSameType() {
+    val sqlTaco = ClassName("java.sql", "Taco")
+    val source = FileSpec.builder("com.squareup.tacos", "Taco")
+        .addType(TypeSpec.classBuilder("Taco")
+            .addModifiers(KModifier.DATA)
+            .addProperty(PropertySpec.builder("madeFreshDatabaseDate", sqlTaco)
+                .initializer("madeFreshDatabaseDate")
+                .build())
+            .primaryConstructor(FunSpec.constructorBuilder()
+                .addParameter("madeFreshDatabaseDate", sqlTaco)
+                .addParameter("fooNt", INT)
+                .build())
+            .addFunction(FunSpec.constructorBuilder()
+                .addParameter("anotherTaco", ClassName("com.squareup.tacos", "Taco"))
+                .callThisConstructor(CodeBlock.of("%T.defaultInstance(), 0", sqlTaco))
+                .build())
+            .build())
+        .build()
+
+    // What should happen: no sql taco import, fully qualify the data class parameter in the primary
+    // constructor
+    assertThat(source.toString()).isEqualTo("""
+        |package com.squareup.tacos
+        |
+        |import kotlin.Int
+        |
+        |data class Taco(val madeFreshDatabaseDate: java.sql.Taco.Taco, fooNt: Int) {
+        |  constructor(anotherTaco: Taco) : this(java.sql.Taco.defaultInstance(), 0)
+        |}
+        |""".trimMargin())
+  }
 }

--- a/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -700,8 +700,8 @@ class FileSpecTest {
         |
         |import kotlin.Int
         |
-        |data class Taco(val madeFreshDatabaseDate: java.sql.Taco.Taco, fooNt: Int) {
-        |  constructor(anotherTaco: Taco) : this(java.sql.Taco.defaultInstance(), 0)
+        |data class Taco(val madeFreshDatabaseDate: java.sql.Taco, fooNt: Int) {
+        |    constructor(anotherTaco: Taco) : this(java.sql.Taco.defaultInstance(), 0)
         |}
         |""".trimMargin())
   }


### PR DESCRIPTION
This attempts to fix a bug I came across when managing imports and type name collisions. I've been talking with @Egorand and not sure this is the right solution, but it does make the test pass at least.

Currently master produces this code for the test snippet, which isn't correct because the `Taco` import overrides the `anotherTaco` constructor param type and doesn't match the spec

```kotlin
package com.squareup.tacos

import java.sql.Taco
import kotlin.Int

data class Taco(val madeFreshDatabaseDate: Taco, fooNt: Int) {
  constructor(anotherTaco: Taco) : this(java.sql.Taco.defaultInstance(), 0)
}
```

Which doesn't compile because the `