### PR TITLE
#629 Demo: Introduce %C for strings that should be compile-time constants

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
@@ -41,6 +41,8 @@ import kotlin.reflect.KClass
  *    (`$`), use `%P` for string templates.
  *  * `%P` - Similar to `%S`, but doesn't escape dollar signs (`$`) to allow creation of string
  *    templates. If the string contains dollar signs that should be escaped - use `%S`.
+ *  * `%C` - Similar to `%S`, but enforces that the string can be a compile-time constant (for use
+ *    in annotations, `const`, etc). If the string does not need to be constant - use `%S`.
  *  * `%T` emits a *type* reference. Types will be imported if possible. Arguments for types may be
  *    [classes][Class], [type mirrors][javax.lang.model.type.TypeMirror], and
  *    [elements][javax.lang.model.element.Element].
@@ -340,7 +342,7 @@ class CodeBlock private constructor(
       when (c) {
         'N' -> this.args += argToName(arg).escapeIfKeyword()
         'L' -> this.args += argToLiteral(arg)
-        'S' -> this.args += argToString(arg)
+        'S', 'C' -> this.args += argToString(arg)
         'P' -> this.args += if (arg is CodeBlock) arg else argToString(arg)
         'T' -> this.args += argToType(arg)
         'M' -> this.args += arg

--- a/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -224,11 +224,11 @@ internal class CodeWriter constructor(
 
         "%N" -> emit(codeBlock.args[a++] as String)
 
-        "%S" -> {
+        "%S", "%C" -> {
           val string = codeBlock.args[a++] as String?
           // Emit null as a literal null: no quotes.
           val literal = if (string != null) {
-            stringLiteralWithQuotes(string, escapeDollarSign = true)
+            stringLiteralWithQuotes(string, escapeDollarSign = true, treatAsConstant = part == "%C")
           } else {
             "null"
           }

--- a/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -81,9 +81,10 @@ private val Char.isIsoControl: Boolean
 /** Returns the string literal representing `value`, including wrapping double quotes.  */
 internal fun stringLiteralWithQuotes(
   value: String,
-  escapeDollarSign: Boolean = true
+  escapeDollarSign: Boolean = true,
+  treatAsConstant: Boolean = false
 ): String {
-  if ('\n' in value) {
+  if (!treatAsConstant && '\n' in value) {
     val result = StringBuilder(value.length + 32)
     result.append("\"\"\"\n|")
     var i = 0

--- a/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
@@ -82,8 +82,8 @@ class AnnotationSpecTest {
     var b = AnnotationSpec.builder(AnnotationC::class.java).build()
     assertThat(a == b).isTrue()
     assertThat(a.hashCode()).isEqualTo(b.hashCode())
-    a = AnnotationSpec.builder(AnnotationC::class.java).addMember("value", "%S", "123").build()
-    b = AnnotationSpec.builder(AnnotationC::class.java).addMember("value", "%S", "123").build()
+    a = AnnotationSpec.builder(AnnotationC::class.java).addMember("value", "%C", "123").build()
+    b = AnnotationSpec.builder(AnnotationC::class.java).addMember("value", "%C", "123").build()
     assertThat(a == b).isTrue()
     assertThat(a.hashCode()).isEqualTo(b.hashCode())
   }
@@ -236,8 +236,8 @@ class AnnotationSpecTest {
 
   @Test fun deprecatedTest() {
     val annotation = AnnotationSpec.builder(Deprecated::class)
-        .addMember("%S", "Nope")
-        .addMember("%T(%S)", ReplaceWith::class, "Yep")
+        .addMember("%C", "Nope")
+        .addMember("%T(%C)", ReplaceWith::class, "Yep")
         .build()
 
     assertThat(annotation.toString()).isEqualTo("" +
@@ -246,14 +246,23 @@ class AnnotationSpecTest {
 
   @Test fun modifyMembers() {
     val builder = AnnotationSpec.builder(Deprecated::class)
-        .addMember("%S", "Nope")
-        .addMember("%T(%S)", ReplaceWith::class, "Yep")
+        .addMember("%C", "Nope")
+        .addMember("%T(%C)", ReplaceWith::class, "Yep")
 
     builder.members.removeAt(1)
-    builder.members.add(CodeBlock.of("%T(%S)", ReplaceWith::class, "Nope"))
+    builder.members.add(CodeBlock.of("%T(%C)", ReplaceWith::class, "Nope"))
 
     assertThat(builder.build().toString()).isEqualTo("" +
         "@kotlin.Deprecated(\"Nope\", kotlin.ReplaceWith(\"Nope\"))")
+  }
+
+  @Test fun stringsAreConstants() {
+    val text = "This is a long string with a newline\nin the middle."
+    val builder = AnnotationSpec.builder(Deprecated::class)
+        .addMember("%C", text)
+
+    assertThat(builder.build().toString()).isEqualTo("" +
+        "@kotlin.Deprecated(\"${text.replace("\n", "\\n")}\")")
   }
 
   private fun toString(annotationSpec: AnnotationSpec) =

--- a/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -758,4 +758,20 @@ class FileSpecTest {
       |
       |""".trimMargin())
   }
+
+  @Test fun constProperty() {
+    val text = "This is a long string with a newline\nin the middle."
+    val spec = FileSpec.builder("testsrc", "Test")
+        .addProperty(PropertySpec.builder("FOO", String::class, KModifier.CONST)
+            .initializer("%C", text)
+            .build())
+        .build()
+    assertThat(spec.toString()).isEqualTo("""
+      |package testsrc
+      |
+      |import kotlin.String
+      |
+      |const val FOO: String = "${text.replace("\n", "\\n")}"
+      |""".trimMargin())
+  }
 }

--- a/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
@@ -65,6 +65,8 @@ class UtilTest {
         .isEqualTo("\"\"\"\n|abc();\n|def();\n\"\"\".trimMargin()")
     stringLiteral("This is \\\"quoted\\\"!", "This is \"quoted\"!")
     stringLiteral("e^{i\\\\pi}+1=0", "e^{i\\pi}+1=0")
+    assertThat(stringLiteralWithQuotes("abc();\ndef();", treatAsConstant = true))
+        .isEqualTo("\"abc();\\ndef();\"")
   }
 
   @Test fun legalIdentifiers() {


### PR DESCRIPTION
This is a proposal solution for addressing #629 via adding a new `%C` placeholder API to `CodeBlock` to indicate that it should use compile-time-constant strings formats (i.e. not templated) for that String. Basically a constant-alternative for `%S`