### PR TITLE
Fix kdoc formatting for property getter/setters

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -69,7 +69,7 @@ class FunSpec private constructor(builder: Builder) {
     if (includeKdocTags) {
       codeWriter.emitKdoc(kdocWithTags())
     } else {
-      codeWriter.emitKdoc(kdoc)
+      codeWriter.emitKdoc(kdoc.ensureEndsWithNewLine())
     }
     codeWriter.emitAnnotations(annotations, false)
     codeWriter.emitModifiers(modifiers, implicitModifiers)

--- a/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -314,8 +314,7 @@ class PropertySpecTest {
       |""".trimMargin())
   }
 
-  @Test
-  fun propertyKdocWithoutLinebreak() {
+  @Test fun propertyKdocWithoutLinebreak() {
     val property = PropertySpec.builder("topping", String::class)
         .addKdoc("The topping you want on your pizza")
         .build()
@@ -327,8 +326,7 @@ class PropertySpecTest {
       |""".trimMargin())
   }
 
-  @Test
-  fun propertyKdocWithLinebreak() {
+  @Test fun propertyKdocWithLinebreak() {
     val property = PropertySpec.builder("topping", String::class)
         .addKdoc("The topping you want on your pizza\n")
         .build()

--- a/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -339,4 +339,22 @@ class PropertySpecTest {
       |val topping: kotlin.String
       |""".trimMargin())
   }
+
+  @Test fun getterKdoc() {
+    val property = PropertySpec.builder("amount", Int::class)
+        .initializer("4")
+        .getter(FunSpec.getterBuilder()
+            .addKdoc("Simple multiplier")
+            .addStatement("return %L * 5", "field")
+            .build())
+        .build()
+
+    assertThat(property.toString()).isEqualTo("""
+      |val amount: kotlin.Int = 4
+      |    /**
+      |     * Simple multiplier
+      |     */
+      |    get() = field * 5
+      |""".trimMargin())
+  }
 }


### PR DESCRIPTION
Last codepath which is utilized by property getters/setters. 
Ref #586 