### PR TITLE
Allow ensureEndsWithNewLine to work with empty args

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -161,6 +161,9 @@ internal val String.isName get() = split("\\.").none { it.isKeyword }
 internal fun CodeBlock.ensureEndsWithNewLine() = if (isEmpty()) this else with(toBuilder()) {
   val lastFormatPart = formatParts.last()
   if (CodeBlock.isPlaceholder(lastFormatPart)) {
+    if (args.isEmpty()) {
+      return@with build()
+    }
     val lastArg = args.last()
     if (lastArg is String) {
       args[args.size - 1] = lastArg.trimEnd('\n') + '\n'

--- a/src/test/java/com/squareup/kotlinpoet/CodeBlockTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/CodeBlockTest.kt
@@ -441,4 +441,18 @@ class CodeBlockTest {
       |}
       |""".trimMargin())
   }
+
+  @Test fun ensureEndsWithNewLineWithNoArgs() {
+    val codeBlock = CodeBlock.builder()
+        .addStatement("Modeling a kdoc")
+        .add("\n")
+        .addStatement("Statement with no args")
+        .build()
+
+    assertThat(codeBlock.ensureEndsWithNewLine().toString()).isEqualTo("""
+      |Modeling a kdoc
+      |
+      |Statement with no args
+      |""".trimMargin())
+  }
 }


### PR DESCRIPTION
This originally came up when adding kdocs in `TypeSpec`. Here is a failing test case for `TypeSpec`. 

**Stacktrace**
```
UtilKt.ensureEndsWithNewLine(Util.kt:167)
	at com.squareup.kotlinpoet.TypeSpec.kdocWithConstructorParameters(TypeSpec.kt:311)
	at com.squareup.kotlinpoet.TypeSpec.emit$kotlinpoet(TypeSpec.kt:125)
	at com.squareup.kotlinpoet.TypeSpec.emit$kotlinpoet$default(TypeSpec.kt:79)
	at com.squareup.kotlinpoet.TypeSpec.toString(TypeSpec.kt:357)
	at com.squareup.kotlinpoet.TypeSpecTest.test(TypeSpecTest.kt:3742)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at com.google.testing.compile.CompilationRule$EvaluatingProcessor.process(CompilationRule.java:119)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment.callProcessor(JavacProcessingEnvironment.java:794)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment.access$200(JavacProcessingEnvironment.java:91)
```

**Reproducing test case:**

```kotlin
@Test fun test() {
    val taco = TypeSpec.classBuilder("Taco")
        .addKdoc(CodeBlock.builder()
            .addStatement("Describes a Taco ")
            .build())
        .addFunction(FunSpec.builder("getAnswer")
            .returns(Int::class)
            .addStatement("return 42")
            .build())
        .build()

    assertThat(taco.toString()).isEqualTo("")
  }
```
