### PR TITLE
Introduce notion of "constant context" to CodeWriter

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -62,9 +62,11 @@ class AnnotationSpec private constructor(
 
     codeWriter.emit("(")
     if (members.size > 1) codeWriter.emit(whitespace).indent(2)
-    codeWriter.emitCode(members
-        .map { if (inline) it.replaceAll("[⇥|⇤]", "") else it }
-        .joinToCode(separator = memberSeparator))
+    codeWriter.emitCode(
+        codeBlock = members
+            .map { if (inline) it.replaceAll("[⇥|⇤]", "") else it }
+            .joinToCode(separator = memberSeparator),
+        isConstantContext = true)
     if (members.size > 1) codeWriter.unindent(2).emit(whitespace)
     codeWriter.emit(")")
   }

--- a/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -84,7 +84,11 @@ class PropertySpec private constructor(
       } else {
         codeWriter.emitCode(" = ")
       }
-      codeWriter.emitCode(if (initializer.hasStatements()) "%L" else "«%L»", initializer)
+      val initializerFormat = if (initializer.hasStatements()) "%L" else "«%L»"
+      codeWriter.emitCode(
+          codeBlock = CodeBlock.of(initializerFormat, initializer),
+          isConstantContext = KModifier.CONST in modifiers
+      )
     }
     codeWriter.emitWhereBlock(typeVariables)
     if (!inline) codeWriter.emit("\n")

--- a/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -81,9 +81,10 @@ private val Char.isIsoControl: Boolean
 /** Returns the string literal representing `value`, including wrapping double quotes.  */
 internal fun stringLiteralWithQuotes(
   value: String,
-  escapeDollarSign: Boolean = true
+  escapeDollarSign: Boolean = true,
+  isConstantContext: Boolean = false
 ): String {
-  if ('\n' in value) {
+  if (!isConstantContext && '\n' in value) {
     val result = StringBuilder(value.length + 32)
     result.append("\"\"\"\n|")
     var i = 0

--- a/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
@@ -256,6 +256,15 @@ class AnnotationSpecTest {
         "@kotlin.Deprecated(\"Nope\", kotlin.ReplaceWith(\"Nope\"))")
   }
 
+  @Test fun annotationStringsAreConstant() {
+    val text = "This is a long string with a newline\nin the middle."
+    val builder = AnnotationSpec.builder(Deprecated::class)
+        .addMember("%S", text)
+
+    assertThat(builder.build().toString()).isEqualTo("" +
+        "@kotlin.Deprecated(\"This is a long string with a newline\\nin the middle.\")")
+  }
+
   private fun toString(annotationSpec: AnnotationSpec) =
       toString(TypeSpec.classBuilder("Taco").addAnnotation(annotationSpec).build())
 

--- a/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
@@ -265,6 +265,45 @@ class AnnotationSpecTest {
         "@kotlin.Deprecated(\"This is a long string with a newline\\nin the middle.\")")
   }
 
+  @Test fun literalAnnotation() {
+    val annotationSpec = AnnotationSpec.builder(Suppress::class)
+        .addMember("%S", "Things")
+        .build()
+
+    val file = FileSpec.builder("test", "Test")
+        .addFunction(FunSpec.builder("test")
+            .addStatement("%L", annotationSpec)
+            .addStatement("val annotatedString = %S", "AnnotatedString")
+            .build())
+        .build()
+    assertThat(file.toString().trim()).isEqualTo("""
+      package test
+
+      import kotlin.Suppress
+
+      fun test() {
+          @Suppress("Things")
+          val annotatedString = "AnnotatedString"
+      }
+    """.trimIndent())
+  }
+
+  @Test fun functionOnlyLiteralAnnotation() {
+    val annotation = AnnotationSpec
+        .builder(ClassName.bestGuess("Suppress"))
+        .addMember("%S", "UNCHECKED_CAST")
+        .build()
+    val funSpec = FunSpec.builder("operation")
+        .addStatement("%L", annotation)
+        .build()
+
+    assertThat(funSpec.toString().trim()).isEqualTo("""
+      fun operation() {
+          @Suppress("UNCHECKED_CAST")
+      }
+      """.trimIndent())
+  }
+
   private fun toString(annotationSpec: AnnotationSpec) =
       toString(TypeSpec.classBuilder("Taco").addAnnotation(annotationSpec).build())
 

--- a/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
@@ -277,15 +277,15 @@ class AnnotationSpecTest {
             .build())
         .build()
     assertThat(file.toString().trim()).isEqualTo("""
-      package test
-
-      import kotlin.Suppress
-
-      fun test() {
-          @Suppress("Things")
-          val annotatedString = "AnnotatedString"
-      }
-    """.trimIndent())
+      |package test
+      |
+      |import kotlin.Suppress
+      |
+      |fun test() {
+      |    @Suppress("Things")
+      |    val annotatedString = "AnnotatedString"
+      |}
+    """.trimMargin())
   }
 
   @Test fun functionOnlyLiteralAnnotation() {
@@ -298,10 +298,10 @@ class AnnotationSpecTest {
         .build()
 
     assertThat(funSpec.toString().trim()).isEqualTo("""
-      fun operation() {
-          @Suppress("UNCHECKED_CAST")
-      }
-      """.trimIndent())
+      |fun operation() {
+      |    @Suppress("UNCHECKED_CAST")
+      |}
+      """.trimMargin())
   }
 
   private fun toString(annotationSpec: AnnotationSpec) =

--- a/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -359,4 +359,20 @@ class PropertySpecTest {
       |    get() = field * 5
       |""".trimMargin())
   }
+
+  @Test fun constProperty() {
+    val text = "This is a long string with a newline\nin the middle."
+    val spec = FileSpec.builder("testsrc", "Test")
+        .addProperty(PropertySpec.builder("FOO", String::class, KModifier.CONST)
+            .initializer("%S", text)
+            .build())
+        .build()
+    assertThat(spec.toString()).isEqualTo("""
+      |package testsrc
+      |
+      |import kotlin.String
+      |
+      |const val FOO: String = "This is a long string with a newline\nin the middle."
+      |""".trimMargin())
+  }
 }

--- a/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
@@ -65,6 +65,8 @@ class UtilTest {
         .isEqualTo("\"\"\"\n|abc();\n|def();\n\"\"\".trimMargin()")
     stringLiteral("This is \\\"quoted\\\"!", "This is \"quoted\"!")
     stringLiteral("e^{i\\\\pi}+1=0", "e^{i\\pi}+1=0")
+    assertThat(stringLiteralWithQuotes("abc();\ndef();", isConstantContext = true))
+        .isEqualTo("\"abc();\\ndef();\"")
   }
 
   @Test fun legalIdentifiers() {


### PR DESCRIPTION
This is a successor to #630 and #628, with the goal of resolving a couple issues around constant context emissions.

There are two use cases right now:
1 - Strings that should be constant (such as for `const` or as annotation members). Ref - #629
2 - Better supporting literal annotations emission depending on the context. As an annotation member, they need to be constant and can omit the `@` sign. As a literal in a `CodeBlock` that isn't in this context, they need the `@` sign. Adding this clarifies that context and can be controlled at the `AnnotationSpec` level. Ref - #649

By only adding this as an added parameter to `CodeWriter#emitCode()`, this is far less invasive than #630. It also doesn't do #630's property type validation for `KModifier.CONST` and instead just uses the presence of `CONST` in its modifiers as the sole heuristic, with the idea being that the developer should know if the type they're using can't be `const` and if they don't then the compiler will tell them later :).

Resolves #629
Resolves #649

I think this kills two birds with one stone quite nicely. Let me know what you all think!