### PR TITLE
Expose mutable builder properties and move their validations to build-time

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -100,8 +100,9 @@ class AnnotationSpec private constructor(builder: AnnotationSpec.Builder) {
   }
 
   class Builder internal constructor(internal val type: TypeName) {
-    internal val members = mutableListOf<CodeBlock>()
     internal var useSiteTarget: UseSiteTarget? = null
+
+    val members = mutableListOf<CodeBlock>()
 
     fun addMember(format: String, vararg args: Any) =
         addMember(CodeBlock.of(format, *args))

--- a/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -273,7 +273,7 @@ class FileSpec private constructor(builder: FileSpec.Builder) {
     }
 
     fun build(): FileSpec {
-      annotations.forEach { annotationSpec ->
+      for (annotationSpec in annotations) {
         if (annotationSpec.useSiteTarget != FILE) {
           error(
               "Use-site target ${annotationSpec.useSiteTarget} not supported for file annotations.")

--- a/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -173,11 +173,12 @@ class FileSpec private constructor(builder: FileSpec.Builder) {
     val packageName: String,
     val name: String
   ) {
-    internal val annotations = mutableListOf<AnnotationSpec>()
     internal val comment = CodeBlock.builder()
     internal val memberImports = sortedSetOf<Import>()
     internal var indent = DEFAULT_INDENT
     internal val members = mutableListOf<Any>()
+
+    val annotations = mutableListOf<AnnotationSpec>()
 
     init {
       require(name.isName) { "not a valid file name: $name" }
@@ -271,7 +272,15 @@ class FileSpec private constructor(builder: FileSpec.Builder) {
       this.indent = indent
     }
 
-    fun build() = FileSpec(this)
+    fun build(): FileSpec {
+      annotations.forEach { annotationSpec ->
+        if (annotationSpec.useSiteTarget != FILE) {
+          error(
+              "Use-site target ${annotationSpec.useSiteTarget} not supported for file annotations.")
+        }
+      }
+      return FileSpec(this)
+    }
   }
 
   companion object {

--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -334,9 +334,7 @@ class FunSpec private constructor(builder: Builder) {
     }
 
     fun build(): FunSpec {
-      if (typeVariables.isNotEmpty()) {
-        check(!name.isAccessor) { "$name cannot have type variables" }
-      }
+      check(typeVariables.isEmpty() || !name.isAccessor) { "$name cannot have type variables" }
       check(!(name == GETTER && parameters.isNotEmpty())) { "$name cannot have parameters" }
       check(!(name == SETTER && parameters.size != 1)) { "$name can have only one parameter" }
       return FunSpec(this)

--- a/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
@@ -67,9 +67,10 @@ class ParameterSpec private constructor(builder: ParameterSpec.Builder) {
     internal val name: String,
     internal val type: TypeName
   ) {
-    internal val annotations = mutableListOf<AnnotationSpec>()
-    internal val modifiers = mutableListOf<KModifier>()
     internal var defaultValue: CodeBlock? = null
+
+    val annotations = mutableListOf<AnnotationSpec>()
+    val modifiers = mutableListOf<KModifier>()
 
     fun addAnnotations(annotationSpecs: Iterable<AnnotationSpec>) = apply {
       annotations += annotationSpecs

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -109,13 +109,14 @@ class PropertySpec private constructor(builder: Builder) {
   class Builder internal constructor(internal val name: String, internal val type: TypeName) {
     internal var mutable = false
     internal val kdoc = CodeBlock.builder()
-    internal val annotations = mutableListOf<AnnotationSpec>()
-    internal val modifiers = mutableListOf<KModifier>()
     internal var initializer: CodeBlock? = null
     internal var delegated = false
     internal var getter: FunSpec? = null
     internal var setter: FunSpec? = null
     internal var receiverType: TypeName? = null
+
+    val annotations = mutableListOf<AnnotationSpec>()
+    val modifiers = mutableListOf<KModifier>()
 
     fun mutable(mutable: Boolean) = apply {
       this.mutable = mutable
@@ -146,9 +147,6 @@ class PropertySpec private constructor(builder: Builder) {
     fun addAnnotation(annotation: KClass<*>) = addAnnotation(annotation.asClassName())
 
     fun addModifiers(vararg modifiers: KModifier) = apply {
-      for (modifier in modifiers) {
-        modifier.checkTarget(KModifier.Target.PROPERTY)
-      }
       this.modifiers += modifiers
     }
 
@@ -187,7 +185,10 @@ class PropertySpec private constructor(builder: Builder) {
 
     fun receiver(receiverType: KClass<*>) = receiver(receiverType.asTypeName())
 
-    fun build() = PropertySpec(this)
+    fun build(): PropertySpec {
+      modifiers.forEach { it.checkTarget(KModifier.Target.PROPERTY) }
+      return PropertySpec(this)
+    }
   }
 
   companion object {

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -186,7 +186,9 @@ class PropertySpec private constructor(builder: Builder) {
     fun receiver(receiverType: KClass<*>) = receiver(receiverType.asTypeName())
 
     fun build(): PropertySpec {
-      modifiers.forEach { it.checkTarget(KModifier.Target.PROPERTY) }
+      for (it in modifiers) {
+        it.checkTarget(KModifier.Target.PROPERTY)
+      }
       return PropertySpec(this)
     }
   }

--- a/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
@@ -96,7 +96,7 @@ class TypeAliasSpec private constructor(builder: TypeAliasSpec.Builder) {
     }
 
     fun build(): TypeAliasSpec {
-      modifiers.forEach {
+      for (it in modifiers) {
         require(it in ALLOWABLE_MODIFIERS) {
           "unexpected typealias modifier $it"
         }

--- a/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
@@ -62,9 +62,10 @@ class TypeAliasSpec private constructor(builder: TypeAliasSpec.Builder) {
     internal val name: String,
     internal val type: TypeName
   ) {
-    internal val modifiers = mutableSetOf<KModifier>()
-    internal val typeVariables = mutableSetOf<TypeVariableName>()
     internal val kdoc = CodeBlock.builder()
+
+    val modifiers = mutableSetOf<KModifier>()
+    val typeVariables = mutableSetOf<TypeVariableName>()
 
     init {
       require(name.isName) { "not a valid name: $name" }
@@ -75,9 +76,6 @@ class TypeAliasSpec private constructor(builder: TypeAliasSpec.Builder) {
     }
 
     private fun addModifier(modifier: KModifier) {
-      require(modifier in setOf(PUBLIC, INTERNAL, PRIVATE, ACTUAL)) {
-        "unexpected typealias modifier $modifier"
-      }
       this.modifiers.add(modifier)
     }
 
@@ -97,7 +95,18 @@ class TypeAliasSpec private constructor(builder: TypeAliasSpec.Builder) {
       kdoc.add(block)
     }
 
-    fun build() = TypeAliasSpec(this)
+    fun build(): TypeAliasSpec {
+      modifiers.forEach {
+        require(it in ALLOWABLE_MODIFIERS) {
+          "unexpected typealias modifier $it"
+        }
+      }
+      return TypeAliasSpec(this)
+    }
+
+    private companion object {
+      private val ALLOWABLE_MODIFIERS = setOf(PUBLIC, INTERNAL, PRIVATE, ACTUAL)
+    }
   }
 
   companion object {

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -384,6 +384,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     internal val name: String?
   ) {
     internal val kdoc = CodeBlock.builder()
+    internal val annotations = mutableListOf<AnnotationSpec>()
     internal var primaryConstructor: FunSpec? = null
     internal var superclass: TypeName = ANY
     internal val initializerBlock = CodeBlock.builder()
@@ -395,7 +396,6 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
 
     val superinterfaces = mutableMapOf<TypeName, CodeBlock?>()
     val enumConstants = mutableMapOf<String, TypeSpec>()
-    val annotations = mutableListOf<AnnotationSpec>()
     val typeVariables = mutableListOf<TypeVariableName>()
     val superclassConstructorParameters = mutableListOf<CodeBlock>()
     val propertySpecs = mutableListOf<PropertySpec>()
@@ -412,6 +412,12 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
 
     fun addKdoc(block: CodeBlock) = apply {
       kdoc.add(block)
+    }
+
+    fun replaceAnnotations(modifierBlock: (List<AnnotationSpec>) -> Iterable<AnnotationSpec>) = apply {
+      val currentAnnotations = annotations.toList()
+      annotations.clear()
+      addAnnotations(modifierBlock(currentAnnotations))
     }
 
     fun addAnnotations(annotationSpecs: Iterable<AnnotationSpec>) = apply {

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -455,12 +455,12 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     }
 
     fun superclass(superclass: TypeName) = apply {
-      ensureCanHaveSuperclass()
+      checkCanHaveSuperclass()
       check(this.superclass === ANY) { "superclass already set to ${this.superclass}" }
       this.superclass = superclass
     }
 
-    private fun ensureCanHaveSuperclass() {
+    private fun checkCanHaveSuperclass() {
       check(isSimpleClass || kind is Object) {
         "only classes can have super classes, not $kind"
       }
@@ -475,7 +475,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     }
 
     fun addSuperclassConstructorParameter(codeBlock: CodeBlock) = apply {
-      ensureCanHaveSuperclass()
+      checkCanHaveSuperclass()
       this.superclassConstructorParameters += codeBlock
     }
 
@@ -594,7 +594,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
       }
 
       if (superclassConstructorParameters.isNotEmpty()) {
-        ensureCanHaveSuperclass()
+        checkCanHaveSuperclass()
       }
 
       check(!(isAnonymousClass && typeVariables.isNotEmpty())) {

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -588,7 +588,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     fun build(): TypeSpec {
       if (enumConstants.isNotEmpty()) {
         check(isEnum) { "${this.name} is not enum and cannot have enum constants" }
-        enumConstants.keys.forEach {
+        for (it in enumConstants.keys) {
           require(it.isName) { "not a valid enum constant: $name" }
         }
       }

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -384,7 +384,6 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     internal val name: String?
   ) {
     internal val kdoc = CodeBlock.builder()
-    internal val annotations = mutableListOf<AnnotationSpec>()
     internal var primaryConstructor: FunSpec? = null
     internal var superclass: TypeName = ANY
     internal val initializerBlock = CodeBlock.builder()
@@ -396,6 +395,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
 
     val superinterfaces = mutableMapOf<TypeName, CodeBlock?>()
     val enumConstants = mutableMapOf<String, TypeSpec>()
+    val annotations = mutableListOf<AnnotationSpec>()
     val typeVariables = mutableListOf<TypeVariableName>()
     val superclassConstructorParameters = mutableListOf<CodeBlock>()
     val propertySpecs = mutableListOf<PropertySpec>()
@@ -412,12 +412,6 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
 
     fun addKdoc(block: CodeBlock) = apply {
       kdoc.add(block)
-    }
-
-    fun replaceAnnotations(modifierBlock: (List<AnnotationSpec>) -> Iterable<AnnotationSpec>) = apply {
-      val currentAnnotations = annotations.toList()
-      annotations.clear()
-      addAnnotations(modifierBlock(currentAnnotations))
     }
 
     fun addAnnotations(annotationSpecs: Iterable<AnnotationSpec>) = apply {

--- a/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
@@ -285,6 +285,18 @@ class AnnotationSpecTest {
         "@kotlin.Deprecated(\"Nope\", kotlin.ReplaceWith(\"Yep\"))")
   }
 
+  @Test fun modifyMembers() {
+    val builder = AnnotationSpec.builder(Deprecated::class)
+        .addMember("%S", "Nope")
+        .addMember("%T(%S)", ReplaceWith::class, "Yep")
+
+    builder.members.removeAt(1)
+    builder.members.add(CodeBlock.of("%T(%S)", ReplaceWith::class, "Nope"))
+
+    assertThat(builder.build().toString()).isEqualTo("" +
+        "@kotlin.Deprecated(\"Nope\", kotlin.ReplaceWith(\"Nope\"))")
+  }
+
   private fun toString(annotationSpec: AnnotationSpec) =
       toString(TypeSpec.classBuilder("Taco").addAnnotation(annotationSpec).build())
 

--- a/src/test/java/com/squareup/kotlinpoet/CrossplatformTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/CrossplatformTest.kt
@@ -155,6 +155,7 @@ class CrossplatformTest {
           .addFunction(FunSpec.builder("print")
               .addStatement("println()")
               .build())
+          .build()
     }.hasMessageThat().isEqualTo("functions in expect classes can't have bodies")
   }
 

--- a/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -20,11 +20,11 @@ import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget.FILE
 import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget.SET
 import com.squareup.kotlinpoet.KModifier.VARARG
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
-import kotlin.test.Ignore
-import kotlin.test.Test
 import java.util.Collections
 import java.util.Date
 import java.util.concurrent.TimeUnit
+import kotlin.test.Ignore
+import kotlin.test.Test
 
 class FileSpecTest {
   @Test fun importStaticReadmeExample() {
@@ -687,5 +687,22 @@ class FileSpecTest {
         .build()
 
     assertThat(source.toBuilder().build()).isEqualTo(source)
+  }
+
+  @Test fun modifyAnnotations() {
+    val builder = FileSpec.builder("com.taco", "Taco")
+        .addAnnotation(AnnotationSpec.builder(JvmName::class.asClassName())
+            .useSiteTarget(FILE)
+            .addMember("name = %S", "JvmTaco")
+            .build())
+
+    val javaWord = AnnotationSpec.builder(JvmName::class.asClassName())
+        .useSiteTarget(FILE)
+        .addMember("name = %S", "JavaTaco")
+        .build()
+    builder.annotations.clear()
+    builder.annotations.add(javaWord)
+
+    assertThat(builder.build().annotations).containsExactly(javaWord)
   }
 }

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -404,4 +404,51 @@ class FunSpecTest {
       |constructor(values: kotlin.collections.List<kotlin.String>) : super(values.toImmutableList())
       |""".trimMargin())
   }
+
+  @Test fun modifyModifiers() {
+    val builder = FunSpec.builder("taco")
+        .addModifiers(KModifier.PRIVATE)
+
+    builder.modifiers.clear()
+    builder.modifiers.add(KModifier.INTERNAL)
+
+    assertThat(builder.build().modifiers).containsExactly(KModifier.INTERNAL)
+  }
+
+  @Test fun modifyAnnotations() {
+    val builder = FunSpec.builder("taco")
+        .addAnnotation(AnnotationSpec.builder(JvmName::class.asClassName())
+            .addMember("name = %S", "jvmWord")
+            .build())
+
+    val javaWord = AnnotationSpec.builder(JvmName::class.asClassName())
+        .addMember("name = %S", "javaWord")
+        .build()
+    builder.annotations.clear()
+    builder.annotations.add(javaWord)
+
+    assertThat(builder.build().annotations).containsExactly(javaWord)
+  }
+
+  @Test fun modifyTypeVariableNames() {
+    val builder = FunSpec.builder("taco")
+        .addTypeVariable(TypeVariableName("V"))
+
+    val tVar = TypeVariableName("T")
+    builder.typeVariables.clear()
+    builder.typeVariables.add(tVar)
+
+    assertThat(builder.build().typeVariables).containsExactly(tVar)
+  }
+
+  @Test fun modifyParameters() {
+    val builder = FunSpec.builder("taco")
+        .addParameter(ParameterSpec.builder("topping", String::class.asClassName()).build())
+
+    val seasoning = ParameterSpec.builder("seasoning", String::class.asClassName()).build()
+    builder.parameters.clear()
+    builder.parameters.add(seasoning)
+
+    assertThat(builder.build().parameters).containsExactly(seasoning)
+  }
 }

--- a/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -19,7 +19,6 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.jvm.jvmField
 import com.squareup.kotlinpoet.jvm.jvmSuppressWildcards
-import com.squareup.kotlinpoet.jvm.jvmWildcard
 import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 
@@ -153,7 +152,7 @@ class KotlinPoetTest {
 
   @Test fun mistargetedModifier() {
     assertThrows<IllegalArgumentException> {
-      PropertySpec.builder("CHEESE", String::class, KModifier.DATA)
+      PropertySpec.builder("CHEESE", String::class, KModifier.DATA).build()
     }
   }
 

--- a/src/test/java/com/squareup/kotlinpoet/ParameterSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/ParameterSpecTest.kt
@@ -57,4 +57,31 @@ class ParameterSpecTest {
 
     assertThat(parameterSpec.toBuilder().build()).isEqualTo(parameterSpec)
   }
+
+  @Test fun modifyModifiers() {
+    val builder = ParameterSpec
+        .builder("word", String::class)
+        .addModifiers(KModifier.PRIVATE)
+
+    builder.modifiers.clear()
+    builder.modifiers.add(KModifier.INTERNAL)
+
+    assertThat(builder.build().modifiers).containsExactly(KModifier.INTERNAL)
+  }
+
+  @Test fun modifyAnnotations() {
+    val builder = ParameterSpec
+        .builder("word", String::class)
+        .addAnnotation(AnnotationSpec.builder(JvmName::class.asClassName())
+            .addMember("name = %S", "jvmWord")
+            .build())
+
+    val javaWord = AnnotationSpec.builder(JvmName::class.asClassName())
+        .addMember("name = %S", "javaWord")
+        .build()
+    builder.annotations.clear()
+    builder.annotations.add(javaWord)
+
+    assertThat(builder.build().annotations).containsExactly(javaWord)
+  }
 }

--- a/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -70,6 +70,7 @@ class PropertySpecTest {
     assertThrows<IllegalArgumentException> {
       PropertySpec.builder("foo", String::class)
           .addModifiers(KModifier.INLINE)
+          .build()
     }
   }
 
@@ -123,6 +124,33 @@ class PropertySpecTest {
             .build())
         .build()
 
-    assertThat(prop.toBuilder().build()).isEqualTo(prop);
+    assertThat(prop.toBuilder().build()).isEqualTo(prop)
+  }
+
+  @Test fun modifyModifiers() {
+    val builder = PropertySpec
+        .builder("word", String::class)
+        .addModifiers(KModifier.PRIVATE)
+
+    builder.modifiers.clear()
+    builder.modifiers.add(KModifier.INTERNAL)
+
+    assertThat(builder.build().modifiers).containsExactly(KModifier.INTERNAL)
+  }
+
+  @Test fun modifyAnnotations() {
+    val builder = PropertySpec
+        .builder("word", String::class)
+        .addAnnotation(AnnotationSpec.builder(JvmName::class.asClassName())
+            .addMember("name = %S", "jvmWord")
+            .build())
+
+    val javaWord = AnnotationSpec.builder(JvmName::class.asClassName())
+        .addMember("name = %S", "javaWord")
+        .build()
+    builder.annotations.clear()
+    builder.annotations.add(javaWord)
+
+    assertThat(builder.build().annotations).containsExactly(javaWord)
   }
 }

--- a/src/test/java/com/squareup/kotlinpoet/TypeAliasSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeAliasSpecTest.kt
@@ -17,8 +17,8 @@ package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
-import kotlin.test.Test
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
 
 class TypeAliasSpecTest {
 
@@ -126,5 +126,28 @@ class TypeAliasSpecTest {
         .addTypeVariable(typeParam)
         .build()
     assertThat(typeAliasSpec.toBuilder().build()).isEqualTo(typeAliasSpec)
+  }
+
+  @Test fun modifyModifiers() {
+    val builder = TypeAliasSpec
+        .builder("Word", String::class)
+        .addModifiers(KModifier.PRIVATE)
+
+    builder.modifiers.clear()
+    builder.modifiers.add(KModifier.INTERNAL)
+
+    assertThat(builder.build().modifiers).containsExactly(KModifier.INTERNAL)
+  }
+
+  @Test fun modifyTypeVariableNames() {
+    val builder = TypeAliasSpec
+        .builder("Word", String::class)
+        .addTypeVariable(TypeVariableName("V"))
+
+    val tVar = TypeVariableName("T")
+    builder.typeVariables.clear()
+    builder.typeVariables.add(tVar)
+
+    assertThat(builder.build().typeVariables).containsExactly(tVar)
   }
 }

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -3301,13 +3301,16 @@ class TypeSpecTest {
             .addMember("name = %S", "jvmWord")
             .build())
 
-    val javaWord = AnnotationSpec.builder(JvmName::class.asClassName())
-        .addMember("name = %S", "javaWord")
+    val suppressWarnings = AnnotationSpec.builder(SuppressWarnings::class.asClassName())
+        .addMember("value = [%S]", "randomstuff")
         .build()
-    builder.annotations.clear()
-    builder.annotations.add(javaWord)
 
-    assertThat(builder.build().annotations).containsExactly(javaWord)
+    builder.replaceAnnotations { currentAnnotations ->
+      currentAnnotations.filterNot { it.type == JvmName::class.asClassName() }
+          .plus(suppressWarnings)
+    }
+
+    assertThat(builder.build().annotations).containsExactly(suppressWarnings)
   }
 
   @Test fun modifyTypeVariableNames() {

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -3301,16 +3301,13 @@ class TypeSpecTest {
             .addMember("name = %S", "jvmWord")
             .build())
 
-    val suppressWarnings = AnnotationSpec.builder(SuppressWarnings::class.asClassName())
-        .addMember("value = [%S]", "randomstuff")
+    val javaWord = AnnotationSpec.builder(JvmName::class.asClassName())
+        .addMember("name = %S", "javaWord")
         .build()
+    builder.annotations.clear()
+    builder.annotations.add(javaWord)
 
-    builder.replaceAnnotations { currentAnnotations ->
-      currentAnnotations.filterNot { it.type == JvmName::class.asClassName() }
-          .plus(suppressWarnings)
-    }
-
-    assertThat(builder.build().annotations).containsExactly(suppressWarnings)
+    assertThat(builder.build().annotations).containsExactly(javaWord)
   }
 
   @Test fun modifyTypeVariableNames() {


### PR DESCRIPTION
This is the analogue to https://github.com/square/javapoet/pull/650

Each commit should be digestible for review and isolated. The general approach was to make the properties public, add tests, and then move any of their validations to `build()`