### PR TITLE
Allow opening braces and params in beginControlFlow()

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
@@ -350,12 +350,25 @@ class CodeBlock private constructor(
     }
 
     /**
-     * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
-     *     Shouldn't contain braces or newline characters.
+     * @param controlFlow the control flow construct and its code, such as `if (foo == 5)`.
+     *     Shouldn't contain newline characters. Can contain opening braces, e.g.
+     *     `beginControlFlow("list.forEach { element ->")`. If there's no opening brace at the end
+     *     of the string, it will be added.
      */
     fun beginControlFlow(controlFlow: String, vararg args: Any?) = apply {
-      add(controlFlow + " {\n", *args)
+      add(controlFlow.withOpeningBrace(), *args)
       indent()
+    }
+
+    private fun String.withOpeningBrace(): String {
+      for (i in length - 1 downTo 0) {
+        if (this[i] == '{') {
+          return "$this\n"
+        } else if (this[i] == '}') {
+          break
+        }
+      }
+      return "$this {\n"
     }
 
     /**

--- a/src/test/java/com/squareup/kotlinpoet/CodeBlockTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/CodeBlockTest.kt
@@ -399,4 +399,30 @@ class CodeBlockTest {
     assertThat(blocks.joinToCode(prefix = "(", suffix = ")"))
         .isEqualTo(CodeBlock.of("(%L, %L, %L)", "taco1", "taco2", "taco3"))
   }
+
+  @Test fun beginControlFlowWithParams() {
+    val controlFlow = CodeBlock.builder()
+        .beginControlFlow("list.forEach { element ->")
+        .addStatement("println(element)")
+        .endControlFlow()
+        .build()
+    assertThat(controlFlow.toString()).isEqualTo("""
+      |list.forEach { element ->
+      |    println(element)
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun beginControlFlowWithParamsAndTemplateString() {
+    val controlFlow = CodeBlock.builder()
+        .beginControlFlow("listOf(\"\${1.toString()}\").forEach { element ->")
+        .addStatement("println(element)")
+        .endControlFlow()
+        .build()
+    assertThat(controlFlow.toString()).isEqualTo("""
+      |listOf("${'$'}{1.toString()}").forEach { element ->
+      |    println(element)
+      |}
+      |""".trimMargin())
+  }
 }


### PR DESCRIPTION
Fixes #416 

This is an alternative to #418 that avoids introducing new API