### PR TITLE
Flesh out more KmSpecs tests

### DIFF
--- a/kotlinpoet-km/src/main/kotlin/com/squareup/kotlinpoet/km/Flags.kt
+++ b/kotlinpoet-km/src/main/kotlin/com/squareup/kotlinpoet/km/Flags.kt
@@ -257,7 +257,9 @@ val ImmutableKmValueParameter.isNoInline: Boolean get() = Flag.ValueParameter.IS
 
 // Property flags.
 @KotlinPoetKm
-val Flags.isOverrideProperty: Boolean get() = Flag.Property.IS_FAKE_OVERRIDE(this)
+val Flags.isFakeOverrideProperty: Boolean get() = Flag.Property.IS_FAKE_OVERRIDE(this)
+@KotlinPoetKm
+val Flags.isOverrideProperty: Boolean get() = false // TODO This isn't contained in metadata. Likely have to read an annotation
 @KotlinPoetKm
 val KmProperty.hasConstant: Boolean get() = Flag.Property.HAS_CONSTANT(flags)
 @KotlinPoetKm
@@ -277,7 +279,7 @@ val KmProperty.isExpect: Boolean get() = Flag.Property.IS_EXPECT(flags)
 @KotlinPoetKm
 val KmProperty.isExternal: Boolean get() = Flag.Property.IS_EXTERNAL(flags)
 @KotlinPoetKm
-val KmProperty.isOverride: Boolean get() = flags.isOverrideProperty
+val KmProperty.isFakeOverride: Boolean get() = flags.isFakeOverrideProperty
 @KotlinPoetKm
 val KmProperty.isLateinit: Boolean get() = Flag.Property.IS_LATEINIT(flags)
 @KotlinPoetKm
@@ -304,6 +306,8 @@ val ImmutableKmProperty.isDelegation: Boolean get() = Flag.Property.IS_DELEGATIO
 val ImmutableKmProperty.isExpect: Boolean get() = Flag.Property.IS_EXPECT(flags)
 @KotlinPoetKm
 val ImmutableKmProperty.isExternal: Boolean get() = Flag.Property.IS_EXTERNAL(flags)
+@KotlinPoetKm
+val ImmutableKmProperty.isFakeOverride: Boolean get() = flags.isFakeOverrideProperty
 @KotlinPoetKm
 val ImmutableKmProperty.isOverride: Boolean get() = flags.isOverrideProperty
 @KotlinPoetKm

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/KmSpecs.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/KmSpecs.kt
@@ -309,38 +309,33 @@ private fun ImmutableKmProperty.toPropertySpec(
         }
       }
       if (hasGetter) {
-        val visibility = setterFlags.visibility
-        val modalities = setterFlags.modalities
-            .filterNot { it == KModifier.FINAL && !flags.isOverrideProperty }
-        val propertyAccessorFlags = setterFlags.propertyAccessorFlags
-        if (visibility != KModifier.PUBLIC || modalities.isNotEmpty() || propertyAccessorFlags.isNotEmpty()) {
-          getter(FunSpec.setterBuilder()
-              .apply {
-                addModifiers(visibility)
-                addModifiers(*modalities.toTypedArray())
-                addModifiers(*propertyAccessorFlags.toKModifiersArray())
-              }
-              .build())
-        }
+        propertyAccessor(getterFlags, FunSpec.getterBuilder())?.let(::getter)
       }
       if (hasSetter) {
-        val visibility = setterFlags.visibility
-        val modalities = setterFlags.modalities
-            .filterNot { it == KModifier.FINAL && !flags.isOverrideProperty }
-        val propertyAccessorFlags = setterFlags.propertyAccessorFlags
-        if (visibility != KModifier.PUBLIC || modalities.isNotEmpty() || propertyAccessorFlags.isNotEmpty()) {
-          setter(FunSpec.setterBuilder()
-              .apply {
-                addModifiers(visibility)
-                addModifiers(*modalities.toTypedArray())
-                addModifiers(*propertyAccessorFlags.toKModifiersArray())
-              }
-              .build())
-        }
+        propertyAccessor(setterFlags, FunSpec.setterBuilder())?.let(::setter)
       }
     }
     .tag(this)
     .build()
