### PR TITLE
Escape property names if Kotlin keywords

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -238,7 +238,6 @@ class PropertySpec private constructor(builder: Builder) {
 
   companion object {
     @JvmStatic fun builder(name: String, type: TypeName, vararg modifiers: KModifier): Builder {
-      require(name.isName) { "not a valid name: $name" }
       return Builder(name, type)
           .addModifiers(*modifiers)
     }

--- a/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -106,8 +106,24 @@ class PropertySpecTest {
     assertThat(a.hashCode()).isEqualTo(b.hashCode())
   }
 
-  @Test
-  fun externalTopLevel() {
+  @Test fun escapeKeywordInPropertyName() {
+    val prop = PropertySpec.builder("object", String::class)
+        .build()
+    assertThat(prop.toString()).isEqualTo("""
+      |val `object`: kotlin.String
+      |""".trimMargin())
+  }
+
+  @Test fun escapeKeywordInVariableName() {
+    val prop = PropertySpec.builder("object", String::class)
+        .mutable()
+        .build()
+    assertThat(prop.toString()).isEqualTo("""
+      |var `object`: kotlin.String
+      |""".trimMargin())
+  }
+
+  @Test fun externalTopLevel() {
     val prop = PropertySpec.builder("foo", String::class)
         .addModifiers(KModifier.EXTERNAL)
         .build()


### PR DESCRIPTION
I didn't have push access to the previous branch and so I couldn't just rebase the conflicts. I've basically just copied over the changes and tests. 

Closes #476 