### PR TITLE
Allow passing line prefix into LineWrapper to enable proper line wrapping in KDoc

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -450,7 +450,11 @@ internal class CodeWriter constructor(
       if (nonWrapping) {
         out.appendNonWrapping(line)
       } else {
-        out.append(line, indentLevel + 2)
+        out.append(
+            line,
+            indentLevel = if (kdoc) indentLevel else indentLevel + 2,
+            linePrefix = if (kdoc) " * " else ""
+        )
       }
       trailingNewline = false
     }

--- a/src/main/java/com/squareup/kotlinpoet/LineWrapper.kt
+++ b/src/main/java/com/squareup/kotlinpoet/LineWrapper.kt
@@ -36,8 +36,11 @@ internal class LineWrapper(
   /** Number of indents in wraps. -1 if the current line has no wraps. */
   private var indentLevel = -1
 
+  /** Optional prefix that will be prepended to wrapped lines. */
+  private var linePrefix = ""
+
   /** Emit `s` replacing its spaces with line wraps as necessary. */
-  fun append(s: String, indentLevel: Int) {
+  fun append(s: String, indentLevel: Int = -1, linePrefix: String = "") {
     check(!closed) { "closed" }
 
     var pos = 0
@@ -47,6 +50,7 @@ internal class LineWrapper(
         ' ' -> {
           // Each space starts a new empty segment.
           this.indentLevel = indentLevel
+          this.linePrefix = linePrefix
           segments += ""
           pos++
         }
@@ -130,6 +134,7 @@ internal class LineWrapper(
       for (i in 0 until indentLevel) {
         out.append(indent)
       }
+      out.append(linePrefix)
     }
 
     // Emit each segment separated by spaces.

--- a/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -792,4 +792,42 @@ class KotlinPoetTest {
       |        val name: String)
       |""".trimMargin())
   }
+
+  // https://github.com/square/kotlinpoet/issues/578
+  @Test fun wrappingInsideKdocKeepsKdocFormatting() {
+    val file = FileSpec.builder("com.squareup.tacos", "Taco")
+        .addType(TypeSpec.classBuilder("Builder")
+            .addKdoc("Builder class for Foo. Allows creating instances of Foo by initializing " +
+                "a subset of their fields, following the Builder pattern.\n")
+            .addFunction(FunSpec.builder("summary_text")
+                .addKdoc("The description for the choice, e.g. \"Currently unavailable due to " +
+                    "high demand. Please try later.\" May be null.")
+                .addParameter("summary_text", String::class.asClassName().copy(nullable = true))
+                .returns(ClassName("com.squareup.tacos", "Builder"))
+                .addStatement("this.summary_text = summary_text")
+                .addStatement("return this")
+                .build())
+            .build())
+        .build()
+    assertThat(file.toString()).isEqualTo("""
+      |package com.squareup.tacos
+      |
+      |import kotlin.String
+      |
+      |/**
+      | * Builder class for Foo. Allows creating instances of Foo by initializing a subset of their fields,
+      | * following the Builder pattern.
+      | */
+      |class Builder {
+      |    /**
+      |     * The description for the choice, e.g. "Currently unavailable due to high demand. Please try
+      |     * later." May be null.
+      |     */
+      |    fun summary_text(summary_text: String?): Builder {
+      |        this.summary_text = summary_text
+      |        return this
+      |    }
+      |}
+      |""".trimMargin())
+  }
 }

--- a/src/test/java/com/squareup/kotlinpoet/LineWrapperTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/LineWrapperTest.kt
@@ -186,4 +186,21 @@ class LineWrapperTest {
         | -1
         """.trimMargin())
   }
+
+  @Test fun linePrefix() {
+    val out = StringBuffer()
+    val lineWrapper = LineWrapper(out, "  ", 10)
+    lineWrapper.append("/**\n")
+    lineWrapper.append(" * ")
+    lineWrapper.append("a b c d e f g h i j k l m n\n", linePrefix = " * ")
+    lineWrapper.append(" */")
+    lineWrapper.close()
+    assertThat(out.toString()).isEqualTo("""
+        |/**
+        | * a b c d
+        | * e f g h i j
+        | * k l m n
+        | */
+        """.trimMargin())
+  }
 }


### PR DESCRIPTION
Fixes #578 