### PR TITLE
building TypeName for Array<primitive-type>

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
@@ -136,18 +136,19 @@ class ParameterizedTypeName internal constructor(
         return type.asTypeName()
       }
 
+      val effectiveType = if (type.java.isArray) Array<Unit>::class else type
       val enclosingClass = type.java.enclosingClass?.kotlin
 
       return ParameterizedTypeName(
           enclosingClass?.let {
-            get(it, false, typeArguments.drop(type.typeParameters.size))
+            get(it, false, typeArguments.drop(effectiveType.typeParameters.size))
           },
-          type.asTypeName(),
-          typeArguments.take(type.typeParameters.size).map {
+          effectiveType.asTypeName(),
+          typeArguments.take(effectiveType.typeParameters.size).map {
             it.type?.asTypeName() ?: WildcardTypeName.STAR
           },
           nullable,
-          type.annotations.map { AnnotationSpec.get(it) })
+          effectiveType.annotations.map { AnnotationSpec.get(it) })
     }
   }
 }

--- a/src/test/java/com/squareup/kotlinpoet/ParameterizedTypeNameTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/ParameterizedTypeNameTest.kt
@@ -19,6 +19,11 @@ package com.squareup.kotlinpoet
 import com.google.common.truth.Truth.assertThat
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.plusParameter
 import org.junit.Test
+import java.io.Closeable
+import java.io.InputStream
+import kotlin.reflect.KTypeProjection
+import kotlin.reflect.KVariance
+import kotlin.reflect.full.createType
 
 class ParameterizedTypeNameTest {
   @Test fun classNamePlusParameter() {
@@ -55,6 +60,26 @@ class ParameterizedTypeNameTest {
   @Test fun classPlusParameter() {
     val typeName = java.util.List::class.java.plusParameter(java.lang.String::class.java)
     assertThat(typeName.toString()).isEqualTo("java.util.List<java.lang.String>")
+  }
+
+  @Test fun primitiveArray() {
+    assertThat(ByteArray::class.asTypeName().toString()).isEqualTo("kotlin.ByteArray")
+    assertThat(CharArray::class.asTypeName().toString()).isEqualTo("kotlin.CharArray")
+    assertThat(ShortArray::class.asTypeName().toString()).isEqualTo("kotlin.ShortArray")
+    assertThat(IntArray::class.asTypeName().toString()).isEqualTo("kotlin.IntArray")
+    assertThat(LongArray::class.asTypeName().toString()).isEqualTo("kotlin.LongArray")
+    assertThat(FloatArray::class.asTypeName().toString()).isEqualTo("kotlin.FloatArray")
+    assertThat(DoubleArray::class.asTypeName().toString()).isEqualTo("kotlin.DoubleArray")
+  }
+
+  @Test fun arrayPlusPrimitiveParameter() {
+    val typeName = Array<Int>::class.createType(listOf(KTypeProjection(KVariance.INVARIANT, Int::class.createType()))).asTypeName()
+    assertThat(typeName.toString()).isEqualTo("kotlin.Array<kotlin.Int>")
+  }
+
+  @Test fun arrayPlusObjectParameter() {
+    val typeName = Array<Unit>::class.createType(listOf(KTypeProjection(KVariance.INVARIANT, Closeable::class.createType()))).asTypeName()
+    assertThat(typeName.toString()).isEqualTo("kotlin.Array<java.io.Closeable>")
   }
 
   @Test fun classPlusTwoParameters() {


### PR DESCRIPTION
fix exception on building TypeName for arrays of primitive types, such as `Array<Int>`
Correctly distinguish two types: `IntArray` and `Array<Int>`

exception being fixed:
java.lang.IllegalArgumentException: no type arguments: kotlin.IntArray
	at com.squareup.kotlinpoet.ParameterizedTypeName.<init>(ParameterizedTypeName.kt:38)
	at com.squareup.kotlinpoet.ParameterizedTypeName$Companion.get$kotlinpoet(ParameterizedTypeName.kt:141)
	at com.squareup.kotlinpoet.ParameterizedTypeNames.asTypeName(ParameterizedTypeName.kt:170)