### PR TITLE
Make primary MemberName constructor internal

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/MemberName.kt
+++ b/src/main/java/com/squareup/kotlinpoet/MemberName.kt
@@ -24,7 +24,7 @@ package com.squareup.kotlinpoet
  * companion object of the Map.Entry class
  * @param simpleName e.g. `isBlank`, `size`
  */
-data class MemberName(
+data class MemberName internal constructor(
   val packageName: String,
   val enclosingClassName: ClassName?,
   val simpleName: String


### PR DESCRIPTION
Using this constructor might lead to incorrect assumptions, we don't want people to be doing something like:
```kotlin
val className = ClassName("", "Foo")
val memberName = MemberName(
  packageName = "com.example", 
  enclosingClassName = className, 
  simpleName = "create"
)
println(memberName.canonicalName) // prints "Foo.create", not "com.example.Foo.create"
```
Other public constructors allow you to either pass in a `packageName` or an `enclosingClassName`, suggesting that those are mutually exclusive.