### PR TITLE
Import known types in KDoc

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -353,9 +353,7 @@ internal class CodeWriter constructor(
     }
 
     // We'll have to use the fully-qualified name. Mark the type as importable for a future pass.
-    if (!kdoc) {
-      importableType(className)
-    }
+    importableType(className)
 
     return className.canonicalName
   }

--- a/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -745,4 +745,59 @@ class FileSpecTest {
       |
       |""".trimMargin())
   }
+
+  @Test fun importTypeInKDoc() {
+    val source = FileSpec.builder("com.squareup.tacos", "Taco")
+        .addType(TypeSpec.classBuilder("Taco")
+            .addKdoc("Tacos and [%T]s.\n", String::class)
+            .build())
+        .build()
+    assertThat(source.toString()).isEqualTo("""
+    |package com.squareup.tacos
+    |
+    |import kotlin.String
+    |
+    |/**
+    | * Tacos and [String]s.
+    | */
+    |class Taco
+    |""".trimMargin())
+  }
+
+  @Test fun kdocWithoutImportedType() {
+    val source = FileSpec.builder("com.squareup.tacos", "Taco")
+        .addType(TypeSpec.classBuilder("Taco")
+            .addKdoc("Tacos and [kotlin.String]s.\n")
+            .build())
+        .build()
+    assertThat(source.toString()).isEqualTo("""
+    |package com.squareup.tacos
+    |
+    |/**
+    | * Tacos and [kotlin.String]s.
+    | */
+    |class Taco
+    |""".trimMargin())
+  }
+
+  @Test fun importTypeInKDocWithClashingImports() {
+    val source = FileSpec.builder("com.squareup.tacos", "Taco")
+        .addType(TypeSpec.classBuilder("Taco")
+            .addKdoc("Tacos and [%T]s.\n", String::class)
+            .addProperty("name", String::class)
+            .build())
+        .build()
+    assertThat(source.toString()).isEqualTo("""
+    |package com.squareup.tacos
+    |
+    |import kotlin.String
+    |
+    |/**
+    | * Tacos and [String]s.
+    | */
+    |class Taco {
+    |    val name: String
+    |}
+    |""".trimMargin())
+  }
 }

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -1134,12 +1134,14 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import java.util.Locale
+        |import java.util.Random
         |import kotlin.Boolean
+        |import kotlin.String
         |
         |/**
         | * A hard or soft tortilla, loosely folded and filled with whatever
-        | * [random][java.util.Random] tex-mex stuff we could find in the pantry
-        | * and some [kotlin.String] cheese.
+        | * [random][Random] tex-mex stuff we could find in the pantry
+        | * and some [String] cheese.
         | */
         |class Taco {
         |    /**
@@ -1192,14 +1194,16 @@ class TypeSpecTest {
     assertThat(toString(taco)).isEqualTo("""
         |package com.squareup.tacos
         |
+        |import java.util.Random
         |import kotlin.Boolean
         |import kotlin.Double
         |import kotlin.Int
+        |import kotlin.String
         |
         |/**
         | * A hard or soft tortilla, loosely folded and filled with whatever
-        | * [random][java.util.Random] tex-mex stuff we could find in the pantry
-        | * and some [kotlin.String] cheese.
+        | * [random][Random] tex-mex stuff we could find in the pantry
+        | * and some [String] cheese.
         | * @param temperature Taco temperature. Can be as cold as the famous ice tacos from
         | * the Andes, or hot with lava-like cheese from the depths of
         | * the Ninth Circle.


### PR DESCRIPTION
The nature of the check `if (!kdoc)` makes me feel like this was probably there for a reason so probably worth a discussion. 🙂 

Looks cleaner with the imports but also more lines. 

Resolves #558 
