### PR TITLE
Remove n^2 algorithm in CodeWriter.resolve() by precomputing all of the nested simple names of a TypeSpec

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -456,10 +456,8 @@ internal class CodeWriter constructor(
     // Match a child of the current (potentially nested) class.
     for (i in typeSpecStack.indices.reversed()) {
       val typeSpec = typeSpecStack[i]
-      for (visibleChild in typeSpec.typeSpecs) {
-        if (visibleChild.name == simpleName) {
-          return stackClassName(i, simpleName)
-        }
+      if (typeSpec.nestedTypesSimpleNames.contains(simpleName)) {
+        return stackClassName(i, simpleName)
       }
     }
 

--- a/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -456,7 +456,7 @@ internal class CodeWriter constructor(
     // Match a child of the current (potentially nested) class.
     for (i in typeSpecStack.indices.reversed()) {
       val typeSpec = typeSpecStack[i]
-      if (typeSpec.nestedTypesSimpleNames.contains(simpleName)) {
+      if (simpleName in typeSpec.nestedTypesSimpleNames) {
         return stackClassName(i, simpleName)
       }
     }

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -57,6 +57,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
   val initializerBlock = builder.initializerBlock.build()
   val funSpecs = builder.funSpecs.toImmutableList()
   val typeSpecs = builder.typeSpecs.toImmutableList()
+  internal val nestedTypesSimpleNames = nestedTypesSimpleNames(builder)
 
   fun toBuilder(): Builder {
     val builder = Builder(kind, name, *modifiers.toTypedArray())
@@ -275,6 +276,14 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     } finally {
       codeWriter.statementLine = previousStatementLine
     }
+  }
+
+  private fun nestedTypesSimpleNames(): Set<String> {
+    var nestedTypesSimpleNames = HashSet<String>(typeSpecs.size)
+    for (typeSpec in typeSpecs) {
+      nestedTypesSimpleNames.add(typeSpec.name)
+    }
+    return nestedTypesSimpleNames
   }
 
   /** Returns the properties that can be declared inline as constructor parameters. */

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -57,7 +57,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
   val initializerBlock = builder.initializerBlock.build()
   val funSpecs = builder.funSpecs.toImmutableList()
   val typeSpecs = builder.typeSpecs.toImmutableList()
-  internal val nestedTypesSimpleNames = nestedTypesSimpleNames(builder)
+  internal val nestedTypesSimpleNames: = typeSpecs.map { it.name }.toImmutableSet()
 
   fun toBuilder(): Builder {
     val builder = Builder(kind, name, *modifiers.toTypedArray())
@@ -279,11 +279,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
   }
 
   private fun nestedTypesSimpleNames(): Set<String> {
-    var nestedTypesSimpleNames = HashSet<String>(typeSpecs.size)
-    for (typeSpec in typeSpecs) {
-      nestedTypesSimpleNames.add(typeSpec.name)
-    }
-    return nestedTypesSimpleNames
+    return typeSpecs.map { it.name }.toSet();
   }
 
   /** Returns the properties that can be declared inline as constructor parameters. */

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -57,7 +57,7 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
   val initializerBlock = builder.initializerBlock.build()
   val funSpecs = builder.funSpecs.toImmutableList()
   val typeSpecs = builder.typeSpecs.toImmutableList()
-  internal val nestedTypesSimpleNames: = typeSpecs.map { it.name }.toImmutableSet()
+  internal val nestedTypesSimpleNames = typeSpecs.map { it.name }.toImmutableSet()
 
   fun toBuilder(): Builder {
     val builder = Builder(kind, name, *modifiers.toTypedArray())
@@ -276,10 +276,6 @@ class TypeSpec private constructor(builder: TypeSpec.Builder) {
     } finally {
       codeWriter.statementLine = previousStatementLine
     }
-  }
-
-  private fun nestedTypesSimpleNames(): Set<String> {
-    return typeSpecs.map { it.name }.toSet();
   }
 
   /** Returns the properties that can be declared inline as constructor parameters. */


### PR DESCRIPTION
This is the KotlinPoet equivalent of https://github.com/square/javapoet/pull/705