### PR TITLE
Move WildcardTypeName.Companion.STAR to be beside UNIT and other types

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
@@ -146,9 +146,9 @@ class ParameterizedTypeName internal constructor(
           },
           effectiveType.asTypeName(),
           typeArguments.take(effectiveType.typeParameters.size).map { (paramVariance, paramType) ->
-            val typeName = paramType?.asTypeName() ?: return@map WildcardTypeName.STAR
+            val typeName = paramType?.asTypeName() ?: return@map STAR
             when (paramVariance) {
-              null -> WildcardTypeName.STAR
+              null -> STAR
               KVariance.INVARIANT -> typeName
               KVariance.IN -> WildcardTypeName.supertypeOf(typeName)
               KVariance.OUT -> WildcardTypeName.subtypeOf(typeName)

--- a/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -217,6 +217,9 @@ abstract class TypeName internal constructor(
 @JvmField val FLOAT = ClassName("kotlin", "Float")
 @JvmField val DOUBLE = ClassName("kotlin", "Double")
 
+/** The wildcard type `*` which is shorthand for `out Any?`. */
+@JvmField val STAR = WildcardTypeName.subtypeOf(ANY.asNullable())
+
 @JvmField val DYNAMIC = object : TypeName(false, emptyList()) {
 
   override fun asNullable() =

--- a/src/main/java/com/squareup/kotlinpoet/WildcardTypeName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/WildcardTypeName.kt
@@ -46,37 +46,32 @@ class WildcardTypeName private constructor(
   override fun withoutAnnotations() = WildcardTypeName(upperBounds, lowerBounds, nullable)
 
   override fun emit(out: CodeWriter): CodeWriter {
-    if (lowerBounds.size == 1) {
-      return out.emitCode("in %T", lowerBounds[0])
+    return when {
+      lowerBounds.size == 1 -> out.emitCode("in %T", lowerBounds[0])
+      upperBounds == STAR.upperBounds -> out.emit("*")
+      else -> out.emitCode("out %T", upperBounds[0])
     }
-    return if (upperBounds[0] == ANY.asNullable())
-      out.emit("*") else
-      out.emitCode("out %T", upperBounds[0])
   }
 
   companion object {
-    @JvmField val STAR = subtypeOf(ANY.asNullable())
-
     /**
-     * Returns a type that represents an unknown type that extends `bound`. For example, if `bound`
-     * is `CharSequence.class`, this returns `? extends CharSequence`. If `bound` is `Object.class`,
-     * this returns `?`, which is shorthand for `? extends Object`.
+     * Returns a type that represents an unknown type that extends `upperBound`. For example, if
+     * `upperBound` is `CharSequence`, this returns `out CharSequence`. If `upperBound` is `Any?`,
+     * this returns `*`, which is shorthand for `out Any?`.
      */
-    @JvmStatic fun subtypeOf(upperBound: TypeName): WildcardTypeName {
-      return WildcardTypeName(listOf(upperBound), emptyList())
-    }
+    @JvmStatic fun subtypeOf(upperBound: TypeName) =
+      WildcardTypeName(listOf(upperBound), emptyList())
 
     @JvmStatic fun subtypeOf(upperBound: Type) = subtypeOf(upperBound.asTypeName())
 
     @JvmStatic fun subtypeOf(upperBound: KClass<*>) = subtypeOf(upperBound.asTypeName())
 
     /**
-     * Returns a type that represents an unknown supertype of `bound`. For example, if `bound` is
-     * `String.class`, this returns `? super String`.
+     * Returns a type that represents an unknown supertype of `lowerBound`. For example, if
+     * `lowerBound` is `String`, this returns `in String`.
      */
-    @JvmStatic fun supertypeOf(lowerBound: TypeName): WildcardTypeName {
-      return WildcardTypeName(listOf(ANY), listOf(lowerBound))
-    }
+    @JvmStatic fun supertypeOf(lowerBound: TypeName) =
+      WildcardTypeName(listOf(ANY), listOf(lowerBound))
 
     @JvmStatic fun supertypeOf(lowerBound: Type) = supertypeOf(lowerBound.asTypeName())
 
@@ -89,9 +84,11 @@ class WildcardTypeName private constructor(
       val extendsBound = mirror.extendsBound
       if (extendsBound == null) {
         val superBound = mirror.superBound
-        return if (superBound == null)
-          STAR else
+        return if (superBound == null) {
+          STAR
+        } else {
           supertypeOf(TypeName.get(superBound, typeVariables))
+        }
       } else {
         return subtypeOf(TypeName.get(extendsBound, typeVariables))
       }

--- a/src/test/java/com/squareup/kotlinpoet/AbstractTypesTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/AbstractTypesTest.kt
@@ -143,7 +143,7 @@ abstract class AbstractTypesTest {
   }
 
   @Test fun starProjection() {
-    assertThat(WildcardTypeName.STAR.toString()).isEqualTo("*")
+    assertThat(STAR.toString()).isEqualTo("*")
   }
 
   @Ignore("Figure out what this maps to in Kotlin.")

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -21,12 +21,12 @@ import com.google.testing.compile.CompilationRule
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
 import com.squareup.kotlinpoet.KModifier.DATA
 import com.squareup.kotlinpoet.KModifier.IN
+import com.squareup.kotlinpoet.KModifier.INLINE
 import com.squareup.kotlinpoet.KModifier.INNER
 import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.KModifier.PUBLIC
 import com.squareup.kotlinpoet.KModifier.VARARG
-import com.squareup.kotlinpoet.KModifier.INLINE
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.jvm.throws
 import org.junit.Rule
@@ -85,7 +85,7 @@ class TypeSpecTest {
   }
 
   @Test fun interestingTypes() {
-    val listOfAny = List::class.asClassName().parameterizedBy(WildcardTypeName.STAR)
+    val listOfAny = List::class.asClassName().parameterizedBy(STAR)
     val listOfExtends = List::class.asClassName()
         .parameterizedBy(WildcardTypeName.subtypeOf(Serializable::class))
     val listOfSuper = List::class.asClassName()


### PR DESCRIPTION
It was weird to have many interesting types defined together but not this one.