### PR TITLE
Default to CodeBlock.Empty for return kdoc

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -280,7 +280,7 @@ class FunSpec private constructor(builder: Builder) {
 
     fun receiver(receiverType: KClass<*>, kdoc: String, vararg args: Any) = receiver(receiverType, CodeBlock.of(kdoc, args))
 
-    @JvmOverloads fun returns(returnType: TypeName, kdoc: CodeBlock? = null) = apply {
+    @JvmOverloads fun returns(returnType: TypeName, kdoc: CodeBlock = CodeBlock.EMPTY) = apply {
       check(!name.isConstructor && !name.isAccessor) { "$name cannot have a return type" }
       this.returnType = returnType
       kdoc?.let {
@@ -288,11 +288,11 @@ class FunSpec private constructor(builder: Builder) {
       }
     }
 
-    @JvmOverloads fun returns(returnType: Type, kdoc: CodeBlock? = null) = returns(returnType.asTypeName(), kdoc)
+    @JvmOverloads fun returns(returnType: Type, kdoc: CodeBlock = CodeBlock.EMPTY) = returns(returnType.asTypeName(), kdoc)
 
     fun returns(returnType: Type, kdoc: String, vararg args: Any) = returns(returnType.asTypeName(), CodeBlock.of(kdoc, args))
 
-    @JvmOverloads fun returns(returnType: KClass<*>, kdoc: CodeBlock? = null) = returns(returnType.asTypeName(), kdoc)
+    @JvmOverloads fun returns(returnType: KClass<*>, kdoc: CodeBlock = CodeBlock.EMPTY) = returns(returnType.asTypeName(), kdoc)
 
     fun returns(returnType: KClass<*>, kdoc: String, vararg args: Any)
         = returns(returnType.asTypeName(), CodeBlock.of(kdoc, args))

--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -283,9 +283,7 @@ class FunSpec private constructor(builder: Builder) {
     @JvmOverloads fun returns(returnType: TypeName, kdoc: CodeBlock = CodeBlock.EMPTY) = apply {
       check(!name.isConstructor && !name.isAccessor) { "$name cannot have a return type" }
       this.returnType = returnType
-      kdoc?.let {
-        this.returnKdoc = it
-      }
+      this.returnKdoc = kdoc
     }
 
     @JvmOverloads fun returns(returnType: Type, kdoc: CodeBlock = CodeBlock.EMPTY) = returns(returnType.asTypeName(), kdoc)

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -210,7 +210,7 @@ class FunSpecTest {
             .addKdoc("A string parameter.")
             .build())
         .addParameter(ParameterSpec.builder("nodoc", Boolean::class).build())
-        .returns(String::class, "the foo.")
+        .returns(String::class,  kdoc = "the foo.")
         .addCode("return %S", "foo")
         .build()
     assertThat(funSpec.toString()).isEqualTo("""
@@ -224,11 +224,11 @@ class FunSpecTest {
   @Test fun functionWithModifiedReturnKdoc() {
     val funSpec = FunSpec.builder("foo")
         .addParameter("nodoc", Boolean::class)
-        .returns(String::class, "the foo.")
+        .returns(String::class, kdoc = "the foo.")
         .addCode("return %S", "foo")
         .build()
         .toBuilder()
-        .returns(String::class, "the modified foo.")
+        .returns(String::class, kdoc = "the modified foo.")
         .build()
     assertThat(funSpec.toString()).isEqualTo("""
       |/**


### PR DESCRIPTION
This avoids letting consumers pass null and lets us avoid the null check