### PR TITLE
Proposal: Add isCompanion to Object kind to differentiate

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -367,6 +367,8 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
         setOf(PUBLIC),
         modifiers.toSet()) {
 
+      val isCompanion get() = COMPANION in modifiers
+
       override fun plusModifiers(vararg modifiers: KModifier) =
           Object(*(this.modifiers.toTypedArray() + modifiers))
     }

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -26,6 +26,7 @@ import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.KModifier.PUBLIC
 import com.squareup.kotlinpoet.KModifier.VARARG
+import com.squareup.kotlinpoet.TypeSpec.Kind
 import com.squareup.kotlinpoet.jvm.throws
 import org.junit.Rule
 import java.io.IOException
@@ -3164,6 +3165,13 @@ class TypeSpecTest {
       |class `With-Hyphen`
       |
       """.trimMargin())
+  }
+
+  @Test fun objectKindIsCompanion() {
+    val comanionObject = TypeSpec.companionObjectBuilder()
+        .build()
+    assertThat(comanionObject.kind is Kind.Object).isTrue()
+    assertThat((comanionObject.kind as Kind.Object).isCompanion).isTrue()
   }
 
   companion object {


### PR DESCRIPTION
Ran into this case in internal prototyping and wanted to propose it as a PR. Currently there's no way to tell if a typespec of Object kind is a companion object or not