### PR TITLE
Fix a crashing bug in LineWrapper.

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/LineWrapper.kt
+++ b/src/main/java/com/squareup/kotlinpoet/LineWrapper.kt
@@ -151,7 +151,7 @@ internal class LineWrapper(
       if (UNSAFE_LINE_START.matches(segment)) {
         segments[i - 1] = segments[i - 1] + " " + segments[i]
         segments.removeAt(i)
-        if (i > 0) i--
+        if (i > 1) i--
       } else {
         i++
       }

--- a/src/test/java/com/squareup/kotlinpoet/LineWrapperTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/LineWrapperTest.kt
@@ -176,4 +176,14 @@ class LineWrapperTest {
         |    efgh ij kl mn
         """.trimMargin())
   }
+
+  @Test fun loneUnsafeUnaryOperator() {
+    val out = StringBuffer()
+    val lineWrapper = LineWrapper(out, "  ", 10)
+    lineWrapper.append(" -1", indentLevel = 2)
+    lineWrapper.close()
+    assertThat(out.toString()).isEqualTo("""
+        | -1
+        """.trimMargin())
+  }
 }


### PR DESCRIPTION
It tries to fold lines that begin with a unary operator even if there's
nothing to fold them with. This loop's minimum is 1 so we're always on
something that's eligible to be folded.