### PR TITLE
Don't validate modifiers when emitting

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -21,7 +21,7 @@ import java.lang.reflect.Type
 import kotlin.reflect.KClass
 
 /** A generated property declaration.  */
-class PropertySpec private constructor(builder: Builder) {
+class PropertySpec internal constructor(builder: Builder) {
   val mutable = builder.mutable
   val name = builder.name
   val type = builder.type

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -17,11 +17,13 @@ package com.squareup.kotlinpoet
 
 import com.squareup.kotlinpoet.FunSpec.Companion.GETTER
 import com.squareup.kotlinpoet.FunSpec.Companion.SETTER
+import com.squareup.kotlinpoet.KModifier.Target.PROPERTY
+import com.squareup.kotlinpoet.KModifier.VARARG
 import java.lang.reflect.Type
 import kotlin.reflect.KClass
 
 /** A generated property declaration.  */
-class PropertySpec internal constructor(builder: Builder) {
+class PropertySpec private constructor(builder: Builder) {
   val mutable = builder.mutable
   val name = builder.name
   val type = builder.type
@@ -98,6 +100,15 @@ class PropertySpec internal constructor(builder: Builder) {
     }
   }
 
+  fun fromPrimaryConstructorParameter(parameter: ParameterSpec): PropertySpec {
+    val builder = toBuilder()
+        .addAnnotations(parameter.annotations)
+    builder.validate = false
+    builder.modifiers += parameter.modifiers
+
+    return builder.build()
+  }
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null) return false
@@ -125,6 +136,7 @@ class PropertySpec internal constructor(builder: Builder) {
   }
 
   class Builder internal constructor(internal val name: String, internal val type: TypeName) {
+    internal var validate = true
     internal var mutable = false
     internal val kdoc = CodeBlock.builder()
     internal var initializer: CodeBlock? = null
@@ -218,7 +230,7 @@ class PropertySpec internal constructor(builder: Builder) {
             "properties. You should mark either the getter, the setter, or both inline.")
       }
       for (it in modifiers) {
-        it.checkTarget(KModifier.Target.PROPERTY)
+            if (it == VARARG && validate) it.checkTarget(PROPERTY)
       }
       return PropertySpec(this)
     }

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -18,7 +18,6 @@ package com.squareup.kotlinpoet
 import com.squareup.kotlinpoet.FunSpec.Companion.GETTER
 import com.squareup.kotlinpoet.FunSpec.Companion.SETTER
 import com.squareup.kotlinpoet.KModifier.Target.PROPERTY
-import com.squareup.kotlinpoet.KModifier.VARARG
 import java.lang.reflect.Type
 import kotlin.reflect.KClass
 
@@ -103,7 +102,7 @@ class PropertySpec private constructor(builder: Builder) {
   fun fromPrimaryConstructorParameter(parameter: ParameterSpec): PropertySpec {
     val builder = toBuilder()
         .addAnnotations(parameter.annotations)
-    builder.validate = false
+    builder.isPrimaryConstructorParameter = true
     builder.modifiers += parameter.modifiers
 
     return builder.build()
@@ -136,7 +135,7 @@ class PropertySpec private constructor(builder: Builder) {
   }
 
   class Builder internal constructor(internal val name: String, internal val type: TypeName) {
-    internal var validate = true
+    internal var isPrimaryConstructorParameter = false
     internal var mutable = false
     internal val kdoc = CodeBlock.builder()
     internal var initializer: CodeBlock? = null
@@ -230,7 +229,7 @@ class PropertySpec private constructor(builder: Builder) {
             "properties. You should mark either the getter, the setter, or both inline.")
       }
       for (it in modifiers) {
-            if (validate) it.checkTarget(PROPERTY)
+            if (!isPrimaryConstructorParameter) it.checkTarget(PROPERTY)
       }
       return PropertySpec(this)
     }

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -230,7 +230,7 @@ class PropertySpec private constructor(builder: Builder) {
             "properties. You should mark either the getter, the setter, or both inline.")
       }
       for (it in modifiers) {
-            if (it == VARARG && validate) it.checkTarget(PROPERTY)
+            if (validate) it.checkTarget(PROPERTY)
       }
       return PropertySpec(this)
     }

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -99,7 +99,7 @@ class PropertySpec private constructor(builder: Builder) {
     }
   }
 
-  fun fromPrimaryConstructorParameter(parameter: ParameterSpec): PropertySpec {
+  internal fun fromPrimaryConstructorParameter(parameter: ParameterSpec): PropertySpec {
     val builder = toBuilder()
         .addAnnotations(parameter.annotations)
     builder.isPrimaryConstructorParameter = true

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -229,7 +229,7 @@ class PropertySpec private constructor(builder: Builder) {
             "properties. You should mark either the getter, the setter, or both inline.")
       }
       for (it in modifiers) {
-            if (!isPrimaryConstructorParameter) it.checkTarget(PROPERTY)
+          if (!isPrimaryConstructorParameter) it.checkTarget(PROPERTY)
       }
       return PropertySpec(this)
     }

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -285,10 +285,10 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
       val parameter = primaryConstructor.parameter(property.name) ?: continue
       if (parameter.type != property.type) continue
       if (CodeBlock.of("%N", parameter) != property.initializer) continue
-      result[property.name] = property.toBuilder()
-          .addAnnotations(parameter.annotations)
-          .addModifiers(*parameter.modifiers.toTypedArray())
-          .build()
+      val builder = property.toBuilder().addAnnotations(parameter.annotations)
+      builder.modifiers += parameter.modifiers
+
+      result[property.name] = PropertySpec(builder)
     }
     return result
   }

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -285,10 +285,8 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
       val parameter = primaryConstructor.parameter(property.name) ?: continue
       if (parameter.type != property.type) continue
       if (CodeBlock.of("%N", parameter) != property.initializer) continue
-      val builder = property.toBuilder().addAnnotations(parameter.annotations)
-      builder.modifiers += parameter.modifiers
 
-      result[property.name] = PropertySpec(builder)
+      result[property.name] = property.fromPrimaryConstructorParameter(parameter)
     }
     return result
   }

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -528,6 +528,22 @@ class TypeSpecTest {
         |""".trimMargin())
   }
 
+  @Test fun classesMayHaveVarargConstructorProperties() {
+    val variable = TypeSpec.classBuilder("Variable")
+        .primaryConstructor(FunSpec.constructorBuilder()
+            .addParameter(ParameterSpec.builder("name", String::class, VARARG).build())
+            .build())
+        .addProperty(PropertySpec.builder("name", String::class).initializer("name").build())
+        .build()
+    assertThat(toString(variable)).isEqualTo("""
+        |package com.squareup.tacos
+        |
+        |import kotlin.String
+        |
+        |class Variable(vararg val name: String)
+        |""".trimMargin())
+  }
+
   @Test fun enumConstantsRequired() {
     assertThrows<IllegalArgumentException> {
       TypeSpec.enumBuilder("Roshambo")


### PR DESCRIPTION
don't validate modifiers when copying parameter values to the transient property instances

fixes #457