### PR TITLE
Move to newer CodeBlock API for emitting new lines

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -144,17 +144,31 @@ class FunSpec private constructor(builder: Builder) {
   val isAccessor get() = name.isAccessor
 
   private fun kdocWithTags(): CodeBlock {
-    return with(kdoc.toBuilder()) {
+    return with(kdoc.ensureEndsWithNewLine().toBuilder()) {
+      var newLineAdded = false
+      val isNotEmpty = isNotEmpty()
       if (receiverKdoc.isNotEmpty()) {
-        add("@receiver %L\n", receiverKdoc)
+        if (isNotEmpty) {
+          add("\n")
+          newLineAdded = true
+        }
+        add("@receiver %L", receiverKdoc.ensureEndsWithNewLine())
       }
-      for (parameterSpec in parameters) {
+      parameters.forEachIndexed { index, parameterSpec ->
         if (parameterSpec.kdoc.isNotEmpty()) {
-          add("@param %L %L\n", parameterSpec.name, parameterSpec.kdoc)
+          if (!newLineAdded && index == 0 && isNotEmpty) {
+            add("\n")
+            newLineAdded = true
+          }
+          add("@param %L %L", parameterSpec.name, parameterSpec.kdoc.ensureEndsWithNewLine())
         }
       }
       if (returnKdoc.isNotEmpty()) {
-        add("@return %L\n", returnKdoc)
+        if (!newLineAdded && isNotEmpty) {
+          add("\n")
+          newLineAdded = true
+        }
+        add("@return %L", returnKdoc.ensureEndsWithNewLine())
       }
       build()
     }

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -172,12 +172,12 @@ class FunSpecTest {
   @Test fun returnsUnitWithExpressionBody() {
     val funSpec = FunSpec.builder("foo")
         .returns(Unit::class)
-        .addCode(CodeBlock.of("return bar()"))
+        .addStatement("return bar()")
         .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
       |fun foo(): kotlin.Unit = bar()
-      """.trimMargin())
+      |""".trimMargin())
   }
 
   @Test fun functionParamWithKdoc() {
@@ -233,21 +233,22 @@ class FunSpecTest {
             .build())
         .addParameter(ParameterSpec.builder("nodoc", Boolean::class).build())
         .returns(String::class,  kdoc = "the foo.")
-        .addCode("return %S", "foo")
+        .addStatement("return %S", "foo")
         .build()
     assertThat(funSpec.toString()).isEqualTo("""
       |/**
       | * @param string A string parameter.
       | * @return the foo.
       | */
-      |fun foo(string: kotlin.String, nodoc: kotlin.Boolean): kotlin.String = "foo"""".trimMargin())
+      |fun foo(string: kotlin.String, nodoc: kotlin.Boolean): kotlin.String = "foo"
+      |""".trimMargin())
   }
 
   @Test fun functionWithModifiedReturnKdoc() {
     val funSpec = FunSpec.builder("foo")
         .addParameter("nodoc", Boolean::class)
         .returns(String::class, kdoc = "the foo.")
-        .addCode("return %S", "foo")
+        .addStatement("return %S", "foo")
         .build()
         .toBuilder()
         .returns(String::class, kdoc = "the modified foo.")
@@ -256,14 +257,15 @@ class FunSpecTest {
       |/**
       | * @return the modified foo.
       | */
-      |fun foo(nodoc: kotlin.Boolean): kotlin.String = "foo"""".trimMargin())
+      |fun foo(nodoc: kotlin.Boolean): kotlin.String = "foo"
+      |""".trimMargin())
   }
 
   @Test fun functionWithReturnKDocAndMainKdoc() {
     val funSpec = FunSpec.builder("foo")
         .addParameter("nodoc", Boolean::class)
         .returns(String::class, kdoc = "the foo.")
-        .addCode("return %S", "foo")
+        .addStatement("return %S", "foo")
         .addKdoc("Do the foo")
         .build()
     assertThat(funSpec.toString()).isEqualTo("""
@@ -272,7 +274,8 @@ class FunSpecTest {
       | *
       | * @return the foo.
       | */
-      |fun foo(nodoc: kotlin.Boolean): kotlin.String = "foo"""".trimMargin())
+      |fun foo(nodoc: kotlin.Boolean): kotlin.String = "foo"
+      |""".trimMargin())
   }
 
   @Test fun functionParamNoLambdaParam() {
@@ -521,7 +524,7 @@ class FunSpecTest {
     val funSpec = FunSpec.builder("toBar")
         .receiver(String::class, kdoc = "the string to transform.")
         .returns(String::class)
-        .addCode(CodeBlock.of("return %S", "bar"))
+        .addStatement("return %S", "bar")
         .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
@@ -529,7 +532,7 @@ class FunSpecTest {
       | * @receiver the string to transform.
       | */
       |fun kotlin.String.toBar(): kotlin.String = "bar"
-      """.trimMargin())
+      |""".trimMargin())
   }
 
   @Test fun receiverWithKdocAndMainKDoc() {
@@ -537,7 +540,7 @@ class FunSpecTest {
         .receiver(String::class, kdoc = "the string to transform.")
         .returns(String::class)
         .addKdoc("%L", "Converts to bar")
-        .addCode(CodeBlock.of("return %S", "bar"))
+        .addStatement("return %S", "bar")
         .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
@@ -547,7 +550,7 @@ class FunSpecTest {
       | * @receiver the string to transform.
       | */
       |fun kotlin.String.toBar(): kotlin.String = "bar"
-      """.trimMargin())
+      |""".trimMargin())
   }
 
   @Test fun withAllKdocTags() {
@@ -558,7 +561,7 @@ class FunSpecTest {
             .addKdoc("the index of the character that is returned.")
             .build())
         .addKdoc("Returns the character at the given [position].\n\n")
-        .addCode(CodeBlock.of("return -1"))
+        .addStatement("return -1")
         .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
@@ -570,7 +573,7 @@ class FunSpecTest {
       | * @return The char at the given [position].
       | */
       |fun kotlin.String.charAt(position: kotlin.Int): kotlin.Char = -1
-      """.trimMargin())
+      |""".trimMargin())
   }
 
   @Test fun constructorBuilderEqualityTest() {

--- a/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -259,6 +259,22 @@ class FunSpecTest {
       |fun foo(nodoc: kotlin.Boolean): kotlin.String = "foo"""".trimMargin())
   }
 
+  @Test fun functionWithReturnKDocAndMainKdoc() {
+    val funSpec = FunSpec.builder("foo")
+        .addParameter("nodoc", Boolean::class)
+        .returns(String::class, kdoc = "the foo.")
+        .addCode("return %S", "foo")
+        .addKdoc("Do the foo")
+        .build()
+    assertThat(funSpec.toString()).isEqualTo("""
+      |/**
+      | * Do the foo
+      | *
+      | * @return the foo.
+      | */
+      |fun foo(nodoc: kotlin.Boolean): kotlin.String = "foo"""".trimMargin())
+  }
+
   @Test fun functionParamNoLambdaParam() {
     val unitType = UNIT
     val funSpec = FunSpec.builder("foo")
@@ -510,6 +526,24 @@ class FunSpecTest {
 
     assertThat(funSpec.toString()).isEqualTo("""
       |/**
+      | * @receiver the string to transform.
+      | */
+      |fun kotlin.String.toBar(): kotlin.String = "bar"
+      """.trimMargin())
+  }
+
+  @Test fun receiverWithKdocAndMainKDoc() {
+    val funSpec = FunSpec.builder("toBar")
+        .receiver(String::class, kdoc = "the string to transform.")
+        .returns(String::class)
+        .addKdoc("%L", "Converts to bar")
+        .addCode(CodeBlock.of("return %S", "bar"))
+        .build()
+
+    assertThat(funSpec.toString()).isEqualTo("""
+      |/**
+      | * Converts to bar
+      | *
       | * @receiver the string to transform.
       | */
       |fun kotlin.String.toBar(): kotlin.String = "bar"


### PR DESCRIPTION
Builds on the work done by #568 and uses the same API for `FunSpec`. It's a little trickier and tedious here because of the different types of kdoc tags and the need for adding a breakline before them in case that's where the tags begin.