### PR TITLE
Remove companionObject API and funnel everything through types

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -603,10 +603,18 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     }
 
     fun addTypes(typeSpecs: Iterable<TypeSpec>) = apply {
+      typeSpecs.forEachIndexed { index, typeSpec ->
+        require(!(typeSpec.kind is Object && COMPANION in typeSpec.kind.modifiers)) {
+          "provided TypeSpec at index $index is a companion object, use the companionObject() function to set it"
+        }
+      }
       this.typeSpecs += typeSpecs
     }
 
     fun addType(typeSpec: TypeSpec) = apply {
+      require(!(typeSpec.kind is Object && COMPANION in typeSpec.kind.modifiers)) {
+        "provided TypeSpec is a companion object, use the companionObject() function to set it"
+      }
       typeSpecs += typeSpec
     }
 

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -35,7 +35,6 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
   val annotations = builder.annotations.toImmutableList()
   val modifiers = kind.modifiers.toImmutableSet()
   val typeVariables = builder.typeVariables.toImmutableList()
-  val companionObject = builder.companionObject
   val primaryConstructor = builder.primaryConstructor
   val superclass = builder.superclass
   val superclassConstructorParameters = builder.superclassConstructorParameters.toImmutableList()
@@ -67,7 +66,6 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     builder.initializerBlock.add(initializerBlock)
     builder.superinterfaces.putAll(superinterfaces)
     builder.primaryConstructor = primaryConstructor
-    builder.companionObject = companionObject
     return builder
   }
 
@@ -200,7 +198,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
         firstMember = false
         if (i.hasNext()) {
           codeWriter.emit(",\n")
-        } else if (propertySpecs.isNotEmpty() || funSpecs.isNotEmpty() || typeSpecs.isNotEmpty() || companionObject != null) {
+        } else if (propertySpecs.isNotEmpty() || funSpecs.isNotEmpty() || typeSpecs.isNotEmpty()) {
           codeWriter.emit(";\n")
         } else {
           codeWriter.emit("\n")
@@ -257,8 +255,6 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
         firstMember = false
       }
 
-      companionObject?.emit(codeWriter, null, isNestedExternal = areNestedExternal)
-
       codeWriter.unindent()
       codeWriter.popType()
 
@@ -300,8 +296,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
           }
         }
       }
-      return companionObject == null &&
-          enumConstants.isEmpty() &&
+      return enumConstants.isEmpty() &&
           initializerBlock.isEmpty() &&
           (primaryConstructor?.body?.isEmpty() ?: true) &&
           funSpecs.isEmpty() &&
@@ -390,7 +385,6 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     internal val annotations = mutableListOf<AnnotationSpec>()
     internal val typeVariables = mutableListOf<TypeVariableName>()
     internal var primaryConstructor: FunSpec? = null
-    internal var companionObject: TypeSpec? = null
     internal var superclass: TypeName = ANY
     internal val superclassConstructorParameters = mutableListOf<CodeBlock>()
     internal val superinterfaces = mutableMapOf<TypeName, CodeBlock?>()
@@ -441,16 +435,6 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     fun addTypeVariable(typeVariable: TypeVariableName) = apply {
       check(!isAnonymousClass) { "forbidden on anonymous types." }
       typeVariables += typeVariable
-    }
-
-    fun companionObject(companionObject: TypeSpec) = apply {
-      check(kind.isSimpleClass || kind is Interface || kind.isEnum) {
-        "$kind can't have a companion object"
-      }
-      require(companionObject.kind is Object && COMPANION in companionObject.kind.modifiers) {
-        "expected a companion object class but was $kind "
-      }
-      this.companionObject = companionObject
     }
 
     fun primaryConstructor(primaryConstructor: FunSpec?) = apply {
@@ -603,18 +587,10 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     }
 
     fun addTypes(typeSpecs: Iterable<TypeSpec>) = apply {
-      typeSpecs.forEachIndexed { index, typeSpec ->
-        require(!(typeSpec.kind is Object && COMPANION in typeSpec.kind.modifiers)) {
-          "provided TypeSpec at index $index is a companion object, use the companionObject() function to set it"
-        }
-      }
       this.typeSpecs += typeSpecs
     }
 
     fun addType(typeSpec: TypeSpec) = apply {
-      require(!(typeSpec.kind is Object && COMPANION in typeSpec.kind.modifiers)) {
-        "provided TypeSpec is a companion object, use the companionObject() function to set it"
-      }
       typeSpecs += typeSpec
     }
 
