### PR TITLE
import members from default package

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -421,9 +421,6 @@ internal class CodeWriter constructor(
   }
 
   private fun importableType(className: ClassName) {
-    if (className.packageName.isEmpty()) {
-      return
-    }
     val topLevelClassName = className.topLevelClassName()
     val simpleName = memberImports[className.canonicalName]?.alias ?: topLevelClassName.simpleName
     // Check for name clashes with members.

--- a/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -539,7 +539,7 @@ class FileSpecTest {
         |""".trimMargin())
   }
 
-  @Test fun defaultPackageTypesAreNotImported() {
+  @Test fun defaultPackageTypesAreImported() {
     val source = FileSpec.builder("hello", "World")
         .addType(TypeSpec.classBuilder("World")
             .addSuperinterface(ClassName("", "Test"))
@@ -547,6 +547,8 @@ class FileSpecTest {
         .build()
     assertThat(source.toString()).isEqualTo("""
         |package hello
+        |
+        |import Test
         |
         |class World : Test
         |""".trimMargin())

--- a/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -501,7 +501,7 @@ class KotlinPoetTest {
             .initializer("%S", "a")
             .build())
         .addType(TypeSpec.classBuilder("B")
-            .superclass(ClassName("", "A"))
+            .superclass(ClassName(tacosPackage, "A"))
             .addModifiers(KModifier.ABSTRACT)
             .addProperty(PropertySpec.builder("q", String::class.asTypeName())
                 .mutable()
@@ -573,9 +573,9 @@ class KotlinPoetTest {
   }
 
   @Test fun suspendingLambdas() {
-    val barType = ClassName("", "Bar")
+    val barType = ClassName(tacosPackage, "Bar")
     val suspendingLambda = LambdaTypeName
-        .get(parameters = *arrayOf(ClassName("", "Foo")), returnType = barType)
+        .get(parameters = *arrayOf(ClassName(tacosPackage, "Foo")), returnType = barType)
         .copy(suspending = true)
     val source = FileSpec.builder(tacosPackage, "Taco")
         .addProperty(PropertySpec.builder("bar", suspendingLambda)

--- a/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -553,7 +553,7 @@ class TypeSpecTest {
           .build()
     }
   }
-  
+
   /** https://github.com/square/kotlinpoet/issues/621  */
   @Test fun enumWithMembersButNoConstansts() {
     val roshambo = TypeSpec.enumBuilder("RenderPassCreate")
@@ -3327,16 +3327,16 @@ class TypeSpecTest {
   }
 
   @Test fun testDelegateIfaceWithOtherParamTypeName() {
-    val entity = ClassName.bestGuess("Entity")
-    val entityBuilder = ClassName.bestGuess("EntityBuilder")
+    val entity = ClassName(tacosPackage, "Entity")
+    val entityBuilder = ClassName(tacosPackage, "EntityBuilder")
     val type = TypeSpec.classBuilder("EntityBuilder")
         .primaryConstructor(FunSpec.constructorBuilder()
-            .addParameter(ParameterSpec.builder("argBuilder", ClassName.bestGuess("Payload")
+            .addParameter(ParameterSpec.builder("argBuilder", ClassName(tacosPackage, "Payload")
                 .parameterizedBy(entityBuilder, entity))
                 .defaultValue("Payload.create()")
                 .build())
             .build())
-        .addSuperinterface(ClassName.bestGuess("TypeBuilder")
+        .addSuperinterface(ClassName(tacosPackage, "TypeBuilder")
             .parameterizedBy(entityBuilder, entity),
             "argBuilder")
         .build()


### PR DESCRIPTION
In order to use use symbols from the default package in Kotlin they must be imported.