### PR TITLE
Remove addons Travis config block

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ language: java
 jdk:
   - oraclejdk8
 
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer # Updates JDK 8 to the latest available.
-
 script:
   - ./gradlew clean build
 


### PR DESCRIPTION
It's failing builds and I think we don't need it. SQLDelight doesn't have it.