@@ -633,6 +609,22 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
       if (primaryConstructor == null) {
         require(funSpecs.none { it.isConstructor } || superclassConstructorParameters.isEmpty()) {
           "types without a primary constructor cannot specify secondary constructors and superclass constructor parameters"
+        }
+      }
+
+      val companionObjects = typeSpecs.filter {
+        // Replace this with isCompanion check after merged
+        it.kind is Object && COMPANION in it.kind.modifiers
+      }
+      when (companionObjects.size) {
+        0 -> Unit
+        1 -> {
+          require(kind.isSimpleClass || kind is Interface || kind.isEnum) {
+            "$kind types can't have a companion object"
+          }
+        }
+        else -> {
+          throw IllegalArgumentException("Multiple companion objects are present but only one is allowed.")
         }
       }
 

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -2153,7 +2153,7 @@ class TypeSpecTest {
         .addAnnotation(SuppressWarnings::class)
         .addModifiers(DATA)
         .addTypeVariable(TypeVariableName.of("State", listOf(ANY), IN).reified(true))
-        .addType(TypeSpec.companionObjectBuilder()
+        .companionObject(TypeSpec.companionObjectBuilder()
             .build())
         .addType(TypeSpec.classBuilder("InnerTaco")
             .addModifiers(INNER)
@@ -3164,6 +3164,28 @@ class TypeSpecTest {
       |class `With-Hyphen`
       |
       """.trimMargin())
+  }
+
+  @Test fun companionObjectInAddType() {
+    assertThrows<IllegalArgumentException> {
+      TypeSpec.classBuilder("Taco")
+          .addType(TypeSpec.companionObjectBuilder()
+              .build())
+          .build()
+    }
+  }
+
+  @Test fun companionObjectInAddTypes() {
+    assertThrows<IllegalArgumentException> {
+      TypeSpec.classBuilder("Taco")
+          .addTypes(listOf(
+              TypeSpec.companionObjectBuilder()
+                  .build(),
+              TypeSpec.classBuilder("Seasoning")
+                  .build()
+          ))
+          .build()
+    }
   }
 
   companion object {

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -2153,7 +2153,7 @@ class TypeSpecTest {
         .addAnnotation(SuppressWarnings::class)
         .addModifiers(DATA)
         .addTypeVariable(TypeVariableName.of("State", listOf(ANY), IN).reified(true))
-        .companionObject(TypeSpec.companionObjectBuilder()
+        .addType(TypeSpec.companionObjectBuilder()
             .build())
         .addType(TypeSpec.classBuilder("InnerTaco")
             .addModifiers(INNER)
@@ -2347,7 +2347,7 @@ class TypeSpecTest {
 
     val type = TypeSpec.classBuilder("MyClass")
         .addModifiers(KModifier.PUBLIC)
-        .companionObject(companion)
+        .addType(companion)
         .build()
 
     assertThat(toString(type)).isEqualTo("""
@@ -2379,7 +2379,7 @@ class TypeSpecTest {
 
     val type = TypeSpec.classBuilder("MyClass")
             .addModifiers(KModifier.PUBLIC)
-            .companionObject(companion)
+            .addType(companion)
             .build()
 
     assertThat(toString(type)).isEqualTo("""
@@ -2405,7 +2405,7 @@ class TypeSpecTest {
         .build()
 
     val type = TypeSpec.classBuilder("MyClass")
-        .companionObject(companion)
+        .addType(companion)
         .build()
 
     assertThat(toString(type)).isEqualTo("""
@@ -2429,7 +2429,7 @@ class TypeSpecTest {
 
     val type = TypeSpec.interfaceBuilder("MyInterface")
         .addModifiers(KModifier.PUBLIC)
-        .companionObject(companion)
+        .addType(companion)
         .build()
 
     assertThat(toString(type)).isEqualTo("""
@@ -2455,7 +2455,7 @@ class TypeSpecTest {
         .addEnumConstant("FOO")
         .addEnumConstant("BAR")
         .addModifiers(KModifier.PUBLIC)
-        .companionObject(companion)
+        .addType(companion)
         .build()
 
     assertThat(toString(enumBuilder)).isEqualTo("""
@@ -2465,6 +2465,7 @@ class TypeSpecTest {
         |    FOO,
         |
         |    BAR;
+        |
         |    companion object {
         |        fun test() {
         |        }
@@ -2473,7 +2474,7 @@ class TypeSpecTest {
         |""".trimMargin())
   }
 
-  @Test fun companionObjectOnObjectNotAlowed() {
+  @Test fun companionObjectOnObjectNotAllowed() {
     val companion = TypeSpec.companionObjectBuilder()
         .addFunction(FunSpec.builder("test")
             .addModifiers(KModifier.PUBLIC)
@@ -2482,24 +2483,10 @@ class TypeSpecTest {
 
     val objectBuilder = TypeSpec.objectBuilder("MyObject")
         .addModifiers(KModifier.PUBLIC)
-
-    assertThrows<IllegalStateException> {
-      objectBuilder.companionObject(companion)
-    }
-  }
-
-  @Test fun companionObjectIsCompanionObjectKind() {
-    val companion = TypeSpec.objectBuilder("Companion")
-        .addFunction(FunSpec.builder("test")
-            .addModifiers(KModifier.PUBLIC)
-            .build())
-        .build()
-
-    val typeBuilder = TypeSpec.classBuilder("MyClass")
-        .addModifiers(KModifier.PUBLIC)
+        .addType(companion)
 
     assertThrows<IllegalArgumentException> {
-      typeBuilder.companionObject(companion)
+      objectBuilder.build()
     }
   }
 
@@ -2514,7 +2501,7 @@ class TypeSpecTest {
 
     val type = TypeSpec.classBuilder("MyClass")
         .addModifiers(KModifier.PUBLIC)
-        .companionObject(companion)
+        .addType(companion)
         .build()
 
     assertThat(toString(type)).isEqualTo("""
@@ -3122,7 +3109,7 @@ class TypeSpecTest {
                 .build())
             .addFunction(FunSpec.builder("baz").addModifiers(KModifier.EXTERNAL).build())
             .build())
-        .companionObject(TypeSpec.companionObjectBuilder()
+        .addType(TypeSpec.companionObjectBuilder()
             .addModifiers(KModifier.EXTERNAL)
             .addFunction(FunSpec.builder("qux").addModifiers(KModifier.EXTERNAL).build())
             .build())
@@ -3139,6 +3126,7 @@ class TypeSpecTest {
       |            fun bar()
       |        }
       |    }
+      |
       |    companion object {
       |        fun qux()
       |    }
@@ -3166,22 +3154,13 @@ class TypeSpecTest {
       """.trimMargin())
   }
 
-  @Test fun companionObjectInAddType() {
-    assertThrows<IllegalArgumentException> {
-      TypeSpec.classBuilder("Taco")
-          .addType(TypeSpec.companionObjectBuilder()
-              .build())
-          .build()
-    }
-  }
-
-  @Test fun companionObjectInAddTypes() {
+  @Test fun multipleCompanionObjects() {
     assertThrows<IllegalArgumentException> {
       TypeSpec.classBuilder("Taco")
           .addTypes(listOf(
               TypeSpec.companionObjectBuilder()
                   .build(),
-              TypeSpec.classBuilder("Seasoning")
+              TypeSpec.companionObjectBuilder()
                   .build()
           ))
           .build()


### PR DESCRIPTION
This bit me in some prototyping I was doing. Currently nothing prevents users from adding companion objects via `addType`/`addTypes`, which leads to somewhat undefined behavior at emission-time. I suspect this isn't something that should be allowed, so putting this up as a proposal PR