### PR TITLE
Move the modifiers set out of TypeSpec.Kind

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -193,7 +193,7 @@ class FunSpec private constructor(builder: Builder) {
     emit(
         codeWriter = this,
         enclosingName = "Constructor",
-        implicitModifiers = TypeSpec.Kind.Class().implicitFunctionModifiers,
+        implicitModifiers = TypeSpec.Kind.CLASS.implicitFunctionModifiers(),
         includeKdocTags = true)
   }
 


### PR DESCRIPTION
This was a modeling mistake caused by following Java kinds like '@interface'
and 'enum' rather than Kotlin kinds which are only 'object', 'interface', and
'class'.