### PR TITLE
Don't wrap single line comments inside FunSpec

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -403,7 +403,7 @@ class FunSpec private constructor(builder: Builder) {
     }
 
     fun addComment(format: String, vararg args: Any) = apply {
-      body.add("// $format\n", *args)
+      body.add("//·${format.replace(' ', '·')}\n", *args)
     }
 
     /**

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -3640,6 +3640,30 @@ class TypeSpecTest {
       |""".trimMargin())
   }
 
+  // https://github.com/square/kotlinpoet/issues/594
+  @Test fun longComment() {
+    val taco = TypeSpec.classBuilder("Taco")
+        .addFunction(FunSpec.builder("getAnswer")
+            .returns(Int::class)
+            .addComment("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do " +
+                "eiusmod tempor incididunt ut labore et dolore magna aliqua.")
+            .addStatement("return 42")
+            .build())
+        .build()
+    assertThat(toString(taco)).isEqualTo("""
+        |package com.squareup.tacos
+        |
+        |import kotlin.Int
+        |
+        |class Taco {
+        |    fun getAnswer(): Int {
+        |        // Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        |        return 42
+        |    }
+        |}
+        |""".trimMargin())
+  }
+
   companion object {
     private val donutsPackage = "com.squareup.donuts"
   }


### PR DESCRIPTION
Fixes #594 

The fix ensures long single line comments don't get wrapped producing broken code - this is the behavior we had prior to `%W` -> `·` swap.