### PR TITLE
Return KDoc follow up

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -33,7 +33,7 @@ import kotlin.reflect.KClass
 class FunSpec private constructor(builder: Builder) {
   val name = builder.name
   val kdoc = builder.kdoc.build()
-  val returnKdoc = builder.returnKdoc.build()
+  val returnKdoc = builder.returnKdoc
   val annotations = builder.annotations.toImmutableList()
   val modifiers = builder.modifiers.toImmutableSet()
   val typeVariables = builder.typeVariables.toImmutableList()
@@ -146,7 +146,9 @@ class FunSpec private constructor(builder: Builder) {
           add("@param %L %L\n", parameterSpec.name, parameterSpec.kdoc)
         }
       }
-      add(returnKdoc)
+      if (returnKdoc.isNotEmpty()) {
+        add("@return %L\n", returnKdoc)
+      }
       build()
     }
   }
@@ -171,6 +173,7 @@ class FunSpec private constructor(builder: Builder) {
   fun toBuilder(): Builder {
     val builder = Builder(name)
     builder.kdoc.add(kdoc)
+    builder.returnKdoc = returnKdoc
     builder.annotations += annotations
     builder.modifiers += modifiers
     builder.typeVariables += typeVariables
@@ -185,7 +188,7 @@ class FunSpec private constructor(builder: Builder) {
 
   class Builder internal constructor(internal val name: String) {
     internal val kdoc = CodeBlock.builder()
-    internal val returnKdoc = CodeBlock.builder()
+    internal var returnKdoc = CodeBlock.EMPTY
     internal var receiverType: TypeName? = null
     internal var returnType: TypeName? = null
     internal var delegateConstructor: String? = null
@@ -270,7 +273,7 @@ class FunSpec private constructor(builder: Builder) {
       check(!name.isConstructor && !name.isAccessor) { "$name cannot have a return type" }
       this.returnType = returnType
       kdoc?.let {
-        this.returnKdoc.add("@return %L\n", it)
+        this.returnKdoc = it
       }
     }
 

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -221,6 +221,22 @@ class FunSpecTest {
       |fun foo(string: kotlin.String, nodoc: kotlin.Boolean): kotlin.String = "foo"""".trimMargin())
   }
 
+  @Test fun functionWithModifiedReturnKdoc() {
+    val funSpec = FunSpec.builder("foo")
+        .addParameter(ParameterSpec.builder("nodoc", Boolean::class).build())
+        .returns(String::class, "the foo.")
+        .addCode(CodeBlock.of("return \"foo\""))
+        .build()
+        .toBuilder()
+        .returns(String::class, "the modified foo.")
+        .build()
+    assertThat(funSpec.toString()).isEqualTo("""
+      |/**
+      | * @return the modified foo.
+      | */
+      |fun foo(nodoc: kotlin.Boolean): kotlin.String = "foo"""".trimMargin())
+  }
+
   @Test fun functionParamNoLambdaParam() {
     val unitType = UNIT
     val funSpec = FunSpec.builder("foo")

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -211,7 +211,7 @@ class FunSpecTest {
             .build())
         .addParameter(ParameterSpec.builder("nodoc", Boolean::class).build())
         .returns(String::class, "the foo.")
-        .addCode(CodeBlock.of("return \"foo\""))
+        .addCode("return %S", "foo")
         .build()
     assertThat(funSpec.toString()).isEqualTo("""
       |/**
@@ -223,9 +223,9 @@ class FunSpecTest {
 
   @Test fun functionWithModifiedReturnKdoc() {
     val funSpec = FunSpec.builder("foo")
-        .addParameter(ParameterSpec.builder("nodoc", Boolean::class).build())
+        .addParameter("nodoc", Boolean::class)
         .returns(String::class, "the foo.")
-        .addCode(CodeBlock.of("return \"foo\""))
+        .addCode("return %S", "foo")
         .build()
         .toBuilder()
         .returns(String::class, "the modified foo.")


### PR DESCRIPTION
There were some subtle bugs with the initial implementation of adding KDoc to `returns()`. 
1. This fixes the bug where `toBuilder()` wouldn't have the Kdoc associated with the return type.
2. Have moved the `returnKdoc` to only have the description and not the `@return` keyword as well. We only add the `@return` on emission. 
3. To accurately model `returns`, we now just replace the Kdoc given in the `returns()` method instead of appending to the `returnKdoc` CodeBlock. This makes more sense since if you do `toBuilder()` and then change the return type, the newer Kdoc should replace the older one and not append to it. 