### PR TITLE
Emit star-projection only for types with 'Any?' upper bound

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/WildcardTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/WildcardTypeName.kt
@@ -49,13 +49,13 @@ class WildcardTypeName private constructor(
     if (lowerBounds.size == 1) {
       return out.emitCode("in %T", lowerBounds[0])
     }
-    return if (upperBounds[0] == ANY)
+    return if (upperBounds[0] == ANY.asNullable())
       out.emit("*") else
       out.emitCode("out %T", upperBounds[0])
   }
 
   companion object {
-    @JvmField val STAR = subtypeOf(Any::class)
+    @JvmField val STAR = subtypeOf(ANY.asNullable())
 
     /**
      * Returns a type that represents an unknown type that extends `bound`. For example, if `bound`

--- a/src/test/java/com/squareup/kotlinpoet/ParameterizedTypeNameTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/ParameterizedTypeNameTest.kt
@@ -20,6 +20,7 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.plusParameter
 import org.junit.Test
 import java.io.Closeable
+import java.util.Queue
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeProjection
@@ -96,6 +97,7 @@ class ParameterizedTypeNameTest {
     val invariantNullable: KClass<Test>?
     val star: KClass<*>
     val multiVariant: Map<in String, List<Map<KClass<out Number>, *>?>>
+    val outAnyOnTypeWithoutBoundsAndVariance: Queue<out Any>
   }
 
   private fun assertKTypeProjections(kType: KType) = assertThat(kType.asTypeName().toString()).isEqualTo(kType.toString())
@@ -109,4 +111,7 @@ class ParameterizedTypeNameTest {
   @Test fun kTypeStarProjection() = assertKTypeProjections(Projections::star.returnType)
 
   @Test fun kTypeMultiVariantProjection() = assertKTypeProjections(Projections::multiVariant.returnType)
+
+  @Test fun kTypeOutAnyOnTypeWithoutBoundsVariance() = assertKTypeProjections(Projections::outAnyOnTypeWithoutBoundsAndVariance.returnType)
+
 }

--- a/src/test/java/com/squareup/kotlinpoet/ParameterizedTypeNameTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/ParameterizedTypeNameTest.kt
@@ -20,8 +20,8 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.plusParameter
 import org.junit.Test
 import java.io.Closeable
-import java.util.Queue
 import kotlin.reflect.KClass
+import kotlin.reflect.KMutableProperty
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeProjection
 import kotlin.reflect.KVariance
@@ -97,7 +97,7 @@ class ParameterizedTypeNameTest {
     val invariantNullable: KClass<Test>?
     val star: KClass<*>
     val multiVariant: Map<in String, List<Map<KClass<out Number>, *>?>>
-    val outAnyOnTypeWithoutBoundsAndVariance: Queue<out Any>
+    val outAnyOnTypeWithoutBoundsAndVariance: KMutableProperty<out Any>
   }
 
   private fun assertKTypeProjections(kType: KType) = assertThat(kType.asTypeName().toString()).isEqualTo(kType.toString())


### PR DESCRIPTION
Fixes #520 