### PR TITLE
Add %V formatting character for typed literal values

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -200,7 +200,7 @@ class AnnotationSpec private constructor(builder: AnnotationSpec.Builder) {
             builder.addMember(member.build())
             continue
           }
-          member.add("%L", Builder.memberForValue(value))
+          member.add("%V", value)
           builder.addMember(member.build())
         }
         return builder.build()

--- a/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
@@ -324,6 +324,7 @@ class CodeBlock private constructor(
         'L' -> this.args += argToLiteral(arg)
         'S' -> this.args += argToString(arg)
         'T' -> this.args += argToType(arg)
+        'V' -> this.args += argToValue(arg)
         else -> throw IllegalArgumentException(
             String.format("invalid format string: '%s'", format))
       }
@@ -339,6 +340,8 @@ class CodeBlock private constructor(
     }
 
     private fun argToLiteral(o: Any?) = o
+
+    private fun argToValue(o: Any?) = o
 
     private fun argToString(o: Any?) = o?.toString()
 

--- a/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -79,7 +79,7 @@ private val Char.isIsoControl: Boolean
   }
 
 /** Returns the string literal representing `value`, including wrapping double quotes.  */
-internal fun stringLiteralWithQuotes(value: String): String {
+internal fun stringLiteralWithQuotes(value: String, escapeDollar: Boolean = false): String {
   if (value.contains("\n")) {
     val result = StringBuilder(value.length + 32)
     result.append("\"\"\"\n|")
@@ -93,6 +93,8 @@ internal fun stringLiteralWithQuotes(value: String): String {
       } else if (c == '\n') {
         // Add a '|' after newlines. This pipe will be removed by trimMargin().
         result.append("\n|")
+      } else if (escapeDollar && c == '$') {
+        result.append("\${'$'}")
       } else {
         result.append(c)
       }
@@ -116,6 +118,11 @@ internal fun stringLiteralWithQuotes(value: String): String {
       // Trivial case: double quotes must be escaped.
       if (c == '\"') {
         result.append("\\\"")
+        continue
+      }
+      // Trivial case: the dollar sign can start a string template and must be escaped.
+      if (escapeDollar && c == '$') {
+        result.append("\\$")
         continue
       }
       // Default case: just let character literal do its work.

--- a/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
@@ -217,10 +217,10 @@ class AnnotationSpecTest {
         |import kotlin.Float
         |
         |@AnnotationSpecTest.HasDefaultsAnnotation(
-        |        a = 5,
-        |        b = 6,
+        |        a = 5.toByte(),
+        |        b = 6.toShort(),
         |        c = 7,
-        |        d = 8,
+        |        d = 8L,
         |        e = 9.0f,
         |        f = 11.1,
         |        g = [

--- a/src/test/java/com/squareup/kotlinpoet/CodeBlockTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/CodeBlockTest.kt
@@ -442,4 +442,100 @@ class CodeBlockTest {
       |}
       |""".trimMargin())
   }
+
+  @Test fun booleanValue() =
+      assertThat(CodeBlock.of("%V", true).toString())
+          .isEqualTo("true")
+
+  @Test fun byteValue() =
+      assertThat(CodeBlock.of("%V", 8.toByte()).toString())
+          .isEqualTo("8.toByte()")
+
+  @Test fun shortValue() =
+      assertThat(CodeBlock.of("%V", 0x9E37.toShort()).toString())
+          .isEqualTo("-25033.toShort()")
+
+  @Test fun intValue() =
+      assertThat(CodeBlock.of("%V", 0xFA23).toString())
+          .isEqualTo("64035")
+
+  @Test fun longValue() = assertThat(CodeBlock.of("%V", 2L).toString()).isEqualTo("2L")
+
+  @Test fun charValue() = assertThat(CodeBlock.of("%V", 'h').toString()).isEqualTo("'h'")
+
+  @Test fun escapedCharValue() =
+      assertThat(CodeBlock.of("%V", '\\').toString())
+          .isEqualTo("""'\\'""")
+
+  @Test fun floatValue() = assertThat(CodeBlock.of("%V", 1f).toString()).isEqualTo("1.0f")
+
+  @Test fun doubleValue() = assertThat(CodeBlock.of("%V", 1.234).toString()).isEqualTo("1.234")
+
+  @Test fun classValue() =
+      assertThat(CodeBlock.of("%V", Test::class).toString())
+          .isEqualTo("org.junit.Test::class")
+
+  @Test fun enumValue() =
+      assertThat(CodeBlock.of("%V", AnnotationRetention.SOURCE).toString())
+          .isEqualTo("kotlin.annotation.AnnotationRetention.SOURCE")
+
+  @Test fun stringValue() =
+      assertThat(CodeBlock.of("%V", "My String with \$arg and \" escaped.").toString())
+          .isEqualTo(""""My String with \${'$'}arg and \" escaped."""")
+
+  @Test fun multiLineStringValue() =
+      assertThat(CodeBlock.of("%V", "A multi-lined string\nwith a \$var in it.").toString())
+          .isEqualTo("\"\"\"\n|A multi-lined string\n|with a \${'$'}var in it.\n\"\"\".trimMargin()")
+
+  @Test fun booleanArrayValue() =
+      assertThat(CodeBlock.of("%V", booleanArrayOf(true, true, false)).toString())
+          .isEqualTo("booleanArrayOf(true, true, false)")
+
+  @Test fun byteArrayValue() =
+      assertThat(CodeBlock.of("%V", byteArrayOf(1, 2, 3)).toString())
+          .isEqualTo("byteArrayOf(1, 2, 3)")
+
+  @Test fun shortArrayValue() =
+      assertThat(CodeBlock.of("%V", shortArrayOf(4, 5, 6)).toString())
+          .isEqualTo("shortArrayOf(4, 5, 6)")
+
+  @Test fun intArrayValue() =
+      assertThat(CodeBlock.of("%V", intArrayOf(7, 8, 9)).toString())
+          .isEqualTo("intArrayOf(7, 8, 9)")
+
+  @Test fun longArrayValue() =
+      assertThat(CodeBlock.of("%V", longArrayOf(10, 11, 12)).toString())
+          .isEqualTo("longArrayOf(10, 11, 12)")
+
+  @Test fun charArrayValue() =
+      assertThat(CodeBlock.of("%V", charArrayOf('A', 'b', '\n')).toString())
+          .isEqualTo("charArrayOf('A', 'b', '\\n')")
+
+  @Test fun floatArrayValue() =
+      assertThat(CodeBlock.of("%V", floatArrayOf(13f, 14.1f, 15.987f)).toString())
+          .isEqualTo("floatArrayOf(13.0f, 14.1f, 15.987f)")
+
+  @Test fun doubleArrayValue() =
+      assertThat(CodeBlock.of("%V", doubleArrayOf(16.0, -17.6, 18.987)).toString())
+          .isEqualTo("doubleArrayOf(16.0, -17.6, 18.987)")
+
+  @Test fun arrayOfNumbersValue() =
+      assertThat(CodeBlock.of("%V", arrayOf(1, -2L, 3.0, 4f, 5.toShort(), 6.toByte())).toString())
+          .isEqualTo("arrayOf(1, -2L, 3.0, 4.0f, 5.toShort(), 6.toByte())")
+
+  @Test fun emptyArrayValue() =
+      assertThat(CodeBlock.of("%V", emptyArray<String>()).toString())
+          .isEqualTo("arrayOf()")
+
+  @Test fun pairValueOfIntToShort() =
+      assertThat(CodeBlock.of("%V", 1 to 2.toShort()).toString())
+          .isEqualTo("1 to 2.toShort()")
+
+  @Test fun pairValueOfFloatToNull() =
+      assertThat(CodeBlock.of("%V", 3f to null).toString())
+          .isEqualTo("3.0f to null")
+
+  @Test fun pairValueOfCharToSpec() =
+      assertThat(CodeBlock.of("%V", 'A' to TypeSpec.anonymousClassBuilder().build()).toString())
+          .isEqualTo("'A' to object {\n}")
 }


### PR DESCRIPTION
Adds support for emitting the "value" of an object denoted by `%V`.

Using `%V` emits:
- `Byte` -> `v.toByte()`
- `Short` -> `v.toShort()`
- `Int` -> `v`
- `Long` -> `vL`
- `Char` -> `'v'` (escaped)
- ` Float` -> `vf`
- `Double` -> `v`
- `Class, KClass` -> `emitCode("%T::class", v)`
- `Enum` -> `emitCode("%T.%L", o.javaClass, o.name)`
- `String` -> `v` (fully escaped)
- `PrimitiveArray` -> `primitiveArrayOf(v...)`
- `Array` -> `arrayOf(v...)`
- `Pair` -> `emitCode("%V to %V", v.first, v.second)`

The range of types supported is restricted to types that cannot result in an ambiguous output, with unsupported types throwing an `UnsupportedOperationException` that the type is not supported.

The types have been restricted to primitive/simple types to easily allow future types and/or user-supplied "handlers" or what have you to be supported in the future without breaking previously generated code.

With `%V` the behaviour of `%S` can remain unchanged (allowing it to generate template strings etc.) (resolves #439).
