### PR TITLE
Shortcut functions

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/Shortcuts.kt
+++ b/src/main/java/com/squareup/kotlinpoet/Shortcuts.kt
@@ -1,0 +1,343 @@
+package com.squareup.kotlinpoet
+
+import java.lang.reflect.Type
+import javax.lang.model.element.ExecutableElement
+import javax.lang.model.type.DeclaredType
+import javax.lang.model.util.Types
+import kotlin.reflect.KClass
+
+/*
+ * Shortcuts for FileSpec
+ */
+
+fun fileSpec(
+  packageName: String,
+  fileName: String,
+  block: FileSpec.Builder.() -> Unit
+) = FileSpec.builder(packageName, fileName).apply(block).build()
+
+/*
+ * Shortcuts for adding TypeSpec to FileSpec
+ */
+
+fun FileSpec.Builder.classSpec(
+  name: String,
+  block: TypeSpec.Builder.() -> Unit
+): FileSpec.Builder =
+  addType(TypeSpec.classBuilder(name).apply(block).build())
+
+fun FileSpec.Builder.classSpec(
+  className: ClassName,
+  block: TypeSpec.Builder.() -> Unit
+): FileSpec.Builder =
+  addType(TypeSpec.classBuilder(className).apply(block).build())
+
+fun FileSpec.Builder.expectClassSpec(
+  name: String,
+  block: TypeSpec.Builder.() -> Unit
+): FileSpec.Builder =
+  addType(TypeSpec.expectClassBuilder(name).apply(block).build())
+
+fun FileSpec.Builder.expectClassSpec(
+  className: ClassName,
+  block: TypeSpec.Builder.() -> Unit
+): FileSpec.Builder =
+  addType(TypeSpec.expectClassBuilder(className).apply(block).build())
+
+fun FileSpec.Builder.objectSpec(
+  name: String,
+  block: TypeSpec.Builder.() -> Unit
+): FileSpec.Builder =
+  addType(TypeSpec.objectBuilder(name).apply(block).build())
+
+fun FileSpec.Builder.objectSpec(
+  className: ClassName,
+  block: TypeSpec.Builder.() -> Unit
+): FileSpec.Builder =
+  addType(TypeSpec.objectBuilder(className).apply(block).build())
+
+fun FileSpec.Builder.interfaceSpec(
+  name: String,
+  block: TypeSpec.Builder.() -> Unit
+): FileSpec.Builder =
+  addType(TypeSpec.interfaceBuilder(name).apply(block).build())
+
+fun FileSpec.Builder.interfaceSpec(
+  className: ClassName,
+  block: TypeSpec.Builder.() -> Unit
+): FileSpec.Builder =
+  addType(TypeSpec.interfaceBuilder(className).apply(block).build())
+
+fun FileSpec.Builder.enumSpec(
+  name: String,
+  block: TypeSpec.Builder.() -> Unit
+): FileSpec.Builder =
+  addType(TypeSpec.enumBuilder(name).apply(block).build())
+
+fun FileSpec.Builder.enumSpec(
+  className: ClassName,
+  block: TypeSpec.Builder.() -> Unit
+): FileSpec.Builder =
+  addType(TypeSpec.enumBuilder(className).apply(block).build())
+
+fun FileSpec.Builder.annotationSpec(
+  name: String,
+  block: TypeSpec.Builder.() -> Unit
+): FileSpec.Builder =
+  addType(TypeSpec.annotationBuilder(name).apply(block).build())
+
+fun FileSpec.Builder.annotationSpec(
+  className: ClassName,
+  block: TypeSpec.Builder.() -> Unit
+): FileSpec.Builder =
+  addType(TypeSpec.annotationBuilder(className).apply(block).build())
+
+
+/*
+ * Shortcuts for adding TypeSpec to TypeSpec
+ */
+
+fun TypeSpec.Builder.classSpec(
+  name: String,
+  block: TypeSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  addType(TypeSpec.classBuilder(name).apply(block).build())
+
+fun TypeSpec.Builder.classSpec(
+  className: ClassName,
+  block: TypeSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  addType(TypeSpec.classBuilder(className).apply(block).build())
+
+fun TypeSpec.Builder.expectClassSpec(
+  name: String,
+  block: TypeSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  addType(TypeSpec.expectClassBuilder(name).apply(block).build())
+
+fun TypeSpec.Builder.cxpectClassSpec(
+  className: ClassName,
+  block: TypeSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  addType(TypeSpec.expectClassBuilder(className).apply(block).build())
+
+fun TypeSpec.Builder.objectSpec(
+  name: String,
+  block: TypeSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  addType(TypeSpec.objectBuilder(name).apply(block).build())
+
+fun TypeSpec.Builder.objectSpec(
+  className: ClassName,
+  block: TypeSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  addType(TypeSpec.objectBuilder(className).apply(block).build())
+
+fun TypeSpec.Builder.interfaceSpec(
+  name: String,
+  block: TypeSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  addType(TypeSpec.interfaceBuilder(name).apply(block).build())
+
+fun TypeSpec.Builder.interfaceSpec(
+  className: ClassName,
+  block: TypeSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  addType(TypeSpec.interfaceBuilder(className).apply(block).build())
+
+fun TypeSpec.Builder.enumSpec(
+  name: String,
+  block: TypeSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  addType(TypeSpec.enumBuilder(name).apply(block).build())
+
+fun TypeSpec.Builder.enumSpec(
+  className: ClassName,
+  block: TypeSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  addType(TypeSpec.enumBuilder(className).apply(block).build())
+
+fun TypeSpec.Builder.annotationSpec(
+  name: String,
+  block: TypeSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  addType(TypeSpec.annotationBuilder(name).apply(block).build())
+
+fun TypeSpec.Builder.annotationSpec(
+  className: ClassName,
+  block: TypeSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  addType(TypeSpec.annotationBuilder(className).apply(block).build())
+
+/*
+ * Shortcuts for adding PropertySpec to FileSpec
+ */
+
+fun FileSpec.Builder.propertySpec(
+  name: String,
+  type: TypeName,
+  vararg modifiers: KModifier,
+  block: (PropertySpec.Builder.() -> Unit) = {}
+): FileSpec.Builder =
+  addProperty(
+    PropertySpec.builder(name, type, *modifiers)
+      .apply(block).build()
+  )
+
+fun FileSpec.Builder.propertySpec(
+  name: String,
+  type: Type,
+  vararg modifiers: KModifier,
+  block: (PropertySpec.Builder.() -> Unit) = {}
+): FileSpec.Builder =
+  addProperty(
+    PropertySpec.builder(name, type, *modifiers)
+      .apply(block).build()
+  )
+
+fun FileSpec.Builder.propertySpec(
+  name: String,
+  type: KClass<*>,
+  vararg modifiers: KModifier,
+  block: (PropertySpec.Builder.() -> Unit) = {}
+): FileSpec.Builder =
+  addProperty(
+    PropertySpec.builder(name, type, *modifiers)
+      .apply(block).build()
+  )
+
+/*
+ * Shortcuts for adding PropertySpec to TypeSpec
+ */
+
+fun TypeSpec.Builder.propertySpec(
+  name: String,
+  type: TypeName,
+  vararg modifiers: KModifier,
+  block: (PropertySpec.Builder.() -> Unit) = {}
+): TypeSpec.Builder =
+  addProperty(
+    PropertySpec.builder(name, type, *modifiers)
+      .apply(block).build()
+  )
+
+fun TypeSpec.Builder.propertySpec(
+  name: String,
+  type: Type,
+  vararg modifiers: KModifier,
+  block: (PropertySpec.Builder.() -> Unit) = {}
+): TypeSpec.Builder =
+  addProperty(
+    PropertySpec.builder(name, type, *modifiers)
+      .apply(block).build()
+  )
+
+fun TypeSpec.Builder.propertySpec(
+  name: String,
+  type: KClass<*>,
+  vararg modifiers: KModifier,
+  block: (PropertySpec.Builder.() -> Unit) = {}
+): TypeSpec.Builder =
+  addProperty(
+    PropertySpec.builder(name, type, *modifiers)
+      .apply(block).build()
+  )
+
+fun TypeSpec.Builder.varPropertySpec(
+  name: String,
+  type: TypeName,
+  vararg modifiers: KModifier,
+  block: (PropertySpec.Builder.() -> Unit) = {}
+): TypeSpec.Builder =
+  addProperty(
+    PropertySpec.builder(name, type, *modifiers)
+      .mutable(true)
+      .apply(block).build()
+  )
+
+fun TypeSpec.Builder.varPropertySpec(
+  name: String,
+  type: Type,
+  vararg modifiers: KModifier,
+  block: (PropertySpec.Builder.() -> Unit) = {}
+): TypeSpec.Builder =
+  addProperty(
+    PropertySpec.builder(name, type, *modifiers)
+      .mutable(true)
+      .apply(block).build()
+  )
+
+fun TypeSpec.Builder.varPropertySpec(
+  name: String,
+  type: KClass<*>,
+  vararg modifiers: KModifier,
+  block: (PropertySpec.Builder.() -> Unit) = {}
+): TypeSpec.Builder =
+  addProperty(
+    PropertySpec.builder(name, type, *modifiers)
+      .mutable(true)
+      .apply(block).build()
+  )
+
+/*
+ * Shortcuts for adding FunctionSpec to FileSpec
+ */
+
+fun FileSpec.Builder.funSpec(
+  name: String,
+  block: FunSpec.Builder.() -> Unit
+): FileSpec.Builder =
+  addFunction(FunSpec.builder(name).apply(block).build())
+
+/*
+ * Shortcuts for adding FunctionSpec to TypeSpec
+ */
+
+fun TypeSpec.Builder.funSpec(
+  name: String,
+  block: FunSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  addFunction(FunSpec.builder(name).apply(block).build())
+
+fun TypeSpec.Builder.primaryConstructorSpec(
+  block: FunSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  primaryConstructor(FunSpec.constructorBuilder().apply(block).build())
+
+fun TypeSpec.Builder.nonPrimaryConstructorSpec(
+  block: FunSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  addFunction(FunSpec.constructorBuilder().apply(block).build())
+
+fun TypeSpec.Builder.overridingSpec(
+  method: ExecutableElement,
+  block: FunSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  addFunction(FunSpec.overriding(method).apply(block).build())
+
+fun TypeSpec.Builder.overridingSpec(
+  method: ExecutableElement,
+  enclosing: DeclaredType,
+  types: Types,
+  block: FunSpec.Builder.() -> Unit
+): TypeSpec.Builder =
+  addFunction(
+    FunSpec.overriding(
+      method, enclosing, types
+    ).apply(block).build()
+  )
+
+/*
+ * Shortcuts for using Function Spec as setter or getter
+ */
+
+fun PropertySpec.Builder.setterSpec(
+  block: FunSpec.Builder.() -> Unit
+): PropertySpec.Builder =
+  setter(FunSpec.setterBuilder().apply(block).build())
+
+fun PropertySpec.Builder.getterSpec(
+  block: FunSpec.Builder.() -> Unit
+): PropertySpec.Builder =
+  getter(FunSpec.getterBuilder().apply(block).build())
+

--- a/src/test/java/com/squareup/kotlinpoet/ShortcutsTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/ShortcutsTest.kt
@@ -1,0 +1,99 @@
+package com.squareup.kotlinpoet
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.kotlinpoet.KModifier.INTERNAL
+import java.time.Period
+import kotlin.test.Test
+
+
+class ShortcutsTest {
+
+  @Test
+  fun fullFileSpec() {
+    val classic =
+      FileSpec.Builder("com.squareup.kotlinpoet.test", "FooBar")
+        .apply {
+          addProperty(
+            PropertySpec.builder(
+              "foo", String::class, INTERNAL
+            ).build()
+          )
+
+          addType(
+            TypeSpec.classBuilder("FooClass")
+              .primaryConstructor(FunSpec.constructorBuilder()
+                .addCode("println(\"Hello World\")")
+                .build())
+
+              .addProperty(PropertySpec.builder("foo", String::class, INTERNAL)
+                .initializer("\"the foo\"")
+                .mutable(true)
+                .build())
+
+              .addProperty(PropertySpec.builder("foobar", String::class)
+                .getter(FunSpec.getterBuilder()
+                  .addCode("return \"\${foo}bar\"")
+                  .build())
+                .build())
+
+              .addFunction(FunSpec.builder("dooTheFooBar")
+                .returns(Int::class.asTypeName().asNullable())
+                .addParameter("howLong", Period::class, INTERNAL)
+                .addCode("println(\"\$foobar\")")
+                .build())
+
+              .build()
+          )
+
+          addType(
+            TypeSpec.interfaceBuilder("FooInterface")
+              .addFunction(FunSpec.builder("calcMagicNumber")
+                .returns(Long::class)
+                .addCode("return 42L")
+                .build())
+              .build()
+          )
+
+          addType(
+            TypeSpec.objectBuilder("FooObject").build()
+          )
+        }.build()
+
+    val shortcuts = fileSpec("com.squareup.kotlinpoet.test", "FooBar") {
+      propertySpec("foo", String::class, INTERNAL)
+
+      classSpec("FooClass") {
+        primaryConstructorSpec {
+          addCode("println(\"Hello World\")")
+        }
+
+        varPropertySpec("foo", String::class, INTERNAL) {
+          initializer("\"the foo\"")
+        }
+
+        propertySpec("foobar", String::class) {
+          getterSpec { addCode("return \"\${foo}bar\"") }
+        }
+
+        funSpec("dooTheFooBar") {
+          returns(Int::class.asTypeName().asNullable())
+          addParameter("howLong", Period::class, INTERNAL)
+          addCode("println(\"\$foobar\")")
+        }
+      }
+
+      interfaceSpec("FooInterface") {
+        funSpec("calcMagicNumber") {
+          returns(Long::class)
+          addCode("return 42L")
+        }
+      }
+
+      objectSpec("FooObject") {
+
+      }
+    }
+
+    assertThat(shortcuts).isEqualTo(classic)
+  }
+}


### PR DESCRIPTION
For my own Project, I created these shortcuts for many of *kotlinpoet*s builders and I like to share them.

pros for usercode:
- will be less cluttered
- less lines
- less indentations, therefore less space taken by indentation
- correct builders are selected automatically (i.e. `FunSpec.constructorBuilder(...)` for `TypeSpec.primaryConstructor(...)`, `FunSpec.getterBuilder(...)` for `PropertySpec.getter(...)` etc...

I also added a Test which is also a small demonstration.

Shortcuts I didn't use are missing, i.e. for `TypeAliasSpec`.

Here's a preview snipped taken from the testclass:

```kotlin
fileSpec("com.squareup.kotlinpoet.test", "FooBar") {
  propertySpec("foo", String::class, INTERNAL)

  classSpec("FooClass") {
    primaryConstructorSpec {
      addCode("println(\"Hello World\")")
    }

    varPropertySpec("foo", String::class, INTERNAL) {
      initializer("\"the foo\"")
    }

    propertySpec("foobar", String::class) {
      getterSpec { addCode("return \"\${foo}bar\"") }
    }

    funSpec("dooTheFooBar") {
      returns(Int::class.asTypeName().asNullable())
      addParameter("howLong", Period::class, INTERNAL)
      addCode("println(\"\$foobar\")")
    }
  }

  interfaceSpec("FooInterface") {
    funSpec("calcMagicNumber") {
      returns(Long::class)
      addCode("return 42L")
    }
  }

  objectSpec("FooObject") {
  }
}
```