### PR TITLE
Move variance declaration to TypeSpec.addTypeVariable

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -140,22 +140,28 @@ internal class CodeWriter constructor(
   }
 
   /**
-   * Emit type variables with their bounds. If a type variable has more than a single bound - call
-   * [emitWhereBlock] with same input to produce an additional `where` block.
+   * Emit type variables with their bounds.
+   *
+   * If a type variable has more than a single bound it will be omitted: call [emitWhereBlock] with
+   * same input to produce an additional `where` block. [emitWhereBlock] omits type variables that
+   * have less than 2 bounds.
    *
    * This should only be used when declaring type variables; everywhere else bounds are omitted.
    */
-  fun emitTypeVariables(typeVariables: List<TypeVariableName>) {
+  fun emitTypeVariables(
+    typeVariables: List<TypeVariableName>,
+    typeVariableVariance: Map<TypeVariableName, KModifier> = emptyMap()
+  ) {
     if (typeVariables.isEmpty()) return
 
     emit("<")
     typeVariables.forEachIndexed { index, typeVariable ->
       if (index > 0) emit(", ")
-      if (typeVariable.variance != null) {
-        emit("${typeVariable.variance.keyword} ")
-      }
       if (typeVariable.reified) {
         emit("reified ")
+      }
+      typeVariableVariance[typeVariable]?.let { variance ->
+        emitCode("%L ", variance.keyword)
       }
       emitCode("%L", typeVariable.name)
       if (typeVariable.bounds.size == 1 && typeVariable.bounds[0] != NULLABLE_ANY) {

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -35,6 +35,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
   val annotations = builder.annotations.toImmutableList()
   val modifiers = kind.modifiers.toImmutableSet()
   val typeVariables = builder.typeVariables.toImmutableList()
+  val typeVariableVariance = builder.typeVariableVariance.toImmutableMap()
   val primaryConstructor = builder.primaryConstructor
   val superclass = builder.superclass
   val superclassConstructorParameters = builder.superclassConstructorParameters.toImmutableList()
@@ -61,6 +62,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     builder.kdoc.add(kdoc)
     builder.annotations += annotations
     builder.typeVariables += typeVariables
+    builder.typeVariableVariance += typeVariableVariance
     builder.superclass = superclass
     builder.superclassConstructorParameters += superclassConstructorParameters
     builder.enumConstants += enumConstants
@@ -127,7 +129,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
         if (name != null) {
           codeWriter.emitCode(" %L", escapeIfNecessary(name))
         }
-        codeWriter.emitTypeVariables(typeVariables)
+        codeWriter.emitTypeVariables(typeVariables, typeVariableVariance)
 
         primaryConstructor?.let {
           codeWriter.pushType(this) // avoid name collisions when emitting primary constructor
@@ -383,6 +385,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     internal val kdoc = CodeBlock.builder()
     internal val annotations = mutableListOf<AnnotationSpec>()
     internal val typeVariables = mutableListOf<TypeVariableName>()
+    internal val typeVariableVariance = mutableMapOf<TypeVariableName, KModifier>()
     internal var primaryConstructor: FunSpec? = null
     internal var superclass: TypeName = ANY
     internal val superclassConstructorParameters = mutableListOf<CodeBlock>()
@@ -438,6 +441,12 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     fun addTypeVariable(typeVariable: TypeVariableName) = apply {
       check(!isAnonymousClass) { "forbidden on anonymous types." }
       typeVariables += typeVariable
+    }
+
+    fun addTypeVariable(typeVariable: TypeVariableName, variance: KModifier) = apply {
+      check(!isAnonymousClass) { "forbidden on anonymous types." }
+      typeVariables += typeVariable
+      typeVariableVariance += typeVariable to variance
     }
 
     fun primaryConstructor(primaryConstructor: FunSpec?) = apply {

--- a/src/test/java/com/squareup/kotlinpoet/TypeVariableNameTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeVariableNameTest.kt
@@ -118,30 +118,6 @@ class TypeVariableNameTest {
       |""".trimMargin())
   }
 
-  @Test fun inVariance() {
-    val typeSpec = TypeSpec.classBuilder("Taco")
-        .addTypeVariable(TypeVariableName("E", Number::class, variance = KModifier.IN))
-        .build()
-    assertThat(typeSpec.toString()).isEqualTo("""
-      |class Taco<in E : kotlin.Number>
-      |""".trimMargin())
-  }
-
-  @Test fun outVariance() {
-    val typeSpec = TypeSpec.classBuilder("Taco")
-        .addTypeVariable(TypeVariableName("E", Number::class, variance = KModifier.OUT))
-        .build()
-    assertThat(typeSpec.toString()).isEqualTo("""
-      |class Taco<out E : kotlin.Number>
-      |""".trimMargin())
-  }
-
-  @Test fun invalidVariance() {
-    assertThrows<IllegalArgumentException> {
-      TypeVariableName("E", KModifier.FINAL)
-    }
-  }
-
   @Test fun reified() {
     val funSpec = FunSpec.builder("printMembers")
         .addModifiers(KModifier.INLINE)


### PR DESCRIPTION
Part of #382 

Publishing this mostly to open a discussion, and will probably decline afterwards. 

The reasoning behind this change change is that type variable variance only makes sense in the context of type declaration. Similarly, `reified` only makes sense in the context of declaring an `inline fun`. However, kotlin-reflect's `KTypeParameter` has both `isReified` and `variance` fields, and although this feels wrong, it's better to conform to JBs models.