### PR TITLE
Escape $ characters in formatted strings

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -93,6 +93,9 @@ internal fun stringLiteralWithQuotes(value: String): String {
       } else if (c == '\n') {
         // Add a '|' after newlines. This pipe will be removed by trimMargin().
         result.append("\n|")
+      } else if (c == '$') {
+        // Escape '$' symbols with ${'$'}.
+        result.append("\${\'\$\'}")
       } else {
         result.append(c)
       }
@@ -116,6 +119,11 @@ internal fun stringLiteralWithQuotes(value: String): String {
       // Trivial case: double quotes must be escaped.
       if (c == '\"') {
         result.append("\\\"")
+        continue
+      }
+      // Trivial case: $ signs must be escaped.
+      if (c == '$') {
+        result.append("\${\'\$\'}")
         continue
       }
       // Default case: just let character literal do its work.

--- a/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -195,7 +195,7 @@ class KotlinPoetTest {
         "class Taco {\n" +
         "    fun strings() {\n" +
         "        val a = \"basic string\"\n" +
-        "        val b = \"string with a \$ dollar sign\"\n" +
+        "        val b = \"string with a \${\'\$\'} dollar sign\"\n" +
         "    }\n" +
         "}\n")
   }
@@ -239,7 +239,7 @@ class KotlinPoetTest {
         "                |\"raw\"\n" +
         "                |string\n" +
         "                |with\n" +
-        "                |\$a interpolated value\n" +
+        "                |\${\'\$\'}a interpolated value\n" +
         "                \"\"\".trimMargin()\n" +
         "    }\n" +
         "}\n")

--- a/src/test/java/com/squareup/kotlinpoet/StringsTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/StringsTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.kotlinpoet
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class StringsTest {
+  @Test fun singleLineStringWithDollarSymbols() {
+    val stringWithTemplate = "$" + "annoyingUser" + " is annoying."
+    val funSpec = FunSpec.builder("getString")
+        .addStatement("return %S", stringWithTemplate)
+        .build()
+    assertThat(funSpec.toString())
+        .isEqualTo("fun getString() = \"\${\'\$\'}annoyingUser is annoying.\"\n")
+  }
+
+  @Test fun multilineStringWithDollarSymbols() {
+    val stringWithTemplate = "Some string\n" + "$" + "annoyingUser" + " is annoying."
+    val funSpec = FunSpec.builder("getString")
+        .addStatement("return %S", stringWithTemplate)
+        .build()
+    assertThat(funSpec.toString()).isEqualTo("fun getString() = \"\"\"\n" +
+        "|Some string\n" +
+        "|\${\'\$\'}annoyingUser is annoying.\n" +
+        "\"\"\".trimMargin()\n")
+  }
+}

--- a/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
@@ -60,7 +60,7 @@ class UtilTest {
   @Test fun stringLiteral() {
     stringLiteral("abc")
     stringLiteral("♦♥♠♣")
-    stringLiteral("€\\t@\\t$", "€\t@\t$")
+    stringLiteral("€\\t@\\t\${\'\$\'}", "€\t@\t$")
     assertThat(stringLiteralWithQuotes("abc();\ndef();"))
         .isEqualTo("\"\"\"\n|abc();\n|def();\n\"\"\".trimMargin()")
     stringLiteral("This is \\\"quoted\\\"!", "This is \"quoted\"!")


### PR DESCRIPTION
Partial solution to #439. This would at least escape $ characters properly, and we can follow-up with a new modifier that formats executable strings.