### PR TITLE
Pass only unique originating elements to Filer

### DIFF
--- a/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -99,8 +99,10 @@ class FileSpec private constructor(
   /** Writes this to `filer`.  */
   @Throws(IOException::class)
   fun writeTo(filer: Filer) {
-    val originatingElements = members.filterIsInstance<OriginatingElementsHolder>()
-        .flatMap(OriginatingElementsHolder::originatingElements)
+    val originatingElements = members.asSequence()
+        .filterIsInstance<OriginatingElementsHolder>()
+        .flatMap { it.originatingElements.asSequence() }
+        .toSet()
     val filerSourceFile = filer.createResource(StandardLocation.SOURCE_OUTPUT,
         packageName,
         "$name.kt",

--- a/src/test/java/com/squareup/kotlinpoet/FileWritingTest.kt
+++ b/src/test/java/com/squareup/kotlinpoet/FileWritingTest.kt
@@ -207,6 +207,28 @@ class FileWritingTest {
     )
   }
 
+  @Test fun filerPassesOnlyUniqueOriginatingElements() {
+    val element1 = FakeElement()
+    val fun1 = FunSpec.builder("test1")
+        .addOriginatingElement(element1)
+        .build()
+
+    val element2 = FakeElement()
+    val fun2 = FunSpec.builder("test2")
+        .addOriginatingElement(element1)
+        .addOriginatingElement(element2)
+        .build()
+
+    FileSpec.builder("example", "File")
+        .addFunction(fun1)
+        .addFunction(fun2)
+        .build()
+        .writeTo(filer)
+
+    val file = fsRoot.resolve(fs.getPath("example", "File.kt"))
+    assertThat(filer.getOriginatingElements(file)).containsExactly(element1, element2)
+  }
+
   @Test fun filerClassesWithTabIndent() {
     val test = TypeSpec.classBuilder("Test")
         .addProperty("madeFreshDate", Date::class)

--- a/src/test/java/com/squareup/kotlinpoet/TestFiler.kt
+++ b/src/test/java/com/squareup/kotlinpoet/TestFiler.kt
@@ -48,7 +48,7 @@ internal class TestFiler(
 
   private val separator = fileSystem.separator
   private val fileSystemProvider = fileSystem.provider()
-  private val originatingElementsMap = mutableMapOf<Path, Set<Element>>()
+  private val originatingElementsMap = mutableMapOf<Path, List<Element>>()
 
   fun getOriginatingElements(path: Path) = originatingElementsMap[path] ?: throw NullPointerException("Could not find $path")
 
@@ -56,7 +56,7 @@ internal class TestFiler(
       name: CharSequence, vararg originatingElements: Element): JavaFileObject {
     val relative = name.toString().replace(".", separator) + ".kt" // Assumes well-formed.
     val path = fileSystemRoot.resolve(relative)
-    originatingElementsMap[path] = Arrays.asList(*originatingElements).toImmutableSet()
+    originatingElementsMap[path] = originatingElements.toList()
     return Source(path)
   }
 
@@ -67,7 +67,7 @@ internal class TestFiler(
       relativeName: CharSequence, vararg originatingElements: Element): FileObject {
     val relative = pkg.toString().replace(".", separator) + separator + relativeName
     val path = fileSystemRoot.resolve(relative)
-    originatingElementsMap[path] = Arrays.asList(*originatingElements).toImmutableSet()
+    originatingElementsMap[path] = originatingElements.toList()
     return Source(path)
   }
 


### PR DESCRIPTION
If let's say we generate 20 top-level elements from a single originating element there is no point in passing that originating element to Filer 20 times. It's inconvenient during debugging/logging where you are only interested in unique elements and [breaks](https://github.com/JetBrains/kotlin/blob/6381b3b1515fb8f1115610e7019fb7bd30bcbc6a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/incremental/incrementalProcessors.kt#L108-L109) incremental processing (which will be properly fixed in kapt).