### PR TITLE
Fix inline Taggable builder APIs by not breaking builder chain

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -102,7 +102,9 @@ class AnnotationSpec private constructor(
     DELEGATE("delegate")
   }
 
-  class Builder internal constructor(internal val className: ClassName): Taggable.Builder {
+  class Builder internal constructor(
+    internal val className: ClassName
+  ) : Taggable.Builder<AnnotationSpec.Builder> {
     internal var useSiteTarget: UseSiteTarget? = null
 
     val members = mutableListOf<CodeBlock>()

--- a/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -187,7 +187,7 @@ class FileSpec private constructor(
   class Builder internal constructor(
     val packageName: String,
     val name: String
-  ): Taggable.Builder {
+  ) : Taggable.Builder<FileSpec.Builder> {
     internal val comment = CodeBlock.builder()
     internal val memberImports = sortedSetOf<Import>()
     internal var indent = DEFAULT_INDENT

--- a/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -232,7 +232,9 @@ class FunSpec private constructor(
     return builder
   }
 
-  class Builder internal constructor(internal val name: String): Taggable.Builder {
+  class Builder internal constructor(
+    internal val name: String
+): Taggable.Builder<FunSpec.Builder> {
     internal val kdoc = CodeBlock.builder()
     internal var returnKdoc = CodeBlock.EMPTY
     internal var receiverKdoc = CodeBlock.EMPTY

--- a/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
@@ -77,7 +77,7 @@ class ParameterSpec private constructor(
   class Builder internal constructor(
     internal val name: String,
     internal val type: TypeName
-  ): Taggable.Builder {
+  ) : Taggable.Builder<ParameterSpec.Builder> {
     internal var defaultValue: CodeBlock? = null
 
     val kdoc = CodeBlock.builder()

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -144,7 +144,7 @@ class PropertySpec private constructor(
   class Builder internal constructor(
       internal val name: String,
       internal val type: TypeName
-  ): Taggable.Builder {
+  ) : Taggable.Builder<PropertySpec.Builder> {
     internal var isPrimaryConstructorParameter = false
     internal var mutable = false
     internal val kdoc = CodeBlock.builder()

--- a/src/main/java/com/squareup/kotlinpoet/Taggable.kt
+++ b/src/main/java/com/squareup/kotlinpoet/Taggable.kt
@@ -12,7 +12,7 @@ interface Taggable {
   fun <T : Any> tag(type: KClass<T>): T?
 
   /** The builder analogue to [Taggable] types. */
-  interface Builder {
+  interface Builder<out T : Builder<T>> {
 
     /** Mutable map of the current tags this builder contains. */
     val tags: MutableMap<KClass<*>, Any>
@@ -25,7 +25,7 @@ interface Taggable {
      * Use this API to attach originating elements, debugging, or other application data to a spec
      * so that you may read it in other APIs or callbacks.
      */
-    fun tag(type: Class<*>, tag: Any?) = tag(type.kotlin, tag)
+    fun tag(type: Class<*>, tag: Any?): T = tag(type.kotlin, tag)
 
     /**
      * Attaches [tag] to the request using [type] as a key. Tags can be read from a
@@ -35,13 +35,14 @@ interface Taggable {
      * Use this API to attach originating elements, debugging, or other application data to a spec
      * so that you may read it in other APIs or callbacks.
      */
-    fun tag(type: KClass<*>, tag: Any?) = apply {
+    @Suppress("UNCHECKED_CAST")
+    fun tag(type: KClass<*>, tag: Any?): T = apply {
       if (tag == null) {
         this.tags.remove(type)
       } else {
         this.tags[type] = tag
       }
-    }
+    } as T
   }
 }
 
@@ -53,12 +54,73 @@ inline fun <reified T : Any> Taggable.tag(): T? = tag(T::class)
  * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
  * [T].
  *
- * Use this API to attach originating elements, debugging, or other application data to a spec
- * so that you may read it in other APIs or callbacks.
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
  */
-inline fun <reified T : Any> Taggable.Builder.tag(tag: T?) = tag(T::class, tag)
 
-internal fun Taggable.Builder.buildTagMap(): TagMap = TagMap(LinkedHashMap(tags)) // Defensive copy
+inline fun <reified T : Any> AnnotationSpec.Builder.tag(tag: T?): AnnotationSpec.Builder = tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> FileSpec.Builder.tag(tag: T?): FileSpec.Builder = tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> FunSpec.Builder.tag(tag: T?): FunSpec.Builder = tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> ParameterSpec.Builder.tag(tag: T?): ParameterSpec.Builder = tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> PropertySpec.Builder.tag(tag: T?): PropertySpec.Builder = tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> TypeAliasSpec.Builder.tag(tag: T?): TypeAliasSpec.Builder = tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> TypeSpec.Builder.tag(tag: T?): TypeSpec.Builder = tag(T::class, tag)
+
+internal fun Taggable.Builder<*>.buildTagMap(): TagMap = TagMap(LinkedHashMap(tags)) // Defensive copy
 
 internal class TagMap(val tags: Map<KClass<*>, Any>) : Taggable {
   override fun <T : Any> tag(type: KClass<T>): T? {

--- a/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
@@ -65,7 +65,7 @@ class TypeAliasSpec private constructor(
   class Builder internal constructor(
     internal val name: String,
     internal val type: TypeName
-  ): Taggable.Builder {
+  ) : Taggable.Builder<TypeAliasSpec.Builder> {
     internal val kdoc = CodeBlock.builder()
 
     val modifiers = mutableSetOf<KModifier>()

--- a/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -392,7 +392,7 @@ class TypeSpec private constructor(
     internal var kind: Kind,
     internal val name: String?,
     vararg modifiers: KModifier
-  ): Taggable.Builder {
+  ) : Taggable.Builder<TypeSpec.Builder> {
     internal val kdoc = CodeBlock.builder()
     internal var primaryConstructor: FunSpec? = null
     internal var superclass: TypeName = ANY

--- a/src/test/java/com/squareup/kotlinpoet/TaggableTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TaggableTest.kt
@@ -1,6 +1,7 @@
 package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
+import com.squareup.kotlinpoet.KModifier.PUBLIC
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -64,14 +65,50 @@ class TaggableTest(val builder: Taggable.Builder<*>) {
   }
 
   private fun Taggable.Builder<*>.buildTaggable(): Taggable {
+    // Apply blocks test inline builder tag functions don't break the chain. Result is discarded
     return when (this) {
-      is AnnotationSpec.Builder -> build()
-      is FileSpec.Builder -> build()
-      is FunSpec.Builder -> build()
-      is ParameterSpec.Builder -> build()
-      is PropertySpec.Builder -> build()
-      is TypeAliasSpec.Builder -> build()
-      is TypeSpec.Builder -> build()
+      is AnnotationSpec.Builder -> build().apply {
+        toBuilder()
+            .tag(1)
+            .addMember(CodeBlock.of(""))
+            .build()
+      }
+      is FileSpec.Builder -> build().apply {
+        toBuilder()
+            .tag(1)
+            .addComment("Test")
+            .build()
+      }
+      is FunSpec.Builder -> build().apply {
+        toBuilder()
+            .tag(1)
+            .returns(String::class)
+            .build()
+      }
+      is ParameterSpec.Builder -> build().apply {
+        toBuilder()
+            .tag(1)
+            .addModifiers(PUBLIC)
+            .build()
+      }
+      is PropertySpec.Builder -> build().apply {
+        toBuilder()
+            .tag(1)
+            .initializer(CodeBlock.of(""))
+            .build()
+      }
+      is TypeAliasSpec.Builder -> build().apply {
+        toBuilder()
+            .tag(1)
+            .addKdoc(CodeBlock.of(""))
+            .build()
+      }
+      is TypeSpec.Builder -> build().apply {
+        toBuilder()
+            .tag(1)
+            .addKdoc(CodeBlock.of(""))
+            .build()
+      }
       else -> TODO("Unsupported type ${this::class.simpleName}")
     }
   }

--- a/src/test/java/com/squareup/kotlinpoet/TaggableTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TaggableTest.kt
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
-class TaggableTest(val builder: Taggable.Builder) {
+class TaggableTest(val builder: Taggable.Builder<*>) {
 
   companion object {
     @JvmStatic
@@ -28,7 +28,7 @@ class TaggableTest(val builder: Taggable.Builder) {
   }
 
   @Test fun builderShouldMakeDefensiveCopy() {
-    builder.tag("test")
+    builder.tag(String::class, "test")
     val taggable = builder.buildTaggable()
     builder.tags.remove(String::class)
     assertThat(taggable.tag<String>()).isEqualTo("test")
@@ -63,7 +63,7 @@ class TaggableTest(val builder: Taggable.Builder) {
     assertThat(taggable.tag(String::class)).isEqualTo("test")
   }
 
-  private fun Taggable.Builder.buildTaggable(): Taggable {
+  private fun Taggable.Builder<*>.buildTaggable(): Taggable {
     return when (this) {
       is AnnotationSpec.Builder -> build()
       is FileSpec.Builder -> build()


### PR DESCRIPTION
This was an unfortunate bug that I noticed too late - we can't have a general-use `inline` extension function for the builder tag APIs without losing context of the builder type. Open to suggestions on this, but haven't been able to figure out any other way right now. This breaks out the inline extensions to just be overloads for the different subclasses, but at the cost of not being able to make it something that each consumer control.