### PR TITLE
Add experimental typeNameOf() API for TypeName

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
@@ -21,6 +21,10 @@ import java.lang.reflect.ParameterizedType
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
+import kotlin.reflect.typeOf
+
+@ExperimentalStdlibApi
+inline fun <reified T> typeNameOf(): TypeName = typeOf<T>().asTypeName()
 
 /** Returns a parameterized type equivalent to `type`.  */
 @JvmName("get")


### PR DESCRIPTION
This depends on the experimental `typeOf()` API from the stdlib and propagates the same experimental annotation to guard it.

This can be used as a shorthand for basically almost all of the current typename variants' static factories, and just leave the factories for when arguments are being passed in from somewhere else.