### PR TITLE
Escape dollar signs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ class HelloWorld {
 }
 ```
 
+Note that "$" is also escaped. To make string templates, use literals with [%L](#%L-for-Literals).
+
 ### %T for Types
 
 KotlinPoet has rich built-in support for types, including automatic generation of `import`

--- a/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -118,6 +118,11 @@ internal fun stringLiteralWithQuotes(value: String): String {
         result.append("\\\"")
         continue
       }
+      // Trivial case: the dollar sign can start a string template and must be escaped.
+      if (c == '$') {
+        result.append("\\$")
+        continue
+      }
       // Default case: just let character literal do its work.
       result.append(characterLiteralWithoutSingleQuotes(c))
       // Need to append indent after linefeed?

--- a/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -195,7 +195,25 @@ class KotlinPoetTest {
         "class Taco {\n" +
         "    fun strings() {\n" +
         "        val a = \"basic string\"\n" +
-        "        val b = \"string with a \$ dollar sign\"\n" +
+        "        val b = \"string with a \\\$ dollar sign\"\n" +
+        "    }\n" +
+        "}\n")
+  }
+
+  @Test fun stringInterpolation() {
+    val source = FileSpec.get(tacosPackage, TypeSpec.classBuilder("Taco")
+        .addFunction(FunSpec.builder("strings")
+            .addStatement("val a = %S", "basic string")
+            .addStatement("val b = %L", "\"the value of 'a' is \$a.\"")
+            .build())
+        .build())
+    assertThat(source.toString()).isEqualTo("" +
+        "package com.squareup.tacos\n" +
+        "\n" +
+        "class Taco {\n" +
+        "    fun strings() {\n" +
+        "        val a = \"basic string\"\n" +
+        "        val b = \"the value of 'a' is \$a.\"\n" +
         "    }\n" +
         "}\n")
   }

--- a/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
@@ -60,7 +60,7 @@ class UtilTest {
   @Test fun stringLiteral() {
     stringLiteral("abc")
     stringLiteral("♦♥♠♣")
-    stringLiteral("€\\t@\\t$", "€\t@\t$")
+    stringLiteral("€\\t@\\t\\$", "€\t@\t$")
     assertThat(stringLiteralWithQuotes("abc();\ndef();"))
         .isEqualTo("\"\"\"\n|abc();\n|def();\n\"\"\".trimMargin()")
     stringLiteral("This is \\\"quoted\\\"!", "This is \"quoted\"!")


### PR DESCRIPTION
Escaping is needed to prevent making string templates ("\$stringLiteral") and is safe in other usages ("\$" is the same string as "$").

Closes #427.