### PR TITLE
Add parens for annotated types

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/LambdaTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/LambdaTypeName.kt
@@ -62,7 +62,11 @@ class LambdaTypeName internal constructor(
     }
 
     receiver?.let {
-      out.emitCode("%T.", it)
+      if (it.isAnnotated) {
+        out.emitCode("(%T).", it)
+      } else {
+        out.emitCode("%T.", it)
+      }
     }
 
     parameters.emit(out)

--- a/src/test/java/com/squareup/kotlinpoet/LambdaTypeNameTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/LambdaTypeNameTest.kt
@@ -16,11 +16,36 @@
 
 package com.squareup.kotlinpoet
 
+import com.google.common.truth.Truth.assertThat
 import com.squareup.kotlinpoet.KModifier.VARARG
 import kotlin.test.Test
 import javax.annotation.Nullable
 
 class LambdaTypeNameTest {
+
+  @Retention(AnnotationRetention.RUNTIME)
+  annotation class HasSomeAnnotation
+
+  @HasSomeAnnotation
+  inner class IsAnnotated
+
+  @Test fun receiverWithoutAnnotationHasNoParens() {
+    val typeName = LambdaTypeName.get(
+            Int::class.asClassName(),
+            listOf(),
+            Unit::class.asTypeName())
+    assertThat(typeName.toString()).isEqualTo("kotlin.Int.() -> kotlin.Unit")
+  }
+
+  @Test fun receiverWithAnnotationHasParens() {
+    val annotation = IsAnnotated::class.java.getAnnotation(HasSomeAnnotation::class.java)
+    val typeName = LambdaTypeName.get(
+            Int::class.asClassName().annotated(AnnotationSpec.get(annotation, true)),
+            listOf(),
+            Unit::class.asTypeName())
+    assertThat(typeName.toString()).isEqualTo(
+            "(@com.squareup.kotlinpoet.LambdaTypeNameTest.HasSomeAnnotation kotlin.Int).() -> kotlin.Unit")
+  }
 
   @Test fun paramsWithAnnotationsForbidden() {
     assertThrows<IllegalArgumentException> {


### PR DESCRIPTION
Using a `LambdaTypeName` with a receiver type that has an annotation currently produces the following:

```
fun foo(init: @Marker MyType.() -> Unit)
```

I think it's useful to wrap it in parens so that the generated code is:

```
fun foo(init: (@Marker MyType).() -> Unit)
```