### PR TITLE
Upgrade Truth to 1.0

### DIFF
--- a/kotlinpoet-km/build.gradle.kts
+++ b/kotlinpoet-km/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
   api("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
   api("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0")
   testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
-  testImplementation("com.google.truth:truth:0.42")
+  testImplementation("com.google.truth:truth:1.0")
 }
 
 repositories {

--- a/kotlinpoet/build.gradle.kts
+++ b/kotlinpoet/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
   api("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
   implementation("org.jetbrains.kotlin:kotlin-reflect")
   testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
-  testImplementation("com.google.truth:truth:0.42")
+  testImplementation("com.google.truth:truth:1.0")
   testImplementation("com.google.testing.compile:compile-testing:0.15")
   testImplementation("com.google.jimfs:jimfs:1.1")
   testImplementation("org.eclipse.jdt.core.compiler:ecj:4.6.1")


### PR DESCRIPTION
Changelog: https://github.com/google/truth/releases

Now that we have two modules, we should probably extract the dependencies into a `Dependencies.kt` file to avoid duplication. 

Can do that in a followup. 