+
+@KotlinPoetKm
+private fun propertyAccessor(flags: Flags, functionBuilder: FunSpec.Builder): FunSpec? {
+  val visibility = flags.visibility
+  val modalities = flags.modalities
+      .filterNot { it == KModifier.FINAL && !flags.isOverrideProperty }
+  val propertyAccessorFlags = flags.propertyAccessorFlags
+  return if (visibility != KModifier.PUBLIC || modalities.isNotEmpty() || propertyAccessorFlags.isNotEmpty()) {
+    functionBuilder
+        .apply {
+          addModifiers(visibility)
+          addModifiers(*modalities.toTypedArray())
+          addModifiers(*propertyAccessorFlags.toKModifiersArray())
+        }
+        .build()
+  } else {
+    null
+  }
+}
 
 private fun Set<PropertyAccessorFlag>.toKModifiersArray(): Array<KModifier> {
   return map {

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/KmSpecs.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/KmSpecs.kt
@@ -136,6 +136,9 @@ private fun ImmutableKmClass.toTypeSpec(): TypeSpec {
     builder.addModifiers(KModifier.INNER)
   }
   if (isEnumEntry) {
+    // TODO
+  }
+  if (isEnum) {
     // TODO handle typespec arg for complex enums
     enumEntries.forEach {
       builder.addEnumConstant(it)
@@ -143,7 +146,9 @@ private fun ImmutableKmClass.toTypeSpec(): TypeSpec {
   }
 
   builder.addTypeVariables(typeParameters.map { it.toTypeVariableName(typeParamResolver) })
-  supertypes.first().toTypeName(typeParamResolver).takeIf { it != ANY }?.let(builder::superclass)
+  if (!isEnum) {
+    supertypes.first().toTypeName(typeParamResolver).takeIf { it != ANY }?.let(builder::superclass)
+  }
   builder.addSuperinterfaces(supertypes.drop(1).map { it.toTypeName(typeParamResolver) })
   val primaryConstructorSpec = primaryConstructor?.takeIf { it.valueParameters.isNotEmpty() || flags.visibility != KModifier.PUBLIC }?.let {
     it.toFunSpec(typeParamResolver).also {

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/KmSpecs.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/KmSpecs.kt
@@ -119,6 +119,7 @@ private fun ImmutableKmClass.toTypeSpec(): TypeSpec {
   addVisibility { builder.addModifiers(it) }
   builder.addModifiers(*flags.modalities
       .filterNot { it == KModifier.FINAL } // Default
+      .filterNot { isInterface && it == KModifier.ABSTRACT } // Abstract is a default on interfaces
       .toTypedArray()
   )
   if (isData) {
@@ -146,10 +147,10 @@ private fun ImmutableKmClass.toTypeSpec(): TypeSpec {
   }
 
   builder.addTypeVariables(typeParameters.map { it.toTypeVariableName(typeParamResolver) })
-  if (!isEnum) {
+  if (!isEnum && !isInterface) {
     supertypes.first().toTypeName(typeParamResolver).takeIf { it != ANY }?.let(builder::superclass)
   }
-  builder.addSuperinterfaces(supertypes.drop(1).map { it.toTypeName(typeParamResolver) })
+  builder.addSuperinterfaces(supertypes.drop(if (isInterface) 0 else 1).map { it.toTypeName(typeParamResolver) })
   val primaryConstructorSpec = primaryConstructor?.takeIf { it.valueParameters.isNotEmpty() || flags.visibility != KModifier.PUBLIC }?.let {
     it.toFunSpec(typeParamResolver).also {
       builder.primaryConstructor(it)

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/KmSpecs.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/KmSpecs.kt
@@ -279,7 +279,8 @@ private fun ImmutableKmProperty.toPropertySpec(
     .apply {
       addVisibility { addModifiers(it) }
       addModifiers(*flags.modalities
-          .filterNot { it == KModifier.FINAL && !isOverride }
+          .filterNot { it == KModifier.FINAL && !isOverride } // Final is the default
+          .filterNot { it == KModifier.OPEN && isOverride } // Overrides are implicitly open
           .toTypedArray())
       if (isOverride) {
         addModifiers(KModifier.OVERRIDE)

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/KmSpecs.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/KmSpecs.kt
@@ -109,7 +109,7 @@ private fun ImmutableKmClass.toTypeSpec(): TypeSpec {
   val simpleName = name.substringAfterLast(if (isInline) "/" else ".")
   val builder = when {
     isAnnotation -> TypeSpec.annotationBuilder(simpleName)
-    isCompanionObject -> TypeSpec.companionObjectBuilder(simpleName)
+    isCompanionObject -> TypeSpec.companionObjectBuilder(companionObjectName(simpleName))
     isEnum -> TypeSpec.enumBuilder(simpleName)
     isExpect -> TypeSpec.expectClassBuilder(simpleName)
     isObject -> TypeSpec.objectBuilder(simpleName)
@@ -164,7 +164,7 @@ private fun ImmutableKmClass.toTypeSpec(): TypeSpec {
           .asIterable()
   )
   companionObject?.let {
-    builder.addType(TypeSpec.companionObjectBuilder(it).build())
+    builder.addType(TypeSpec.companionObjectBuilder(companionObjectName(it)).build())
   }
   builder.addFunctions(
       functions
@@ -179,6 +179,10 @@ private fun ImmutableKmClass.toTypeSpec(): TypeSpec {
   return builder
       .tag(this)
       .build()
+}
+
+private fun companionObjectName(name: String): String? {
+  return if (name == "Companion") null else name
 }
 
 @KotlinPoetKm

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -27,7 +27,7 @@ class KmSpecsTest {
   fun constructorData() {
     val typeSpec = ConstructorClass::class.toTypeSpec()
     //language=kotlin
-    assertThat(typeSpec.toString().trim()).isEqualTo("""
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class ConstructorClass(
         val foo: kotlin.String,
         vararg bar: kotlin.Int
@@ -48,7 +48,7 @@ class KmSpecsTest {
     val typeSpec = Supertype::class.toTypeSpec()
 
     //language=kotlin
-    assertThat(typeSpec.toString().trim()).isEqualTo("""
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Supertype : com.squareup.kotlinpoet.KmSpecsTest.BaseType(), com.squareup.kotlinpoet.KmSpecsTest.BaseInterface
     """.trimIndent())
   }
@@ -62,7 +62,7 @@ class KmSpecsTest {
     val typeSpec = Properties::class.toTypeSpec()
 
     //language=kotlin
-    assertThat(typeSpec.toString().trim()).isEqualTo("""
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Properties {
         var aList: kotlin.collections.List<kotlin.Int> = TODO("Stub!")
       
@@ -86,7 +86,7 @@ class KmSpecsTest {
   fun companionObject() {
     val typeSpec = CompanionObject::class.toTypeSpec()
     //language=kotlin
-    assertThat(typeSpec.toString().trim()).isEqualTo("""
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class CompanionObject {
         companion object
       }
@@ -101,7 +101,7 @@ class KmSpecsTest {
   fun namedCompanionObject() {
     val typeSpec = NamedCompanionObject::class.toTypeSpec()
     //language=kotlin
-    assertThat(typeSpec.toString().trim()).isEqualTo("""
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class NamedCompanionObject {
         companion object Named
       }
@@ -116,7 +116,7 @@ class KmSpecsTest {
   fun generics() {
     val typeSpec = Generics::class.toTypeSpec()
     //language=kotlin
-    assertThat(typeSpec.toString().trim()).isEqualTo("""
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Generics<T, in R, V>(
         val genericInput: T
       )
@@ -131,7 +131,7 @@ class KmSpecsTest {
 
     // We always resolve the underlying type of typealiases
     //language=kotlin
-    assertThat(typeSpec.toString().trim()).isEqualTo("""
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class TypeAliases(
         val foo: kotlin.String,
         val bar: kotlin.collections.List<kotlin.String>
@@ -145,7 +145,7 @@ class KmSpecsTest {
   fun propertyMutability() {
     val typeSpec = PropertyMutability::class.toTypeSpec()
     //language=kotlin
-    assertThat(typeSpec.toString().trim()).isEqualTo("""
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class PropertyMutability(
         val foo: kotlin.String,
         var mutableFoo: kotlin.String
@@ -159,7 +159,7 @@ class KmSpecsTest {
   fun collectionMutability() {
     val typeSpec = CollectionMutability::class.toTypeSpec()
     //language=kotlin
-    assertThat(typeSpec.toString().trim()).isEqualTo("""
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class CollectionMutability(
         val immutableList: kotlin.collections.List<kotlin.String>,
         val mutableList: kotlin.collections.MutableList<kotlin.String>
@@ -173,7 +173,7 @@ class KmSpecsTest {
   fun suspendTypes() {
     val typeSpec = SuspendTypes::class.toTypeSpec()
     //language=kotlin
-    assertThat(typeSpec.toString().trim()).isEqualTo("""
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class SuspendTypes {
         val testProp: suspend (kotlin.Int, kotlin.Long) -> kotlin.String = TODO("Stub!")
 
@@ -206,7 +206,7 @@ class KmSpecsTest {
   fun parameters() {
     val typeSpec = Parameters::class.toTypeSpec()
     //language=kotlin
-    assertThat(typeSpec.toString().trim()).isEqualTo("""
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Parameters {
         inline fun hasDefault(param1: kotlin.String = TODO("Stub!")) {
         }
@@ -237,7 +237,7 @@ class KmSpecsTest {
   fun lambdaReceiver() {
     val typeSpec = LambdaReceiver::class.toTypeSpec()
     //language=kotlin
-    assertThat(typeSpec.toString().trim()).isEqualTo("""
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class LambdaReceiver {
         fun lambdaReceiver(block: kotlin.String.() -> kotlin.Unit) {
         }
@@ -265,7 +265,7 @@ class KmSpecsTest {
     val typeSpec = NestedTypeAliasTest::class.toTypeSpec()
 
     //language=kotlin
-    assertThat(typeSpec.toString().trim()).isEqualTo("""
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class NestedTypeAliasTest {
         val prop: kotlin.collections.List<kotlin.collections.List<kotlin.String>> = TODO("Stub!")
       }
@@ -281,7 +281,7 @@ class KmSpecsTest {
     val typeSpec = InlineClass::class.toTypeSpec()
 
     //language=kotlin
-    assertThat(typeSpec.toString().trim()).isEqualTo("""
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
       inline class InlineClass(
         val value: kotlin.String
       )
@@ -296,6 +296,10 @@ class KmSpecsTest {
   // TODO Tagged km types
   // TODO Backward referencing type arguments (T, B<T>)
   // TODO Excluding delegated, only including declared
+}
+
+private fun TypeSpec.trimmedToString(): String {
+  return toString().trim()
 }
 
 inline class InlineClass(val value: String)

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -17,6 +17,7 @@ package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
 import com.squareup.kotlinpoet.km.KotlinPoetKm
+import org.junit.Ignore
 import org.junit.Test
 
 @KotlinPoetKm
@@ -307,7 +308,51 @@ class KmSpecsTest {
     }
   }
 
-  // TODO Overridden properties and functions
+  @Ignore("We need to read @Override annotations off of these in metadata parsing")
+  @Test
+  fun overriddenThings() {
+    val typeSpec = OverriddenThings::class.toTypeSpec()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      abstract class OverriddenThings : OverriddenThingsBase(), OverriddenThingsInterface {
+        override var openProp: String = TODO("Stub!")
+        override var openPropInterface: String = TODO("Stub!")
+    
+        override fun openFunction() {
+        }
+    
+        override fun openFunctionInterface() {
+        }
+      }
+    """.trimIndent())
+  }
+
+  abstract class OverriddenThingsBase {
+    abstract var openProp: String
+
+    abstract fun openFunction()
+  }
+
+  interface OverriddenThingsInterface {
+    var openPropInterface: String
+
+    fun openFunctionInterface()
+  }
+
+  abstract class OverriddenThings : OverriddenThingsBase(), OverriddenThingsInterface {
+    override var openProp: String = ""
+    override var openPropInterface: String = ""
+
+    override fun openFunction() {
+
+    }
+
+    override fun openFunctionInterface() {
+
+    }
+  }
+
   // TODO Delegation (class, properties, local vars)
   // TODO Enums (simple and complex)
   // TODO Complex companion objects (implementing interfaces)

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -19,6 +19,7 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.kotlinpoet.km.KotlinPoetKm
 import org.junit.Ignore
 import org.junit.Test
+import kotlin.properties.Delegates
 
 @KotlinPoetKm
 @Suppress("unused", "UNUSED_PARAMETER")
@@ -351,6 +352,43 @@ class KmSpecsTest {
     override fun openFunctionInterface() {
 
     }
+  }
+
+  @Test
+  fun delegatedProperties() {
+    val typeSpec = DelegatedProperties::class.toTypeSpec()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class DelegatedProperties {
+        /**
+         * Note: delegation is ABI stub only and not guaranteed to match source code.
+         */
+        val immutable: kotlin.String by kotlin.lazy { TODO("Stub!") }
+      
+        /**
+         * Note: delegation is ABI stub only and not guaranteed to match source code.
+         */
+        val immutableNullable: kotlin.String? by kotlin.lazy { TODO("Stub!") }
+      
+        /**
+         * Note: delegation is ABI stub only and not guaranteed to match source code.
+         */
+        var mutable: kotlin.String by kotlin.properties.Delegates.notNull()
+      
+        /**
+         * Note: delegation is ABI stub only and not guaranteed to match source code.
+         */
+        var mutableNullable: kotlin.String? by kotlin.properties.Delegates.observable(null) { _, _, _ -> }
+      }
+    """.trimIndent())
+  }
+
+  class DelegatedProperties {
+    val immutable: String by lazy { "" }
+    val immutableNullable: String? by lazy { "" }
+    var mutable: String by Delegates.notNull()
+    var mutableNullable: String? by Delegates.observable(null) { _, _, _ -> }
   }
 
   // TODO Delegation (class, properties, local vars)

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -426,7 +426,51 @@ class KmSpecsTest {
     FOO, BAR, BAZ
   }
 
-  // TODO Enums (complex)
+  @Ignore("Requires recursively reading metadata for each enum entry")
+  @Test
+  fun complexEnum() {
+    val typeSpec = ComplexEnum::class.toTypeSpec()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      enum class SimpleEnum {
+        FOO("foo") {
+          override fun toString(): String {
+            return "foo1"
+          }
+        },
+        BAR("bar") {
+          override fun toString(): String {
+            return "bar1"
+          }
+        },
+        BAZ("baz") {
+          override fun toString(): String {
+            return "baz1"
+          }
+        }
+      }
+    """.trimIndent())
+  }
+
+  enum class ComplexEnum(val value: String) {
+    FOO("foo") {
+      override fun toString(): String {
+        return "foo1"
+      }
+    },
+    BAR("bar") {
+      override fun toString(): String {
+        return "bar1"
+      }
+    },
+    BAZ("baz") {
+      override fun toString(): String {
+        return "baz1"
+      }
+    }
+  }
+
   // TODO Interfaces
   // TODO Complex companion objects (implementing interfaces)
   // TODO Tagged km types

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -471,7 +471,27 @@ class KmSpecsTest {
     }
   }
 
-  // TODO Interfaces
+  @Test
+  fun interfaces() {
+    val typeSpec = SomeInterface::class.toTypeSpec()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      interface SomeInterface : com.squareup.kotlinpoet.KmSpecsTest.SomeInterfaceBase {
+        fun testFunction() {
+        }
+      }
+    """.trimIndent())
+  }
+
+  interface SomeInterfaceBase
+
+  interface SomeInterface : SomeInterfaceBase {
+    fun testFunction() {
+
+    }
+  }
+
   // TODO Complex companion objects (implementing interfaces)
   // TODO Tagged km types
   // TODO Backward referencing type arguments (T, B<T>)

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -16,10 +16,16 @@
 package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
+import com.squareup.kotlinpoet.km.ImmutableKmClass
+import com.squareup.kotlinpoet.km.ImmutableKmConstructor
+import com.squareup.kotlinpoet.km.ImmutableKmFunction
+import com.squareup.kotlinpoet.km.ImmutableKmProperty
+import com.squareup.kotlinpoet.km.ImmutableKmValueParameter
 import com.squareup.kotlinpoet.km.KotlinPoetKm
 import org.junit.Ignore
 import org.junit.Test
 import kotlin.properties.Delegates
+import kotlin.test.fail
 
 @KotlinPoetKm
 @Suppress("unused", "UNUSED_PARAMETER")
@@ -505,8 +511,37 @@ class KmSpecsTest {
 
   interface BackwardReferencingTypeVars<T> : List<Set<T>>
 
+  @Test
+  fun taggedTypes() {
+    val typeSpec = TaggedTypes::class.toTypeSpec()
+    assertThat(typeSpec.tag<ImmutableKmClass>()).isNotNull()
+
+    val constructorSpec = typeSpec.primaryConstructor ?: fail("No constructor found!")
+    assertThat(constructorSpec.tag<ImmutableKmConstructor>()).isNotNull()
+
+    val parameterSpec = constructorSpec.parameters[0]
+    assertThat(parameterSpec.tag<ImmutableKmValueParameter>()).isNotNull()
+
+    // TODO taggable TypeNames
+//    val typeVar = typeSpec.typeVariables[0]
+//    assertThat(typeVar.tag<ImmutableKmTypeParameter>()).isNotNull()
+
+    val funSpec = typeSpec.funSpecs[0]
+    assertThat(funSpec.tag<ImmutableKmFunction>()).isNotNull()
+
+    val propertySpec = typeSpec.propertySpecs[0]
+    assertThat(propertySpec.tag<ImmutableKmProperty>()).isNotNull()
+  }
+
+  class TaggedTypes<T>(val param: T) {
+    val property: String = ""
+
+    fun function() {
+
+    }
+  }
+
   // TODO Complex companion objects (implementing interfaces)
-  // TODO Tagged km types
 }
 
 private fun TypeSpec.trimmedToString(): String {

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -183,9 +183,8 @@ class KmSpecsTest {
 
     val (immutableProp, mutableListProp) = typeSpec.primaryConstructor!!.parameters
     assertThat(immutableProp.type).isEqualTo(List::class.parameterizedBy(String::class))
-    assertThat(mutableListProp.type).isEqualTo(
-        ClassName.bestGuess("kotlin.collections.MutableList").parameterizedBy(
-            String::class.asTypeName()))
+    assertThat(mutableListProp.type)
+        .isEqualTo(MUTABLE_LIST.parameterizedBy(String::class.asTypeName()))
   }
 
   class CollectionMutability(val immutableList: List<String>, val mutableList: MutableList<String>)

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -391,6 +391,21 @@ class KmSpecsTest {
     var mutableNullable: String? by Delegates.observable(null) { _, _, _ -> }
   }
 
+  @Ignore("Need to be able to know about class delegation in metadata")
+  @Test
+  fun classDelegation() {
+    val typeSpec = ClassDelegation::class.toTypeSpec()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class ClassDelegation<T>(
+        delegate: List<T>
+      ): List<T> by delegate
+    """.trimIndent())
+  }
+
+  class ClassDelegation<T>(delegate: List<T>): List<T> by delegate
+
   // TODO Delegation (class, properties, local vars)
   // TODO Enums (simple and complex)
   // TODO Complex companion objects (implementing interfaces)

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -493,9 +493,20 @@ class KmSpecsTest {
     }
   }
 
+  @Test
+  fun backwardReferencingTypeVars() {
+    val typeSpec = BackwardReferencingTypeVars::class.toTypeSpec()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      interface BackwardReferencingTypeVars<T> : kotlin.collections.List<kotlin.collections.Set<T>>
+    """.trimIndent())
+  }
+
+  interface BackwardReferencingTypeVars<T> : List<Set<T>>
+
   // TODO Complex companion objects (implementing interfaces)
   // TODO Tagged km types
-  // TODO Backward referencing type arguments (T, B<T>)
 }
 
 private fun TypeSpec.trimmedToString(): String {

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -73,11 +73,11 @@ class KmSpecsTest {
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Properties {
         var aList: kotlin.collections.List<kotlin.Int> = TODO("Stub!")
-      
+
         val bar: kotlin.String? = null
-      
+
         var baz: kotlin.Int = TODO("Stub!")
-      
+
         val foo: kotlin.String = TODO("Stub!")
       }
     """.trimIndent())
@@ -311,7 +311,6 @@ class KmSpecsTest {
 
   class FunctionsReferencingTypeParameters<T> {
     fun test(param: T) {
-
     }
   }
 
@@ -325,10 +324,10 @@ class KmSpecsTest {
       abstract class OverriddenThings : OverriddenThingsBase(), OverriddenThingsInterface {
         override var openProp: String = TODO("Stub!")
         override var openPropInterface: String = TODO("Stub!")
-    
+
         override fun openFunction() {
         }
-    
+
         override fun openFunctionInterface() {
         }
       }
@@ -352,11 +351,9 @@ class KmSpecsTest {
     override var openPropInterface: String = ""
 
     override fun openFunction() {
-
     }
 
     override fun openFunctionInterface() {
-
     }
   }
 
@@ -371,17 +368,17 @@ class KmSpecsTest {
          * Note: delegation is ABI stub only and not guaranteed to match source code.
          */
         val immutable: kotlin.String by kotlin.lazy { TODO("Stub!") }
-      
+
         /**
          * Note: delegation is ABI stub only and not guaranteed to match source code.
          */
         val immutableNullable: kotlin.String? by kotlin.lazy { TODO("Stub!") }
-      
+
         /**
          * Note: delegation is ABI stub only and not guaranteed to match source code.
          */
         var mutable: kotlin.String by kotlin.properties.Delegates.notNull()
-      
+
         /**
          * Note: delegation is ABI stub only and not guaranteed to match source code.
          */
@@ -411,7 +408,7 @@ class KmSpecsTest {
     """.trimIndent())
   }
 
-  class ClassDelegation<T>(delegate: List<T>): List<T> by delegate
+  class ClassDelegation<T>(delegate: List<T>) : List<T> by delegate
 
   @Test
   fun simpleEnum() {
@@ -495,7 +492,6 @@ class KmSpecsTest {
 
   interface SomeInterface : SomeInterfaceBase {
     fun testFunction() {
-
     }
   }
 
@@ -537,7 +533,6 @@ class KmSpecsTest {
     val property: String = ""
 
     fun function() {
-
     }
   }
 

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -396,6 +396,7 @@ class KmSpecsTest {
   fun classDelegation() {
     val typeSpec = ClassDelegation::class.toTypeSpec()
 
+    // TODO Assert this also excludes functions handled by the delegate
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class ClassDelegation<T>(
@@ -495,7 +496,6 @@ class KmSpecsTest {
   // TODO Complex companion objects (implementing interfaces)
   // TODO Tagged km types
   // TODO Backward referencing type arguments (T, B<T>)
-  // TODO Excluding delegated, only including declared
 }
 
 private fun TypeSpec.trimmedToString(): String {

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -288,7 +288,25 @@ class KmSpecsTest {
     """.trimIndent())
   }
 
-  // TODO Functions referencing class type parameter
+  @Test
+  fun functionReferencingTypeParam() {
+    val typeSpec = FunctionsReferencingTypeParameters::class.toTypeSpec()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class FunctionsReferencingTypeParameters<T> {
+        fun test(param: T) {
+        }
+      }
+    """.trimIndent())
+  }
+
+  class FunctionsReferencingTypeParameters<T> {
+    fun test(param: T) {
+
+    }
+  }
+
   // TODO Overridden properties and functions
   // TODO Delegation (class, properties, local vars)
   // TODO Enums (simple and complex)

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -406,8 +406,28 @@ class KmSpecsTest {
 
   class ClassDelegation<T>(delegate: List<T>): List<T> by delegate
 
-  // TODO Delegation (class, properties, local vars)
-  // TODO Enums (simple and complex)
+  @Test
+  fun simpleEnum() {
+    val typeSpec = SimpleEnum::class.toTypeSpec()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      enum class SimpleEnum {
+        FOO,
+
+        BAR,
+
+        BAZ
+      }
+    """.trimIndent())
+  }
+
+  enum class SimpleEnum {
+    FOO, BAR, BAZ
+  }
+
+  // TODO Enums (complex)
+  // TODO Interfaces
   // TODO Complex companion objects (implementing interfaces)
   // TODO Tagged km types
   // TODO Backward referencing type arguments (T, B<T>)


### PR DESCRIPTION
This reveals a few (now-documented) WIP areas and also addresses the open comments from the previous PR

The missing pieces unfortunately would require inspecting the corresponding classes/subtypes (detecting overrides, companion objects, enum member types)