### PR TITLE
Add checks for inline classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <maven.javadoc.skip>true</maven.javadoc.skip><!-- We use Dokka instead. -->
 
     <java.version>1.7</java.version>
-    <kotlin.version>1.2.71</kotlin.version>
+    <kotlin.version>1.3.0</kotlin.version>
     <dokka.version>0.9.17</dokka.version>
     <junit.version>4.12</junit.version>
     <truth.version>0.40</truth.version>

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -476,7 +476,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
 
         if (isInlineClass) {
           check(primaryConstructor.parameters.size == 1) {
-            "Inline class can only have 1 parameter in constructor"
+            "Inline class must have 1 parameter in constructor"
           }
         }
       }

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -476,7 +476,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
 
         if (isInlineClass) {
           check(primaryConstructor.parameters.size == 1) {
-            "Inline class must have 1 parameter in constructor"
+            "Inline classes must have 1 parameter in constructor"
           }
         }
       }
@@ -503,7 +503,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
         "$kind can't have initializer blocks"
       }
       check(!isInlineClass) {
-        "Inline class can't have initializer blocks"
+        "Inline classes can't have initializer blocks"
       }
       check(EXPECT !in kind.modifiers) {
         "expect $kind can't have initializer blocks"
@@ -671,28 +671,31 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
 
       if (isInlineClass) {
         primaryConstructor?.let {
-          // Inline classes only have 1 constructor parameter
           check(it.parameters.size == 1) {
-            "Inline class must have 1 parameter in constructor"
+            "Inline classes must have 1 parameter in constructor"
           }
-          // Inline class must have public primary constructor
           check(PRIVATE !in it.modifiers && INTERNAL !in it.modifiers) {
-            "Inline class must have a public primary constructor"
+            "Inline classes must have a public primary constructor"
           }
         }
-        // Inline classes can only have 1 backing property
-        check(propertySpecs.size == 1) {
-          "Inline class must have a single read-only (val) property."
+
+        check(propertySpecs.size > 0) {
+          "Inline classes must have at least 1 property"
         }
-        // Inline classes property must be immutable.
-        check(!propertySpecs.first().mutable) {
-          "Inline class must have a single read-only (val) property."
+
+        val constructorParamName = primaryConstructor?.parameters?.firstOrNull()?.name
+        constructorParamName?.let { paramName ->
+          val underlyingProperty = propertySpecs.find { it.name == paramName }
+          requireNotNull(underlyingProperty) {
+            "Inline classes must have a single read-only (val) property parameter."
+          }
+          check(!underlyingProperty.mutable) {
+            "Inline classes must have a single read-only (val) property parameter."
+          }
         }
-        // Inline class cannot have init blocks
         check(initializerBlock.isEmpty()) {
-          "Inline class can't have initializer blocks"
+          "Inline classes can't have initializer blocks"
         }
-        // Inline class cannot have super class
         check(superclass == Any::class.asTypeName()) {
           "Inline classes cannot have super classes"
         }

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -1778,8 +1778,11 @@ class TypeSpecTest {
           .primaryConstructor(FunSpec.constructorBuilder()
               .addParameter("avacado", String::class)
               .build())
-          .addModifiers(INLINE)
+          .addProperty(PropertySpec.builder("avacado", String::class)
+              .initializer("avacado")
+              .build())
           .addInitializerBlock(CodeBlock.EMPTY)
+          .addModifiers(INLINE)
           .build()
     }.hasMessageThat().isEqualTo("Inline class can't have initializer blocks")
   }
@@ -1792,8 +1795,11 @@ class TypeSpecTest {
           .primaryConstructor(FunSpec.constructorBuilder()
               .addParameter("avacado", String::class)
               .build())
-          .addModifiers(INLINE)
+          .addProperty(PropertySpec.builder("avacado", String::class)
+              .initializer("avacado")
+              .build())
           .superclass(InlineSuperClass::class)
+          .addModifiers(INLINE)
           .build()
     }.hasMessageThat().isEqualTo("Inline classes cannot have super classes")
   }
@@ -1808,8 +1814,8 @@ class TypeSpecTest {
         .addProperty(PropertySpec.builder("avacado", String::class)
             .initializer("avacado")
             .build())
-        .addModifiers(INLINE)
         .addSuperinterface(InlineSuperInterface::class)
+        .addModifiers(INLINE)
         .build()
 
     assertThat(guacamole.toString()).isEqualTo("""
@@ -1826,7 +1832,7 @@ class TypeSpecTest {
               .build())
           .addModifiers(INLINE)
           .build()
-    }.hasMessageThat().isEqualTo("Inline class can only have 1 parameter in constructor")
+    }.hasMessageThat().isEqualTo("Inline class must have 1 parameter in constructor")
   }
 
   @Test fun inlineClassWithoutProperties() {
@@ -1837,7 +1843,7 @@ class TypeSpecTest {
               .build())
           .addModifiers(INLINE)
           .build()
-    }.hasMessageThat().isEqualTo("Inline class can only have 1 property")
+    }.hasMessageThat().isEqualTo("Inline class must have a single read-only (val) property.")
   }
 
   @Test fun inlineClassWithMutableProperties() {
@@ -1853,6 +1859,21 @@ class TypeSpecTest {
           .addModifiers(INLINE)
           .build()
     }.hasMessageThat().isEqualTo("Inline class must have a single read-only (val) property.")
+  }
+
+  @Test fun inlineClassWithPrivateConstructor() {
+    assertThrows<IllegalStateException> {
+      TypeSpec.classBuilder("Guacamole")
+          .primaryConstructor(FunSpec.constructorBuilder()
+              .addParameter("avacado", String::class)
+              .addModifiers(PRIVATE)
+              .build())
+          .addProperty(PropertySpec.builder("avacado", String::class)
+              .initializer("avacado")
+              .build())
+          .addModifiers(INLINE)
+          .build()
+    }.hasMessageThat().isEqualTo("Inline class must have a public primary constructor")
   }
 
   @Test fun inlineEnumClass() {

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -1784,7 +1784,7 @@ class TypeSpecTest {
           .addInitializerBlock(CodeBlock.EMPTY)
           .addModifiers(INLINE)
           .build()
-    }.hasMessageThat().isEqualTo("Inline class can't have initializer blocks")
+    }.hasMessageThat().isEqualTo("Inline classes can't have initializer blocks")
   }
 
   class InlineSuperClass
@@ -1793,10 +1793,10 @@ class TypeSpecTest {
     assertThrows<IllegalStateException> {
       TypeSpec.classBuilder("Guacamole")
           .primaryConstructor(FunSpec.constructorBuilder()
-              .addParameter("avacado", String::class)
+              .addParameter("avocado", String::class)
               .build())
-          .addProperty(PropertySpec.builder("avacado", String::class)
-              .initializer("avacado")
+          .addProperty(PropertySpec.builder("avocado", String::class)
+              .initializer("avocado")
               .build())
           .superclass(InlineSuperClass::class)
           .addModifiers(INLINE)
@@ -1809,71 +1809,71 @@ class TypeSpecTest {
   @Test fun inlineClassInheritsFromInterface() {
     val guacamole = TypeSpec.classBuilder("Guacamole")
         .primaryConstructor(FunSpec.constructorBuilder()
-            .addParameter("avacado", String::class)
+            .addParameter("avocado", String::class)
             .build())
-        .addProperty(PropertySpec.builder("avacado", String::class)
-            .initializer("avacado")
+        .addProperty(PropertySpec.builder("avocado", String::class)
+            .initializer("avocado")
             .build())
         .addSuperinterface(InlineSuperInterface::class)
         .addModifiers(INLINE)
         .build()
 
     assertThat(guacamole.toString()).isEqualTo("""
-      |inline class Guacamole(val avacado: kotlin.String) : com.squareup.kotlinpoet.TypeSpecTest.InlineSuperInterface
+      |inline class Guacamole(val avocado: kotlin.String) : com.squareup.kotlinpoet.TypeSpecTest.InlineSuperInterface
       |""".trimMargin())
   }
 
-  @Test fun inlineClassWithTwoParameters() {
-    assertThrows<IllegalStateException> {
+  @Test fun inlineClassWithoutBackingProperty() {
+    assertThrows<IllegalArgumentException> {
       TypeSpec.classBuilder("Guacamole")
           .primaryConstructor(FunSpec.constructorBuilder()
-              .addParameter("avacado", String::class)
-              .addParameter("garlic", String::class)
+              .addParameter("avocado", String::class)
               .build())
+          .addProperty("garlic", String::class)
           .addModifiers(INLINE)
           .build()
-    }.hasMessageThat().isEqualTo("Inline class must have 1 parameter in constructor")
+    }.hasMessageThat().isEqualTo("Inline classes must have a single read-only (val) property parameter.")
   }
 
   @Test fun inlineClassWithoutProperties() {
     assertThrows<IllegalStateException> {
       TypeSpec.classBuilder("Guacamole")
           .primaryConstructor(FunSpec.constructorBuilder()
-              .addParameter("avacado", String::class)
+              .addParameter("avocado", String::class)
               .build())
           .addModifiers(INLINE)
           .build()
-    }.hasMessageThat().isEqualTo("Inline class must have a single read-only (val) property.")
+    }.hasMessageThat().isEqualTo("Inline classes must have at least 1 property")
   }
 
   @Test fun inlineClassWithMutableProperties() {
     assertThrows<IllegalStateException> {
       TypeSpec.classBuilder("Guacamole")
           .primaryConstructor(FunSpec.constructorBuilder()
-              .addParameter("avacado", String::class)
+              .addParameter("avocado", String::class)
               .build())
-          .addProperty(PropertySpec.builder("avacado", String::class)
-              .initializer("avacado")
-              .mutable(true)
+          .addProperty(PropertySpec.builder("avocado", String::class)
+              .initializer("avocado")
+              .mutable()
               .build())
           .addModifiers(INLINE)
           .build()
-    }.hasMessageThat().isEqualTo("Inline class must have a single read-only (val) property.")
+    }.hasMessageThat().isEqualTo("Inline classes must have a single read-only (val) property parameter.")
   }
 
   @Test fun inlineClassWithPrivateConstructor() {
     assertThrows<IllegalStateException> {
       TypeSpec.classBuilder("Guacamole")
           .primaryConstructor(FunSpec.constructorBuilder()
-              .addParameter("avacado", String::class)
+              .addParameter("avocado", String::class)
               .addModifiers(PRIVATE)
               .build())
-          .addProperty(PropertySpec.builder("avacado", String::class)
-              .initializer("avacado")
+          .addProperty(PropertySpec.builder("avocado", String::class)
+              .initializer("avocado")
               .build())
           .addModifiers(INLINE)
           .build()
-    }.hasMessageThat().isEqualTo("Inline class must have a public primary constructor")
+    }.hasMessageThat().isEqualTo("Inline classes must have a public primary constructor")
   }
 
   @Test fun inlineEnumClass() {
@@ -1882,10 +1882,10 @@ class TypeSpecTest {
             .addParameter("x", Int::class)
             .build())
         .addEnumConstant("A", TypeSpec.anonymousClassBuilder()
-            .addSuperclassConstructorParameter("%S", "1")
+            .addSuperclassConstructorParameter("%L", 1)
             .build())
         .addEnumConstant("B", TypeSpec.anonymousClassBuilder()
-            .addSuperclassConstructorParameter("%S", "2")
+            .addSuperclassConstructorParameter("%L", 2)
             .build())
         .addProperty(PropertySpec.builder("x", Int::class)
             .initializer("x")
@@ -1894,9 +1894,9 @@ class TypeSpecTest {
         .build()
     assertThat(guacamole.toString()).isEqualTo("""
       |enum inline class Foo(val x: kotlin.Int) {
-      |    A("1"),
+      |    A(1),
       |
-      |    B("2");
+      |    B(2);
       |}
       |""".trimMargin())
   }


### PR DESCRIPTION
Adds support for doing checks around `inline` classes. Seems like a good time now that 1.3 is official! 

I've used this [KEEP](https://github.com/Kotlin/KEEP/blob/master/proposals/inline-classes.md) as the main reference. It covers most checks like
* Single parameter constructor
* Public constructor
* No super classes
* Can implement interfaces
* Only single backing property
* No `init` blocks
* Read only (`val`) properies.
and also has tests for each of these cases. 

Have also added 2 additional tests to cover valid inline classes as well as inline enum classes. 

Resolves #504 