### PR TITLE
FileSpec.Builder blank package and subfolder fix

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -73,8 +73,9 @@ class FileSpec private constructor(builder: FileSpec.Builder) {
       for (packageComponent in packageName.split('.').dropLastWhile { it.isEmpty() }) {
         outputDirectory = outputDirectory.resolve(packageComponent)
       }
-      Files.createDirectories(outputDirectory)
     }
+    
+    Files.createDirectories(outputDirectory)
 
     val outputPath = outputDirectory.resolve("$name.kt")
     OutputStreamWriter(Files.newOutputStream(outputPath), UTF_8).use { writer -> writeTo(writer) }

--- a/src/test/java/com/squareup/kotlinpoet/FileWritingTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FileWritingTest.kt
@@ -62,6 +62,14 @@ class FileWritingTest {
     assertThat(Files.exists(testPath)).isTrue()
   }
 
+  @Test fun pathDefaultPackageWithSubdirectory() {
+    val type = TypeSpec.classBuilder("Test").build()
+    FileSpec.get("", type).writeTo(fsRoot.resolve("sub"))
+
+    val testPath = fsRoot.resolve("sub/Test.kt")
+    assertThat(Files.exists(testPath)).isTrue()
+  }
+
   @Test fun fileDefaultPackage() {
     val type = TypeSpec.classBuilder("Test").build()
     FileSpec.get("", type).writeTo(tmp.root)


### PR DESCRIPTION
When creating files in subfolders, these are not created if no package is specified. This problem also described in #499 was fixed by changing the code so that missing directories are always created.
I also added a test for this kind of situation.