### PR TITLE
typeNameOf tests + move

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
@@ -21,10 +21,6 @@ import java.lang.reflect.ParameterizedType
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
-import kotlin.reflect.typeOf
-
-@ExperimentalStdlibApi
-inline fun <reified T> typeNameOf(): TypeName = typeOf<T>().asTypeName()
 
 /** Returns a parameterized type equivalent to `type`.  */
 @JvmName("get")

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -39,6 +39,7 @@ import javax.lang.model.util.SimpleTypeVisitor7
 import kotlin.reflect.KClass
 import kotlin.reflect.KTypeProjection
 import kotlin.reflect.KVariance
+import kotlin.reflect.typeOf
 
 /**
  * Any type in Kotlin's type system. This class identifies simple types like `Int` and `String`,
@@ -273,6 +274,9 @@ fun KClass<*>.asTypeName() = asClassName()
 /** Returns a [TypeName] equivalent to this [Type].  */
 @JvmName("get")
 fun Type.asTypeName() = TypeName.get(this, mutableMapOf())
+
+@ExperimentalStdlibApi
+inline fun <reified T> typeNameOf(): TypeName = typeOf<T>().asTypeName()
 
 /** A fully-qualified class name for top-level and member classes.  */
 class ClassName internal constructor(

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeNameKotlinTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeNameKotlinTest.kt
@@ -1,0 +1,60 @@
+package com.squareup.kotlinpoet
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+@ExperimentalStdlibApi
+class TypeNameKotlinTest {
+
+  @Test
+  fun typeNameOf_simple() {
+    val type = typeNameOf<TypeNameKotlinTest>()
+    assertThat(type.toString()).isEqualTo("com.squareup.kotlinpoet.TypeNameKotlinTest")
+  }
+
+  @Test
+  fun typeNameOf_simple_intrinsic() {
+    val type = typeNameOf<String>()
+    assertThat(type.toString()).isEqualTo("kotlin.String")
+  }
+
+  @Test
+  fun typeNameOf_array_primitive() {
+    val type = typeNameOf<IntArray>()
+    assertThat(type.toString()).isEqualTo("kotlin.IntArray")
+  }
+
+  @Test
+  fun typeNameOf_array_parameterized() {
+    val type = typeNameOf<Array<String>>()
+    assertThat(type.toString()).isEqualTo("kotlin.Array<kotlin.String>")
+  }
+
+  @Test
+  fun typeNameOf_generic() {
+    val type = typeNameOf<List<String>>()
+    assertThat(type.toString()).isEqualTo("kotlin.collections.List<kotlin.String>")
+  }
+
+  @Test
+  fun typeNameOf_generic_wildcard_out() {
+    val type = typeNameOf<GenericType<out String>>()
+    assertThat(type.toString()).isEqualTo("com.squareup.kotlinpoet.TypeNameKotlinTest.GenericType<out kotlin.String>")
+  }
+
+  @Test
+  fun typeNameOf_generic_wildcard_in() {
+    val type = typeNameOf<GenericType<in String>>()
+    assertThat(type.toString()).isEqualTo("com.squareup.kotlinpoet.TypeNameKotlinTest.GenericType<in kotlin.String>")
+  }
+
+  @Test
+  fun typeNameOf_complex() {
+    val type = typeNameOf<Map<String, List<Map<Int, GenericType<in Set<Array<GenericType<out String>>>>>>>>()
+    assertThat(type.toString()).isEqualTo("kotlin.collections.Map<kotlin.String, kotlin.collections.List<kotlin.collections.Map<kotlin.Int, com.squareup.kotlinpoet.TypeNameKotlinTest.GenericType<in kotlin.collections.Set<kotlin.Array<com.squareup.kotlinpoet.TypeNameKotlinTest.GenericType<out kotlin.String>>>>>>>")
+  }
+
+  @Suppress("unused")
+  class GenericType<T>
+
+}

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeNameKotlinTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeNameKotlinTest.kt
@@ -56,5 +56,4 @@ class TypeNameKotlinTest {
 
   @Suppress("unused")
   class GenericType<T>
-
 }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeNameKotlinTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeNameKotlinTest.kt
@@ -50,8 +50,8 @@ class TypeNameKotlinTest {
 
   @Test
   fun typeNameOf_complex() {
-    val type = typeNameOf<Map<String, List<Map<Int, GenericType<in Set<Array<GenericType<out String>>>>>>>>()
-    assertThat(type.toString()).isEqualTo("kotlin.collections.Map<kotlin.String, kotlin.collections.List<kotlin.collections.Map<kotlin.Int, com.squareup.kotlinpoet.TypeNameKotlinTest.GenericType<in kotlin.collections.Set<kotlin.Array<com.squareup.kotlinpoet.TypeNameKotlinTest.GenericType<out kotlin.String>>>>>>>")
+    val type = typeNameOf<Map<String, List<Map<*, GenericType<in Set<Array<GenericType<out String>>>>>>>>()
+    assertThat(type.toString()).isEqualTo("kotlin.collections.Map<kotlin.String, kotlin.collections.List<kotlin.collections.Map<*, com.squareup.kotlinpoet.TypeNameKotlinTest.GenericType<in kotlin.collections.Set<kotlin.Array<com.squareup.kotlinpoet.TypeNameKotlinTest.GenericType<out kotlin.String>>>>>>>")
   }
 
   @Suppress("unused")

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeNameKotlinTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeNameKotlinTest.kt
@@ -31,6 +31,12 @@ class TypeNameKotlinTest {
   }
 
   @Test
+  fun typeNameOf_nullable() {
+    val type = typeNameOf<String?>()
+    assertThat(type.toString()).isEqualTo("kotlin.String?")
+  }
+
+  @Test
   fun typeNameOf_generic() {
     val type = typeNameOf<List<String>>()
     assertThat(type.toString()).isEqualTo("kotlin.collections.List<kotlin.String>")
@@ -50,8 +56,8 @@ class TypeNameKotlinTest {
 
   @Test
   fun typeNameOf_complex() {
-    val type = typeNameOf<Map<String, List<Map<*, GenericType<in Set<Array<GenericType<out String>>>>>>>>()
-    assertThat(type.toString()).isEqualTo("kotlin.collections.Map<kotlin.String, kotlin.collections.List<kotlin.collections.Map<*, com.squareup.kotlinpoet.TypeNameKotlinTest.GenericType<in kotlin.collections.Set<kotlin.Array<com.squareup.kotlinpoet.TypeNameKotlinTest.GenericType<out kotlin.String>>>>>>>")
+    val type = typeNameOf<Map<String, List<Map<*, GenericType<in Set<Array<GenericType<out String>?>>>>>>>()
+    assertThat(type.toString()).isEqualTo("kotlin.collections.Map<kotlin.String, kotlin.collections.List<kotlin.collections.Map<*, com.squareup.kotlinpoet.TypeNameKotlinTest.GenericType<in kotlin.collections.Set<kotlin.Array<com.squareup.kotlinpoet.TypeNameKotlinTest.GenericType<out kotlin.String>?>>>>>>")
   }
 
   @Suppress("unused")


### PR DESCRIPTION
This moves `typeNameOf()` to `TypeName.kt` (something I had committed locally but forgot to push before the last PR was merged), and adds tests for it in `TypeNameKotlinTest.kt`