### PR TITLE
Avoid emitting "Unit" as return type

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -125,7 +125,8 @@ class FunSpec private constructor(builder: Builder) {
       param.emit(codeWriter, includeType = name != SETTER)
     }
 
-    if (returnType != null) {
+    // Omit emitting "Unit" for redundancy.
+    if (returnType != null && returnType != Unit::class.asTypeName()) {
       codeWriter.emitCode(": %T", returnType)
     }
 

--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -125,8 +125,7 @@ class FunSpec private constructor(builder: Builder) {
       param.emit(codeWriter, includeType = name != SETTER)
     }
 
-    // Omit emitting "Unit" for redundancy.
-    if (returnType != null && returnType != Unit::class.asTypeName()) {
+    if (emitReturnType(returnType)) {
       codeWriter.emitCode(": %T", returnType)
     }
 
@@ -152,6 +151,26 @@ class FunSpec private constructor(builder: Builder) {
       }
       build()
     }
+  }
+
+  /**
+   * Returns whether we should emit the return type for given [returnType].
+   *
+   * For return types like [Unit], we can omit emitting the return type, only
+   * if it's not a single expression body.
+   * If it is a single expression body, we want to emit [Unit] so that any type
+   * change in the delegated function doesn't inadvertently carry over to the
+   * delegating function.
+   */
+  private fun emitReturnType(returnType: TypeName?): Boolean {
+    if (returnType != null) {
+      return returnType != Unit::class.asTypeName() || isExpressionBody()
+    }
+    return false
+  }
+
+  private fun isExpressionBody(): Boolean {
+    return body.trim().withoutPrefix(EXPRESSION_BODY_PREFIX) != null
   }
 
   override fun equals(other: Any?): Boolean {

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -158,7 +158,7 @@ class FunSpecTest {
       |""".trimMargin())
   }
 
-  @Test fun returnsUnit() {
+  @Test fun returnsUnitWithoutExpressionBody() {
     val funSpec = FunSpec.builder("foo")
         .returns(Unit::class)
         .build()
@@ -167,6 +167,17 @@ class FunSpecTest {
       |fun foo() {
       |}
       |""".trimMargin())
+  }
+
+  @Test fun returnsUnitWithExpressionBody() {
+    val funSpec = FunSpec.builder("foo")
+        .returns(Unit::class)
+        .addCode(CodeBlock.of("return bar()"))
+        .build()
+
+    assertThat(funSpec.toString()).isEqualTo("""
+      |fun foo(): kotlin.Unit = bar()
+      """.trimMargin())
   }
 
   @Test fun functionParamWithKdoc() {

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -158,6 +158,17 @@ class FunSpecTest {
       |""".trimMargin())
   }
 
+  @Test fun returnsUnit() {
+    val funSpec = FunSpec.builder("foo")
+        .returns(Unit::class)
+        .build()
+
+    assertThat(funSpec.toString()).isEqualTo("""
+      |fun foo() {
+      |}
+      |""".trimMargin())
+  }
+
   @Test fun functionParamWithKdoc() {
     val funSpec = FunSpec.builder("foo")
         .addParameter(ParameterSpec.builder("string", String::class.asTypeName())

--- a/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -355,7 +355,7 @@ class KotlinPoetTest {
       |import kotlin.String
       |import kotlin.Unit
       |
-      |fun ((name: String) -> Unit).whatever() = Unit
+      |fun ((name: String) -> Unit).whatever(): Unit = Unit
       |""".trimMargin())
   }
 
@@ -384,7 +384,7 @@ class KotlinPoetTest {
       |    name: String,
       |    Int,
       |    age: Long
-      |) -> Unit).whatever() = Unit
+      |) -> Unit).whatever(): Unit = Unit
       |""".trimMargin())
   }
 

--- a/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -355,7 +355,7 @@ class KotlinPoetTest {
       |import kotlin.String
       |import kotlin.Unit
       |
-      |fun ((name: String) -> Unit).whatever(): Unit = Unit
+      |fun ((name: String) -> Unit).whatever() = Unit
       |""".trimMargin())
   }
 
@@ -384,7 +384,7 @@ class KotlinPoetTest {
       |    name: String,
       |    Int,
       |    age: Long
-      |) -> Unit).whatever(): Unit = Unit
+      |) -> Unit).whatever() = Unit
       |""".trimMargin())
   }
 


### PR DESCRIPTION
In accordance with the Kotlin [coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#avoiding-redundant-constructs), we can safely omit emitting the "Unit" class when it's used as a return type. 

I'm not aware of any other wildcards like "Unit", hence just the single exclusion. If you know of any, I can make the check more general. 