### PR TITLE
Add support for receiver kdoc

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -266,19 +266,17 @@ class FunSpec private constructor(builder: Builder) {
       typeVariables += typeVariable
     }
 
-    @JvmOverloads fun receiver(receiverType: TypeName, kdoc: CodeBlock? = null) = apply {
+    @JvmOverloads fun receiver(receiverType: TypeName, kdoc: CodeBlock = CodeBlock.EMPTY) = apply {
       check(!name.isConstructor) { "$name cannot have receiver type" }
       this.receiverType = receiverType
-      kdoc?.let {
-        receiverKdoc = it
-      }
+      this.receiverKdoc = kdoc
     }
 
-    @JvmOverloads fun receiver(receiverType: Type, kdoc: CodeBlock? = null) = receiver(receiverType.asTypeName(), kdoc)
+    @JvmOverloads fun receiver(receiverType: Type, kdoc: CodeBlock = CodeBlock.EMPTY) = receiver(receiverType.asTypeName(), kdoc)
 
     fun receiver(receiverType: Type, kdoc: String, vararg args: Any) = receiver(receiverType, CodeBlock.of(kdoc, args))
 
-    @JvmOverloads fun receiver(receiverType: KClass<*>, kdoc: CodeBlock? = null) = receiver(receiverType.asTypeName(), kdoc)
+    @JvmOverloads fun receiver(receiverType: KClass<*>, kdoc: CodeBlock = CodeBlock.EMPTY) = receiver(receiverType.asTypeName(), kdoc)
 
     fun receiver(receiverType: KClass<*>, kdoc: String, vararg args: Any) = receiver(receiverType, CodeBlock.of(kdoc, args))
 

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -478,7 +478,7 @@ class FunSpecTest {
 
   @Test fun receiverWithKdoc() {
     val funSpec = FunSpec.builder("toBar")
-        .receiver(String::class, "the string to transform.")
+        .receiver(String::class, kdoc = "the string to transform.")
         .returns(String::class)
         .addCode(CodeBlock.of("return %S", "bar"))
         .build()
@@ -487,13 +487,14 @@ class FunSpecTest {
       |/**
       | * @receiver the string to transform.
       | */
-      |fun kotlin.String.toBar(): kotlin.String = "bar"""".trimMargin())
+      |fun kotlin.String.toBar(): kotlin.String = "bar"
+      """.trimMargin())
   }
 
   @Test fun withAllKdocTags() {
     val funSpec = FunSpec.builder("charAt")
-        .receiver(String::class, "the string you want the char from.")
-        .returns(Char::class, "The char at the given [position].")
+        .receiver(String::class, kdoc = "the string you want the char from.")
+        .returns(Char::class, kdoc = "The char at the given [position].")
         .addParameter(ParameterSpec.builder("position", Int::class)
             .addKdoc("the index of the character that is returned.")
             .build())
@@ -510,7 +511,7 @@ class FunSpecTest {
       | * @return The char at the given [position].
       | */
       |fun kotlin.String.charAt(position: kotlin.Int): kotlin.Char = -1
-    """.trimMargin())
+      """.trimMargin())
   }
 
   @Test fun constructorBuilderEqualityTest() {

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -476,6 +476,43 @@ class FunSpecTest {
     assertThat(funSpec.toBuilder().build()).isEqualTo(funSpec);
   }
 
+  @Test fun receiverWithKdoc() {
+    val funSpec = FunSpec.builder("toBar")
+        .receiver(String::class, "the string to transform.")
+        .returns(String::class)
+        .addCode(CodeBlock.of("return %S", "bar"))
+        .build()
+
+    assertThat(funSpec.toString()).isEqualTo("""
+      |/**
+      | * @receiver the string to transform.
+      | */
+      |fun kotlin.String.toBar(): kotlin.String = "bar"""".trimMargin())
+  }
+
+  @Test fun withAllKdocTags() {
+    val funSpec = FunSpec.builder("charAt")
+        .receiver(String::class, "the string you want the char from.")
+        .returns(Char::class, "The char at the given [position].")
+        .addParameter(ParameterSpec.builder("position", Int::class)
+            .addKdoc("the index of the character that is returned.")
+            .build())
+        .addKdoc("Returns the character at the given [position].\n\n")
+        .addCode(CodeBlock.of("return -1"))
+        .build()
+
+    assertThat(funSpec.toString()).isEqualTo("""
+      |/**
+      | * Returns the character at the given [position].
+      | *
+      | * @receiver the string you want the char from.
+      | * @param position the index of the character that is returned.
+      | * @return The char at the given [position].
+      | */
+      |fun kotlin.String.charAt(position: kotlin.Int): kotlin.Char = -1
+    """.trimMargin())
+  }
+
   @Test fun constructorBuilderEqualityTest() {
     val funSpec = FunSpec.constructorBuilder()
         .addParameter("list", List::class.parameterizedBy(Int::class))


### PR DESCRIPTION
Adds support for adding a kdoc to the receiver. The order of the Kdoc tags are according to the [Android Kotlin Style Guide](https://developer.android.com/kotlin/style-guide).

Resolves #509 