### PR TITLE
Fix bug with MemberNames in same package nested inside a class.

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -409,13 +409,13 @@ internal class CodeWriter constructor(
     val importedMember = importedMembers[simpleName]
     if (importedMember == memberName) {
       return simpleName
-    } else if (memberName.enclosingClassName != null) {
+    } else if (importedMember != null && memberName.enclosingClassName != null) {
       val enclosingClassName = lookupName(memberName.enclosingClassName)
       return "$enclosingClassName.$simpleName"
     }
 
     // If the member is in the same package, we're done.
-    if (packageName == memberName.packageName) {
+    if (packageName == memberName.packageName && memberName.enclosingClassName == null) {
       referencedNames.add(memberName.simpleName)
       return memberName.simpleName
     }

--- a/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -409,7 +409,7 @@ internal class CodeWriter constructor(
     val importedMember = importedMembers[simpleName]
     if (importedMember == memberName) {
       return simpleName
-    } else if (importedMember != null && memberName.enclosingClassName != null) {
+    } else if (memberName.enclosingClassName != null) {
       val enclosingClassName = lookupName(memberName.enclosingClassName)
       return "$enclosingClassName.$simpleName"
     }

--- a/src/test/java/com/squareup/kotlinpoet/MemberNameTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/MemberNameTest.kt
@@ -79,6 +79,25 @@ class MemberNameTest {
       |""".trimMargin())
   }
 
+  @Test fun memberInsideClassInSamePackage() {
+    val createTaco = MemberName(
+        ClassName("com.squareup.tacos", "Town"),
+        "createTaco"
+    )
+    val file = FileSpec.builder("com.squareup.tacos", "Tacos")
+        .addFunction(FunSpec.builder("makeTastyTacos")
+            .addStatement("%M()", createTaco)
+            .build())
+        .build()
+    assertThat(file.toString()).isEqualTo("""
+      |package com.squareup.tacos
+      |
+      |fun makeTastyTacos() {
+      |  Town.createTaco()
+      |}
+      |""".trimMargin())
+  }
+
   @Test fun memberNamesClash() {
     val createSquareTaco = MemberName("com.squareup.tacos", "createTaco")
     val createTwitterTaco = MemberName("com.twitter.tacos", "createTaco")

--- a/src/test/java/com/squareup/kotlinpoet/MemberNameTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/MemberNameTest.kt
@@ -92,8 +92,10 @@ class MemberNameTest {
     assertThat(file.toString()).isEqualTo("""
       |package com.squareup.tacos
       |
+      |import com.squareup.tacos.Town.createTaco
+      |
       |fun makeTastyTacos() {
-      |  Town.createTaco()
+      |  createTaco()
       |}
       |""".trimMargin())
   }


### PR DESCRIPTION
The test case pretty accurately reflects the bug I was encountering: within the same package, we still need to qualify members that are part of an enclosing class.