### PR TITLE
Add implicitModifiers for types

### DIFF
--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -1026,21 +1026,6 @@ class TypeSpecTest {
       |""".trimMargin())
   }
 
-  @Test
-  fun test () {
-    val fileSpec = FileSpec.builder("com", "Example")
-        .addType(TypeSpec.expectClassBuilder("ClassA")
-            .addType(TypeSpec.classBuilder("ClassB")
-                .addFunction(FunSpec.builder("test")
-                    .build())
-                .build())
-            .build())
-        .build()
-
-    assertThat(fileSpec.toString()).isEqualTo("""
-      |""".trimMargin())
-  }
-
   @Test fun interfaceWithMethods() {
     val taco = TypeSpec.interfaceBuilder("Taco")
         .addFunction(FunSpec.builder("aMethod")

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -979,6 +979,68 @@ class TypeSpecTest {
         |""".trimMargin())
   }
 
+  @Test fun expectClass() {
+    val classA = TypeSpec.expectClassBuilder("ClassA")
+        .addFunction(FunSpec.builder("test")
+            .build())
+        .build()
+
+    assertThat(classA.toString()).isEqualTo("""
+      |expect class ClassA {
+      |  fun test()
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun nestedExpectCompanionObjectWithFunction() {
+    val classA = TypeSpec.expectClassBuilder("ClassA")
+        .addType(TypeSpec.companionObjectBuilder()
+            .addFunction(FunSpec.builder("test")
+                .build())
+            .build())
+        .build()
+
+    assertThat(classA.toString()).isEqualTo("""
+      |expect class ClassA {
+      |  companion object {
+      |    fun test()
+      |  }
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun nestedExpectClassWithFunction() {
+    val classA = TypeSpec.expectClassBuilder("ClassA")
+        .addType(TypeSpec.classBuilder("ClassB")
+            .addFunction(FunSpec.builder("test")
+                .build())
+            .build())
+        .build()
+
+    assertThat(classA.toString()).isEqualTo("""
+      |expect class ClassA {
+      |  class ClassB {
+      |    fun test()
+      |  }
+      |}
+      |""".trimMargin())
+  }
+
+  @Test
+  fun test () {
+    val fileSpec = FileSpec.builder("com", "Example")
+        .addType(TypeSpec.expectClassBuilder("ClassA")
+            .addType(TypeSpec.classBuilder("ClassB")
+                .addFunction(FunSpec.builder("test")
+                    .build())
+                .build())
+            .build())
+        .build()
+
+    assertThat(fileSpec.toString()).isEqualTo("""
+      |""".trimMargin())
+  }
+
   @Test fun interfaceWithMethods() {
     val taco = TypeSpec.interfaceBuilder("Taco")
         .addFunction(FunSpec.builder("aMethod")


### PR DESCRIPTION
Have added a way for implicit modifiers to get propagated for types as well. This allows `expect` modifiers to go down to inner types. 

Resolves #699 