### PR TITLE
Add newline for remaining Specs

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -55,7 +55,7 @@ class PropertySpec private constructor(builder: Builder) {
         setter?.modifiers?.contains(KModifier.INLINE) ?: false
     val propertyModifiers = if (isInlineProperty) modifiers + KModifier.INLINE else modifiers
     if (!inline) {
-      codeWriter.emitKdoc(kdoc)
+      codeWriter.emitKdoc(kdoc.ensureEndsWithNewLine())
     }
     codeWriter.emitAnnotations(annotations, inline)
     codeWriter.emitModifiers(propertyModifiers, implicitModifiers)

--- a/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
@@ -31,7 +31,7 @@ class TypeAliasSpec private constructor(builder: TypeAliasSpec.Builder) {
   val kdoc = builder.kdoc.build()
 
   internal fun emit(codeWriter: CodeWriter) {
-    codeWriter.emitKdoc(kdoc)
+    codeWriter.emitKdoc(kdoc.ensureEndsWithNewLine())
     codeWriter.emitModifiers(modifiers)
     codeWriter.emitCode("typealias %L", name)
     codeWriter.emitTypeVariables(typeVariables)

--- a/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -313,4 +313,30 @@ class PropertySpecTest {
       |
       |""".trimMargin())
   }
+
+  @Test
+  fun propertyKdocWithoutLinebreak() {
+    val property = PropertySpec.builder("topping", String::class)
+        .addKdoc("The topping you want on your pizza")
+        .build()
+    assertThat(property.toString()).isEqualTo("""
+      |/**
+      | * The topping you want on your pizza
+      | */
+      |val topping: kotlin.String
+      |""".trimMargin())
+  }
+
+  @Test
+  fun propertyKdocWithLinebreak() {
+    val property = PropertySpec.builder("topping", String::class)
+        .addKdoc("The topping you want on your pizza\n")
+        .build()
+    assertThat(property.toString()).isEqualTo("""
+      |/**
+      | * The topping you want on your pizza
+      | */
+      |val topping: kotlin.String
+      |""".trimMargin())
+  }
 }

--- a/src/test/java/com/squareup/kotlinpoet/TypeAliasSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeAliasSpecTest.kt
@@ -109,6 +109,20 @@ class TypeAliasSpecTest {
       |""".trimMargin())
   }
 
+  @Test fun kdocWithoutNewLine() {
+    val typeAliasSpec = TypeAliasSpec
+        .builder("Word", String::class)
+        .addKdoc("Word is just a type alias for [String](%T).", String::class)
+        .build()
+
+    assertThat(typeAliasSpec.toString()).isEqualTo("""
+      |/**
+      | * Word is just a type alias for [String](kotlin.String).
+      | */
+      |typealias Word = kotlin.String
+      |""".trimMargin())
+  }
+
   @Test fun equalsAndHashCode() {
     val a = TypeAliasSpec.builder("Word", String::class).addModifiers(KModifier.PUBLIC).build()
     val b = TypeAliasSpec.builder("Word", String::class).addModifiers(KModifier.PUBLIC).build()

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -3582,6 +3582,22 @@ class TypeSpecTest {
     |""".trimMargin())
   }
 
+  @Test fun classWithoutPropertyKdoc() {
+    val typeSpec = TypeSpec.classBuilder("Foo")
+        .addProperty(PropertySpec.builder("bar", String::class)
+            .addKdoc("The bar for your foo")
+            .build())
+        .build()
+    assertThat(typeSpec.toString()).isEqualTo("""
+    |class Foo {
+    |    /**
+    |     * The bar for your foo
+    |     */
+    |    val bar: kotlin.String
+    |}
+    |""".trimMargin())
+  }
+
   // https://github.com/square/kotlinpoet/issues/563
   @Test fun kdocFormatting() {
     val typeSpec = TypeSpec.classBuilder("MyType")

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -3582,7 +3582,7 @@ class TypeSpecTest {
     |""".trimMargin())
   }
 
-  @Test fun classWithoutPropertyKdoc() {
+  @Test fun classWithPropertyKdoc() {
     val typeSpec = TypeSpec.classBuilder("Foo")
         .addProperty(PropertySpec.builder("bar", String::class)
             .addKdoc("The bar for your foo")


### PR DESCRIPTION
Resolves #586 
This adds a new-line to `TypeAliasSpec` and `PropertySpec`