### PR TITLE
widen parameter type from ClassName to TypeName

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
@@ -52,7 +52,7 @@ class ParameterizedTypeName internal constructor(
   override fun withoutAnnotations()
       = ParameterizedTypeName(enclosingType, rawType, typeArguments, nullable)
 
-  fun plusParameter(typeArgument: ClassName) = ParameterizedTypeName(enclosingType, rawType,
+  fun plusParameter(typeArgument: TypeName) = ParameterizedTypeName(enclosingType, rawType,
       typeArguments + typeArgument, nullable, annotations)
 
   fun plusParameter(typeArgument: KClass<*>) = plusParameter(typeArgument.asClassName())


### PR DESCRIPTION
The parameter type of ClassName appears to be a copypasta typo.  This cleans that up.