### PR TITLE
#629 Demo: Add constantStrings API to CodeBlock

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -28,7 +28,9 @@ import kotlin.reflect.KClass
 /** A generated annotation on a declaration.  */
 class AnnotationSpec private constructor(builder: AnnotationSpec.Builder) {
   val className: ClassName = builder.className
-  val members = builder.members.toImmutableList()
+  val members = builder.members
+      .map { it.copy(constantStrings = true) }
+      .toImmutableList()
   val useSiteTarget: UseSiteTarget? = builder.useSiteTarget
 
   internal fun emit(codeWriter: CodeWriter, inline: Boolean, asParameter: Boolean = false) {

--- a/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
@@ -428,7 +428,7 @@ class CodeBlock private constructor(
       formatParts += codeBlock.formatParts
       args.addAll(codeBlock.args)
       if (codeBlock.constantStrings) {
-        // Constant strings are sticky, if one part wants them then they all get them
+        // Constant strings are sticky, if one part wants them then they all get them.
         constantStrings = true
       }
     }

--- a/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -228,7 +228,10 @@ internal class CodeWriter constructor(
           val string = codeBlock.args[a++] as String?
           // Emit null as a literal null: no quotes.
           val literal = if (string != null) {
-            stringLiteralWithQuotes(string, escapeDollarSign = true)
+            stringLiteralWithQuotes(string,
+                escapeDollarSign = true,
+                treatAsConstant = codeBlock.constantStrings
+            )
           } else {
             "null"
           }
@@ -245,7 +248,9 @@ internal class CodeWriter constructor(
           }
           // Emit null as a literal null: no quotes.
           val literal = if (string != null) {
-            stringLiteralWithQuotes(string, escapeDollarSign = false)
+            stringLiteralWithQuotes(string,
+                escapeDollarSign = false,
+                treatAsConstant = codeBlock.constantStrings)
           } else {
             "null"
           }

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -78,7 +78,12 @@ class PropertySpec private constructor(builder: Builder) {
       } else {
         codeWriter.emitCode(" = ")
       }
-      codeWriter.emitCode(if (initializer.hasStatements()) "%L" else "«%L»", initializer)
+      // const strings must be rendered in compile-time-constant-friendly way
+      // Does not account for typealiases, just the String ClassName.
+      val constantStrings = initializer.constantStrings ||
+          (!delegated && KModifier.CONST in modifiers && type == String::class.asClassName())
+      codeWriter.emitCode(if (initializer.hasStatements()) "%L" else "«%L»",
+          initializer.copy(constantStrings = constantStrings))
     }
     codeWriter.emitWhereBlock(typeVariables)
     if (!inline) codeWriter.emit("\n")

--- a/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -81,9 +81,10 @@ private val Char.isIsoControl: Boolean
 /** Returns the string literal representing `value`, including wrapping double quotes.  */
 internal fun stringLiteralWithQuotes(
   value: String,
-  escapeDollarSign: Boolean = true
+  escapeDollarSign: Boolean = true,
+  treatAsConstant: Boolean = false
 ): String {
-  if ('\n' in value) {
+  if (!treatAsConstant && '\n' in value) {
     val result = StringBuilder(value.length + 32)
     result.append("\"\"\"\n|")
     var i = 0

--- a/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
@@ -256,6 +256,15 @@ class AnnotationSpecTest {
         "@kotlin.Deprecated(\"Nope\", kotlin.ReplaceWith(\"Nope\"))")
   }
 
+  @Test fun stringsAreConstants() {
+    val text = "This is a long string with a newline\nin the middle."
+    val builder = AnnotationSpec.builder(Deprecated::class)
+        .addMember("%S", text)
+
+    assertThat(builder.build().toString()).isEqualTo("" +
+        "@kotlin.Deprecated(\"${text.replace("\n", "\\n")}\")")
+  }
+
   private fun toString(annotationSpec: AnnotationSpec) =
       toString(TypeSpec.classBuilder("Taco").addAnnotation(annotationSpec).build())
 

--- a/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -758,4 +758,20 @@ class FileSpecTest {
       |
       |""".trimMargin())
   }
+
+  @Test fun constProperty() {
+    val text = "This is a long string with a newline\nin the middle."
+    val spec = FileSpec.builder("testsrc", "Test")
+        .addProperty(PropertySpec.builder("FOO", String::class, KModifier.CONST)
+            .initializer("%S", text)
+            .build())
+        .build()
+    assertThat(spec.toString()).isEqualTo("""
+      |package testsrc
+      |
+      |import kotlin.String
+      |
+      |const val FOO: String = "${text.replace("\n", "\\n")}"
+      |""".trimMargin())
+  }
 }

--- a/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
@@ -65,6 +65,8 @@ class UtilTest {
         .isEqualTo("\"\"\"\n|abc();\n|def();\n\"\"\".trimMargin()")
     stringLiteral("This is \\\"quoted\\\"!", "This is \"quoted\"!")
     stringLiteral("e^{i\\\\pi}+1=0", "e^{i\\pi}+1=0")
+    assertThat(stringLiteralWithQuotes("abc();\ndef();", treatAsConstant = true))
+        .isEqualTo("\"abc();\\ndef();\"")
   }
 
   @Test fun legalIdentifiers() {


### PR DESCRIPTION
This is a proposal solution for addressing #629 via adding a new `constantStrings` API to `CodeBlock` to indicate that it should use compile-time-constant strings formats (i.e. not templated).