### PR TITLE
Large chunk of misc km work

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -23,6 +23,7 @@ object versions {
 }
 
 object deps {
+  const val autoCommon = "com.google.auto:auto-common:0.10"
   object kotlin {
     const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk7"
     const val reflect = "org.jetbrains.kotlin:kotlin-reflect"

--- a/kotlinpoet-km/src/main/kotlin/com/squareup/kotlinpoet/km/Flags.kt
+++ b/kotlinpoet-km/src/main/kotlin/com/squareup/kotlinpoet/km/Flags.kt
@@ -259,8 +259,6 @@ val ImmutableKmValueParameter.isNoInline: Boolean get() = Flag.ValueParameter.IS
 @KotlinPoetKm
 val Flags.isFakeOverrideProperty: Boolean get() = Flag.Property.IS_FAKE_OVERRIDE(this)
 @KotlinPoetKm
-val Flags.isOverrideProperty: Boolean get() = false // TODO This isn't contained in metadata. Likely have to read an annotation
-@KotlinPoetKm
 val KmProperty.hasConstant: Boolean get() = Flag.Property.HAS_CONSTANT(flags)
 @KotlinPoetKm
 val KmProperty.hasGetter: Boolean get() = Flag.Property.HAS_GETTER(flags)
@@ -308,8 +306,6 @@ val ImmutableKmProperty.isExpect: Boolean get() = Flag.Property.IS_EXPECT(flags)
 val ImmutableKmProperty.isExternal: Boolean get() = Flag.Property.IS_EXTERNAL(flags)
 @KotlinPoetKm
 val ImmutableKmProperty.isFakeOverride: Boolean get() = flags.isFakeOverrideProperty
-@KotlinPoetKm
-val ImmutableKmProperty.isOverride: Boolean get() = flags.isOverrideProperty
 @KotlinPoetKm
 val ImmutableKmProperty.isLateinit: Boolean get() = Flag.Property.IS_LATEINIT(flags)
 @KotlinPoetKm

--- a/kotlinpoet/build.gradle.kts
+++ b/kotlinpoet/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
   api(rootProject.project("kotlinpoet-km"))
   api(deps.kotlin.stdlib)
   implementation(deps.kotlin.reflect)
+  implementation(deps.autoCommon)
   testImplementation(deps.kotlin.junit)
   testImplementation(deps.test.truth)
   testImplementation(deps.test.compileTesting)

--- a/kotlinpoet/build.gradle.kts
+++ b/kotlinpoet/build.gradle.kts
@@ -60,5 +60,6 @@ repositories {
 
 val compileTestKotlin: KotlinCompile by tasks
 compileTestKotlin.kotlinOptions {
-  freeCompilerArgs = listOf("-XXLanguage:+InlineClasses")
+  freeCompilerArgs = listOf("-XXLanguage:+InlineClasses", "-Xjvm-default=enable")
+  jvmTarget = "1.8"
 }

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ElementHandler.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ElementHandler.kt
@@ -181,6 +181,13 @@ interface ElementHandler {
         "kotlin.collections.MutableMap.Entry"
     )
 
+    private val KOTLIN_NULLABILITY_ANNOTATIONS = setOf(
+        "org.jetbrains.annotations.NotNull",
+        "org.jetbrains.annotations.Nullable"
+    )
+
+    private fun List<AnnotationSpec>.filterOutNullabilityAnnotations() = filterNot { it.className.canonicalName in KOTLIN_NULLABILITY_ANNOTATIONS }
+
     /** A reflection-based implementation of [ElementHandler]. */
     fun reflective(): ElementHandler = object : ElementHandler {
 
@@ -263,6 +270,7 @@ interface ElementHandler {
         return lookupField(classJvmName, fieldSignature)?.declaredAnnotations
             .orEmpty()
             .map { AnnotationSpec.get(it, true) }
+            .filterOutNullabilityAnnotations()
       }
 
       override fun constructorAnnotations(
@@ -277,7 +285,9 @@ interface ElementHandler {
               .onEach { it.isAccessible = true }
               .find { signatureString == it.jvmMethodSignature }.toOptional()
         }.nullableValue
-        return constructor?.declaredAnnotations.orEmpty().map { AnnotationSpec.get(it, true) }
+        return constructor?.declaredAnnotations.orEmpty()
+            .map { AnnotationSpec.get(it, true) }
+            .filterOutNullabilityAnnotations()
       }
 
       override fun methodJvmModifiers(
@@ -298,6 +308,7 @@ interface ElementHandler {
               ?.declaredAnnotations
               .orEmpty()
               .map { AnnotationSpec.get(it, true) }
+              .filterOutNullabilityAnnotations()
         } catch (e: ClassNotFoundException) {
           emptyList()
         }
@@ -405,6 +416,7 @@ interface ElementHandler {
               ?.annotationMirrors
               .orEmpty()
               .map { AnnotationSpec.get(it) }
+              .filterOutNullabilityAnnotations()
         }
 
         override fun methodJvmModifiers(
@@ -429,6 +441,7 @@ interface ElementHandler {
                 ?.annotationMirrors
                 .orEmpty()
                 .map { AnnotationSpec.get(it) }
+                .filterOutNullabilityAnnotations()
         }
 
         override fun methodAnnotations(
@@ -439,6 +452,7 @@ interface ElementHandler {
                 ?.annotationMirrors
                 .orEmpty()
                 .map { AnnotationSpec.get(it) }
+                .filterOutNullabilityAnnotations()
         }
 
         override fun enumEntry(enumClassJvmName: String, memberName: String): ImmutableKmClass? {

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ElementHandler.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ElementHandler.kt
@@ -1,0 +1,468 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet
+
+import com.squareup.kotlinpoet.ElementHandler.Companion.fromElements
+import com.squareup.kotlinpoet.ElementHandler.Companion.reflective
+import com.squareup.kotlinpoet.km.ImmutableKmClass
+import com.squareup.kotlinpoet.km.KotlinPoetKm
+import com.squareup.kotlinpoet.km.toImmutableKmClass
+import kotlinx.metadata.jvm.JvmFieldSignature
+import kotlinx.metadata.jvm.JvmMethodSignature
+import java.lang.reflect.Constructor
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import java.util.concurrent.ConcurrentHashMap
+import javax.lang.model.element.ElementKind.ENUM_CONSTANT
+import javax.lang.model.element.ElementKind.INTERFACE
+import javax.lang.model.element.ExecutableElement
+import javax.lang.model.element.TypeElement
+import javax.lang.model.element.VariableElement
+import javax.lang.model.util.ElementFilter
+import javax.lang.model.util.Elements
+import javax.lang.model.util.Types
+
+/**
+ * A basic interface for looking up information about JVM elements.
+ *
+ * @see [reflective] for a reflection-based implementation or [fromElements] for an [Elements]-based
+ * implementation.
+ */
+@KotlinPoetKm
+interface ElementHandler {
+
+  interface JvmModifier {
+    fun annotationSpec(): AnnotationSpec
+  }
+
+  /** Modifiers that are annotations in Kotlin but modifier keywords in bytecode. */
+  enum class JvmFieldModifier : JvmModifier {
+    TRANSIENT {
+      override fun annotationSpec(): AnnotationSpec = AnnotationSpec.builder(Transient::class.asClassName()).build()
+    },
+    VOLATILE {
+      override fun annotationSpec(): AnnotationSpec = AnnotationSpec.builder(Volatile::class.asClassName()).build()
+    };
+  }
+
+  /** Modifiers that are annotations in Kotlin but modifier keywords in bytecode. */
+  enum class JvmMethodModifier : JvmModifier {
+    SYNCHRONIZED {
+      override fun annotationSpec(): AnnotationSpec = AnnotationSpec.builder(Synchronized::class.asClassName()).build()
+    }
+  }
+
+  /**
+   * Looks up other classes, such as for nested members. Note that this class would always be
+   * Kotlin, so Metadata can be relied on for this.
+   *
+   * @param jvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @return the read [ImmutableKmClass] from its metadata. If no class was found, this should throw
+   *         an exception.
+   */
+  fun classFor(jvmName: String): ImmutableKmClass
+
+  /**
+   * Looks up a class and returns whether or not it is an interface. Note that this class can be
+   * Java or Kotlin, so Metadata should not be relied on for this.
+   *
+   * @param jvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @return whether or not it is an interface.
+   */
+  fun isInterface(jvmName: String): Boolean
+
+  /**
+   * Looks up a given class field given its [JvmFieldSignature] and returns any [JvmModifier]s
+   * found on it.
+   *
+   * @param classJvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param fieldSignature The field to look up.
+   * @return the set of found modifiers.
+   */
+  fun fieldJvmModifiers(classJvmName: String, fieldSignature: JvmFieldSignature): Set<JvmFieldModifier>
+
+  /**
+   * Looks up the annotations on a given class field given its [JvmFieldSignature].
+   *
+   * @param classJvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param fieldSignature The field with annotations to look up.
+   * @return the [AnnotationSpec] representations of the annotations on the target field.
+   */
+  fun fieldAnnotations(classJvmName: String, fieldSignature: JvmFieldSignature): List<AnnotationSpec>
+
+  /**
+   * Looks up a given class method given its [JvmMethodSignature] and returns any [JvmMethodModifier]s
+   * found on it.
+   *
+   * @param classJvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param methodSignature The method with annotations to look up.
+   * @return the set of found modifiers.
+   */
+  fun methodJvmModifiers(classJvmName: String, methodSignature: JvmMethodSignature): Set<JvmMethodModifier>
+
+  /**
+   * Looks up the annotations on a given class constructor given its [JvmMethodSignature].
+   *
+   * @param classJvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param constructorSignature The constructor with annotations to look up.
+   * @return the [AnnotationSpec] representations of the annotations on the target method.
+   */
+  fun constructorAnnotations(classJvmName: String, constructorSignature: JvmMethodSignature): List<AnnotationSpec>
+
+  /**
+   * Looks up the annotations on a given class method given its [JvmMethodSignature].
+   *
+   * @param classJvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param methodSignature The method with annotations to look up.
+   * @return the [AnnotationSpec] representations of the annotations on the target method.
+   */
+  fun methodAnnotations(classJvmName: String, methodSignature: JvmMethodSignature): List<AnnotationSpec>
+
+  /**
+   * Looks up the enum entry on a given enum given its member name.
+   *
+   * @param enumClassJvmName The JVM name of the enum class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param memberName The simple member name.
+   * @return the read [ImmutableKmClass] from its metadata, if any. For simple enum members with no
+   *         class bodies, this should always be null.
+   */
+  fun enumEntry(enumClassJvmName: String, memberName: String): ImmutableKmClass?
+
+  /**
+   * Looks up the constant value on a given class field given its [JvmFieldSignature].
+   *
+   * @param classJvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param fieldSignature The field with annotations to look up.
+   * @return the [CodeBlock] representation of the constant on the target field. Null if the value
+   *         cannot be resolved.
+   */
+  fun fieldConstant(classJvmName: String, fieldSignature: JvmFieldSignature): CodeBlock?
+
+  companion object {
+    private fun Any.asLiteralCodeBlock(): CodeBlock {
+      return when (this) {
+        is String -> CodeBlock.of("%S", this)
+        is Long -> CodeBlock.of("%LL", this)
+        is Float -> CodeBlock.of("%LF", this)
+        else -> CodeBlock.of("%L", this)
+      }
+    }
+
+    private val String.canonicalName get() = replace("/", ".").replace("$", ".")
+
+    private val KOTLIN_INTRINSIC_INTERFACES = setOf(
+        "kotlin.CharSequence",
+        "kotlin.Comparable",
+        "kotlin.collections.Iterable",
+        "kotlin.collections.Collection",
+        "kotlin.collections.List",
+        "kotlin.collections.Set",
+        "kotlin.collections.Map",
+        "kotlin.collections.Map.Entry",
+        "kotlin.collections.MutableIterable",
+        "kotlin.collections.MutableCollection",
+        "kotlin.collections.MutableList",
+        "kotlin.collections.MutableSet",
+        "kotlin.collections.MutableMap",
+        "kotlin.collections.MutableMap.Entry"
+    )
+
+    /** A reflection-based implementation of [ElementHandler]. */
+    fun reflective(): ElementHandler = object : ElementHandler {
+
+      private val classCache = ConcurrentHashMap<String, Optional<Class<*>>>()
+      private val methodCache = ConcurrentHashMap<Pair<Class<*>, String>, Optional<Method>>()
+      private val constructorCache = ConcurrentHashMap<Pair<Class<*>, String>, Optional<Constructor<*>>>()
+      private val fieldCache = ConcurrentHashMap<Pair<Class<*>, String>, Optional<Field>>()
+      private val enumCache = ConcurrentHashMap<Pair<Class<*>, String>, Optional<Any>>()
+
+      private fun lookupClass(jvmName: String): Class<*>? {
+        return classCache.getOrPut(jvmName) {
+          try {
+            Class.forName(jvmName.replace("/", "."))
+          } catch (e: ClassNotFoundException) {
+            null
+          }.toOptional()
+        }.nullableValue
+      }
+
+      override fun classFor(jvmName: String): ImmutableKmClass {
+        return lookupClass(jvmName)?.toImmutableKmClass() ?: error("No class found for: $jvmName.")
+      }
+
+      override fun isInterface(jvmName: String): Boolean {
+        if (jvmName.canonicalName in KOTLIN_INTRINSIC_INTERFACES) {
+          return true
+        }
+        return lookupClass(jvmName)?.isInterface ?: false
+      }
+
+      private fun lookupField(classJvmName: String, fieldSignature: JvmFieldSignature): Field? {
+        return try {
+          val clazz = lookupClass(classJvmName) ?: error("No class found for: $classJvmName.")
+          val signatureString = fieldSignature.asString()
+          fieldCache.getOrPut(clazz to signatureString) {
+            clazz.declaredFields
+                .asSequence()
+                .onEach { it.isAccessible = true }
+                .find { signatureString == it.jvmFieldSignature }.toOptional()
+          }.nullableValue
+        } catch (e: ClassNotFoundException) {
+          null
+        }
+      }
+
+      private fun lookupMethod(
+        classJvmName: String,
+        methodSignature: JvmMethodSignature
+      ): Method? {
+        val clazz = lookupClass(classJvmName) ?: error("No class found for: $classJvmName.")
+        val signatureString = methodSignature.asString()
+        return methodCache.getOrPut(clazz to signatureString) {
+          clazz.declaredMethods
+              .asSequence()
+              .onEach { it.isAccessible = true }
+              .find { signatureString == it.jvmMethodSignature }.toOptional()
+        }.nullableValue
+      }
+
+      override fun fieldJvmModifiers(
+        classJvmName: String,
+        fieldSignature: JvmFieldSignature
+      ): Set<JvmFieldModifier> {
+        return lookupField(classJvmName, fieldSignature)?.modifiers.let { modifiers ->
+          if (modifiers != null) {
+            return mutableSetOf<JvmFieldModifier>().apply {
+              if (Modifier.isTransient(modifiers)) {
+                add(JvmFieldModifier.TRANSIENT)
+              }
+              if (Modifier.isVolatile(modifiers)) {
+                add(JvmFieldModifier.VOLATILE)
+              }
+            }
+          }
+          return@let emptySet()
+        }
+      }
+
+      override fun fieldAnnotations(classJvmName: String, fieldSignature: JvmFieldSignature): List<AnnotationSpec> {
+        return lookupField(classJvmName, fieldSignature)?.declaredAnnotations
+            .orEmpty()
+            .map { AnnotationSpec.get(it, true) }
+      }
+
+      override fun constructorAnnotations(
+        classJvmName: String,
+        constructorSignature: JvmMethodSignature
+      ): List<AnnotationSpec> {
+        val clazz = lookupClass(classJvmName) ?: error("No class found for: $classJvmName.")
+        val signatureString = constructorSignature.asString()
+        val constructor = constructorCache.getOrPut(clazz to signatureString) {
+          clazz.declaredConstructors
+              .asSequence()
+              .onEach { it.isAccessible = true }
+              .find { signatureString == it.jvmMethodSignature }.toOptional()
+        }.nullableValue
+        return constructor?.declaredAnnotations.orEmpty().map { AnnotationSpec.get(it, true) }
+      }
+
+      override fun methodJvmModifiers(
+        classJvmName: String,
+        methodSignature: JvmMethodSignature
+      ): Set<JvmMethodModifier> {
+        return lookupMethod(classJvmName, methodSignature)?.modifiers.let { modifiers ->
+          if (modifiers != null && Modifier.isSynchronized(modifiers)) {
+            return@let setOf(JvmMethodModifier.SYNCHRONIZED)
+          }
+          return@let emptySet()
+        }
+      }
+
+      override fun methodAnnotations(classJvmName: String, methodSignature: JvmMethodSignature): List<AnnotationSpec> {
+        return try {
+          lookupMethod(classJvmName, methodSignature)
+              ?.declaredAnnotations
+              .orEmpty()
+              .map { AnnotationSpec.get(it, true) }
+        } catch (e: ClassNotFoundException) {
+          emptyList()
+        }
+      }
+
+      override fun enumEntry(enumClassJvmName: String, memberName: String): ImmutableKmClass? {
+        val clazz = lookupClass(enumClassJvmName)
+            ?: error("No class found for: $enumClassJvmName.")
+        check(clazz.isEnum) {
+          "Class must be an enum but isn't: $clazz"
+        }
+        val enumEntry = enumCache.getOrPut(clazz to memberName) {
+          clazz.enumConstants.find { (it as Enum<*>).name == memberName }.toOptional()
+        }.nullableValue
+        checkNotNull(enumEntry) {
+          "Could not find $memberName on $enumClassJvmName"
+        }
+        if (enumEntry.javaClass == clazz) {
+          // For simple enums with no class bodies, the entry class will be the same as the original
+          // class.
+          return null
+        }
+        return enumEntry.javaClass.getAnnotation(Metadata::class.java)?.toImmutableKmClass()
+      }
+
+      override fun fieldConstant(
+        classJvmName: String,
+        fieldSignature: JvmFieldSignature
+      ): CodeBlock? {
+        val field = lookupField(classJvmName, fieldSignature) ?: error("No field $fieldSignature found in $classJvmName.")
+        if (!Modifier.isStatic(field.modifiers)) {
+          return null
+        }
+        return field
+            .get(null) // Constant means we can do a static get on it.
+            .asLiteralCodeBlock()
+      }
+    }
+
+    /** @return an [Elements]-based implementation of [ElementHandler]. */
+    fun fromElements(elements: Elements, types: Types): ElementHandler {
+      return object : ElementHandler {
+
+        private val typeElementCache = ConcurrentHashMap<String, Optional<TypeElement>>()
+        private val methodCache = ConcurrentHashMap<Pair<TypeElement, String>, Optional<ExecutableElement>>()
+        private val variableElementCache = ConcurrentHashMap<Pair<TypeElement, String>, Optional<VariableElement>>()
+
+        private fun lookupTypeElement(jvmName: String): TypeElement? {
+          return typeElementCache.getOrPut(jvmName) {
+            elements.getTypeElement(jvmName.canonicalName).toOptional()
+          }.nullableValue
+        }
+
+        override fun classFor(jvmName: String): ImmutableKmClass {
+          return lookupTypeElement(jvmName)?.toImmutableKmClass() ?: error("No type element found for: $jvmName.")
+        }
+
+        override fun isInterface(jvmName: String): Boolean {
+          if (jvmName.canonicalName in KOTLIN_INTRINSIC_INTERFACES) {
+            return true
+          }
+          return lookupTypeElement(jvmName)?.kind == INTERFACE
+        }
+
+        private fun lookupField(classJvmName: String, fieldSignature: JvmFieldSignature): VariableElement? {
+          return lookupTypeElement(classJvmName)?.let {
+            val signatureString = fieldSignature.asString()
+            variableElementCache.getOrPut(it to signatureString) {
+              ElementFilter.fieldsIn(it.enclosedElements)
+                  .find { signatureString == it.jvmFieldSignature(types) }.toOptional()
+            }.nullableValue
+          }
+        }
+
+        private fun lookupMethod(classJvmName: String, methodSignature: JvmMethodSignature): ExecutableElement? {
+          return lookupTypeElement(classJvmName)?.let {
+            val signatureString = methodSignature.asString()
+            methodCache.getOrPut(it to signatureString) {
+              ElementFilter.methodsIn(it.enclosedElements)
+                  .find { signatureString == it.jvmMethodSignature(types) }.toOptional()
+            }.nullableValue
+          }
+        }
+
+        override fun fieldJvmModifiers(
+          classJvmName: String,
+          fieldSignature: JvmFieldSignature
+        ): Set<JvmFieldModifier> {
+          return lookupField(classJvmName, fieldSignature)?.modifiers?.let { modifiers ->
+            modifiers.mapNotNullTo(mutableSetOf()) {
+              when (it) {
+                javax.lang.model.element.Modifier.TRANSIENT -> JvmFieldModifier.TRANSIENT
+                javax.lang.model.element.Modifier.VOLATILE -> JvmFieldModifier.VOLATILE
+                else -> null
+              }
+            }
+          }.orEmpty()
+        }
+
+        override fun fieldAnnotations(
+          classJvmName: String,
+          fieldSignature: JvmFieldSignature
+        ): List<AnnotationSpec> {
+          return lookupField(classJvmName, fieldSignature)
+              ?.annotationMirrors
+              .orEmpty()
+              .map { AnnotationSpec.get(it) }
+        }
+
+        override fun methodJvmModifiers(
+          classJvmName: String,
+          methodSignature: JvmMethodSignature
+        ): Set<JvmMethodModifier> {
+          return lookupMethod(classJvmName, methodSignature)?.modifiers?.let { modifiers ->
+            modifiers.mapNotNullTo(mutableSetOf()) {
+              when (it) {
+                javax.lang.model.element.Modifier.SYNCHRONIZED -> JvmMethodModifier.SYNCHRONIZED
+                else -> null
+              }
+            }
+          }.orEmpty()
+        }
+
+        override fun constructorAnnotations(
+          classJvmName: String,
+          constructorSignature: JvmMethodSignature
+        ): List<AnnotationSpec> {
+          return lookupMethod(classJvmName, constructorSignature)
+                ?.annotationMirrors
+                .orEmpty()
+                .map { AnnotationSpec.get(it) }
+        }
+
+        override fun methodAnnotations(
+          classJvmName: String,
+          methodSignature: JvmMethodSignature
+        ): List<AnnotationSpec> {
+          return lookupMethod(classJvmName, methodSignature)
+                ?.annotationMirrors
+                .orEmpty()
+                .map { AnnotationSpec.get(it) }
+        }
+
+        override fun enumEntry(enumClassJvmName: String, memberName: String): ImmutableKmClass? {
+          return lookupTypeElement(enumClassJvmName)?.let { enumType ->
+            val member = variableElementCache.getOrPut(enumType to memberName) {
+              ElementFilter.fieldsIn(enumType.enclosedElements)
+                  .asSequence()
+                  .filter { it.kind == ENUM_CONSTANT }
+                  .find { it.simpleName.contentEquals(memberName) }.toOptional()
+            }.nullableValue
+            member?.getAnnotation(Metadata::class.java)
+                ?.toImmutableKmClass()
+          }
+        }
+
+        override fun fieldConstant(
+          classJvmName: String,
+          fieldSignature: JvmFieldSignature
+        ): CodeBlock? {
+          return lookupField(classJvmName, fieldSignature)?.constantValue
+              ?.asLiteralCodeBlock()
+              ?: error("No field $fieldSignature found in $classJvmName.")
+        }
+      }
+    }
+  }
+}

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ElementHandler.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ElementHandler.kt
@@ -382,11 +382,12 @@ interface ElementHandler {
             .asLiteralCodeBlock()
       }
 
-      override fun isMethodOverride(classJvmName: String,
-          methodSignature: JvmMethodSignature): Boolean {
+      override fun isMethodOverride(
+        classJvmName: String,
+        methodSignature: JvmMethodSignature
+      ): Boolean {
         val clazz = lookupClass(classJvmName) ?: error("No class found for: $classJvmName.")
         return clazz.lookupMethod(methodSignature)?.declaringClass == clazz
-
       }
     }
 
@@ -416,8 +417,10 @@ interface ElementHandler {
           return lookupTypeElement(jvmName)?.kind == INTERFACE
         }
 
-        private fun lookupField(classJvmName: String,
-            fieldSignature: JvmFieldSignature): VariableElement? {
+        private fun lookupField(
+          classJvmName: String,
+          fieldSignature: JvmFieldSignature
+        ): VariableElement? {
           return lookupTypeElement(classJvmName)?.let {
             val signatureString = fieldSignature.asString()
             variableElementCache.getOrPut(it to signatureString) {
@@ -427,15 +430,17 @@ interface ElementHandler {
           }
         }
 
-        private fun lookupMethod(classJvmName: String,
-            methodSignature: JvmMethodSignature,
-            elementFilter: (Iterable<Element>) -> List<ExecutableElement>
+        private fun lookupMethod(
+          classJvmName: String,
+          methodSignature: JvmMethodSignature,
+          elementFilter: (Iterable<Element>) -> List<ExecutableElement>
         ): ExecutableElement? {
           return lookupTypeElement(classJvmName)?.lookupMethod(methodSignature, elementFilter)
         }
 
-        private fun TypeElement.lookupMethod(methodSignature: JvmMethodSignature,
-            elementFilter: (Iterable<Element>) -> List<ExecutableElement>
+        private fun TypeElement.lookupMethod(
+          methodSignature: JvmMethodSignature,
+          elementFilter: (Iterable<Element>) -> List<ExecutableElement>
         ): ExecutableElement? {
           val signatureString = methodSignature.asString()
           return methodCache.getOrPut(this to signatureString) {
@@ -445,8 +450,8 @@ interface ElementHandler {
         }
 
         override fun fieldJvmModifiers(
-            classJvmName: String,
-            fieldSignature: JvmFieldSignature
+          classJvmName: String,
+          fieldSignature: JvmFieldSignature
         ): Set<JvmFieldModifier> {
           return lookupField(classJvmName, fieldSignature)?.modifiers?.let { modifiers ->
             modifiers.mapNotNullTo(mutableSetOf()) {
@@ -461,8 +466,8 @@ interface ElementHandler {
         }
 
         override fun fieldAnnotations(
-            classJvmName: String,
-            fieldSignature: JvmFieldSignature
+          classJvmName: String,
+          fieldSignature: JvmFieldSignature
         ): List<AnnotationSpec> {
           return lookupField(classJvmName, fieldSignature)
               ?.annotationMirrors
@@ -472,8 +477,8 @@ interface ElementHandler {
         }
 
         override fun methodJvmModifiers(
-            classJvmName: String,
-            methodSignature: JvmMethodSignature
+          classJvmName: String,
+          methodSignature: JvmMethodSignature
         ): Set<JvmMethodModifier> {
           return lookupMethod(classJvmName, methodSignature,
               ElementFilter::methodsIn)?.modifiers?.let { modifiers ->
@@ -488,8 +493,8 @@ interface ElementHandler {
         }
 
         override fun constructorAnnotations(
-            classJvmName: String,
-            constructorSignature: JvmMethodSignature
+          classJvmName: String,
+          constructorSignature: JvmMethodSignature
         ): List<AnnotationSpec> {
           return lookupMethod(classJvmName, constructorSignature, ElementFilter::constructorsIn)
               ?.annotationMirrors
@@ -499,8 +504,8 @@ interface ElementHandler {
         }
 
         override fun methodAnnotations(
-            classJvmName: String,
-            methodSignature: JvmMethodSignature
+          classJvmName: String,
+          methodSignature: JvmMethodSignature
         ): List<AnnotationSpec> {
           return lookupMethod(classJvmName, methodSignature, ElementFilter::methodsIn)
               ?.annotationMirrors
@@ -524,16 +529,18 @@ interface ElementHandler {
         }
 
         override fun fieldConstant(
-            classJvmName: String,
-            fieldSignature: JvmFieldSignature
+          classJvmName: String,
+          fieldSignature: JvmFieldSignature
         ): CodeBlock? {
           return lookupField(classJvmName, fieldSignature)?.constantValue
               ?.asLiteralCodeBlock()
               ?: error("No field $fieldSignature found in $classJvmName.")
         }
 
-        override fun isMethodOverride(classJvmName: String,
-            methodSignature: JvmMethodSignature): Boolean {
+        override fun isMethodOverride(
+          classJvmName: String,
+          methodSignature: JvmMethodSignature
+        ): Boolean {
           val typeElement = lookupTypeElement(classJvmName)
               ?: error("No type element found for: $classJvmName.")
           val method = typeElement.lookupMethod(methodSignature, ElementFilter::methodsIn)
@@ -614,7 +621,6 @@ interface ElementHandler {
           }
         }
       }
-
     }
   }
 }

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ElementHandler.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ElementHandler.kt
@@ -15,6 +15,11 @@
  */
 package com.squareup.kotlinpoet
 
+import com.google.auto.common.MoreElements
+import com.google.auto.common.MoreTypes
+import com.google.auto.common.Visibility
+import com.google.common.collect.LinkedHashMultimap
+import com.google.common.collect.SetMultimap
 import com.squareup.kotlinpoet.ElementHandler.Companion.fromElements
 import com.squareup.kotlinpoet.ElementHandler.Companion.reflective
 import com.squareup.kotlinpoet.km.ImmutableKmClass
@@ -30,8 +35,10 @@ import java.util.concurrent.ConcurrentHashMap
 import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind.INTERFACE
 import javax.lang.model.element.ExecutableElement
+import javax.lang.model.element.PackageElement
 import javax.lang.model.element.TypeElement
 import javax.lang.model.element.VariableElement
+import javax.lang.model.type.TypeKind
 import javax.lang.model.util.ElementFilter
 import javax.lang.model.util.Elements
 import javax.lang.model.util.Types
@@ -158,6 +165,17 @@ interface ElementHandler {
    */
   fun fieldConstant(classJvmName: String, fieldSignature: JvmFieldSignature): CodeBlock?
 
+  /**
+   * Looks up if a given [methodSignature] within [classJvmName] is an override of another method.
+   * Implementers should search for a matching method signature in the supertypes/classes of
+   * [classJvmName] to see if there are matches.
+   *
+   * @param classJvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param methodSignature The method signature to check.
+   * @return whether or not the method is an override.
+   */
+  fun isMethodOverride(classJvmName: String, methodSignature: JvmMethodSignature): Boolean
+
   companion object {
     private fun Any.asLiteralCodeBlock(): CodeBlock {
       return when (this) {
@@ -243,10 +261,15 @@ interface ElementHandler {
         classJvmName: String,
         methodSignature: JvmMethodSignature
       ): Method? {
-        val clazz = lookupClass(classJvmName) ?: error("No class found for: $classJvmName.")
+        return lookupClass(classJvmName)?.lookupMethod(methodSignature) ?: error("No class found for: $classJvmName.")
+      }
+
+      private fun Class<*>.lookupMethod(
+        methodSignature: JvmMethodSignature
+      ): Method? {
         val signatureString = methodSignature.asString()
-        return methodCache.getOrPut(clazz to signatureString) {
-          clazz.declaredMethods
+        return methodCache.getOrPut(this to signatureString) {
+          declaredMethods
               .asSequence()
               .onEach { it.isAccessible = true }
               .find { signatureString == it.jvmMethodSignature }.toOptional()
@@ -358,6 +381,13 @@ interface ElementHandler {
             .get(null) // Constant means we can do a static get on it.
             .asLiteralCodeBlock()
       }
+
+      override fun isMethodOverride(classJvmName: String,
+          methodSignature: JvmMethodSignature): Boolean {
+        val clazz = lookupClass(classJvmName) ?: error("No class found for: $classJvmName.")
+        return clazz.lookupMethod(methodSignature)?.declaringClass == clazz
+
+      }
     }
 
     /** @return an [Elements]-based implementation of [ElementHandler]. */
@@ -375,7 +405,8 @@ interface ElementHandler {
         }
 
         override fun classFor(jvmName: String): ImmutableKmClass {
-          return lookupTypeElement(jvmName)?.toImmutableKmClass() ?: error("No type element found for: $jvmName.")
+          return lookupTypeElement(jvmName)?.toImmutableKmClass() ?: error(
+              "No type element found for: $jvmName.")
         }
 
         override fun isInterface(jvmName: String): Boolean {
@@ -385,7 +416,8 @@ interface ElementHandler {
           return lookupTypeElement(jvmName)?.kind == INTERFACE
         }
 
-        private fun lookupField(classJvmName: String, fieldSignature: JvmFieldSignature): VariableElement? {
+        private fun lookupField(classJvmName: String,
+            fieldSignature: JvmFieldSignature): VariableElement? {
           return lookupTypeElement(classJvmName)?.let {
             val signatureString = fieldSignature.asString()
             variableElementCache.getOrPut(it to signatureString) {
@@ -399,18 +431,22 @@ interface ElementHandler {
             methodSignature: JvmMethodSignature,
             elementFilter: (Iterable<Element>) -> List<ExecutableElement>
         ): ExecutableElement? {
-          return lookupTypeElement(classJvmName)?.let {
-            val signatureString = methodSignature.asString()
-            methodCache.getOrPut(it to signatureString) {
-              elementFilter(it.enclosedElements)
-                  .find { signatureString == it.jvmMethodSignature(types) }.toOptional()
-            }.nullableValue
-          }
+          return lookupTypeElement(classJvmName)?.lookupMethod(methodSignature, elementFilter)
+        }
+
+        private fun TypeElement.lookupMethod(methodSignature: JvmMethodSignature,
+            elementFilter: (Iterable<Element>) -> List<ExecutableElement>
+        ): ExecutableElement? {
+          val signatureString = methodSignature.asString()
+          return methodCache.getOrPut(this to signatureString) {
+            elementFilter(enclosedElements)
+                .find { signatureString == it.jvmMethodSignature(types) }.toOptional()
+          }.nullableValue
         }
 
         override fun fieldJvmModifiers(
-          classJvmName: String,
-          fieldSignature: JvmFieldSignature
+            classJvmName: String,
+            fieldSignature: JvmFieldSignature
         ): Set<JvmFieldModifier> {
           return lookupField(classJvmName, fieldSignature)?.modifiers?.let { modifiers ->
             modifiers.mapNotNullTo(mutableSetOf()) {
@@ -425,8 +461,8 @@ interface ElementHandler {
         }
 
         override fun fieldAnnotations(
-          classJvmName: String,
-          fieldSignature: JvmFieldSignature
+            classJvmName: String,
+            fieldSignature: JvmFieldSignature
         ): List<AnnotationSpec> {
           return lookupField(classJvmName, fieldSignature)
               ?.annotationMirrors
@@ -436,10 +472,11 @@ interface ElementHandler {
         }
 
         override fun methodJvmModifiers(
-          classJvmName: String,
-          methodSignature: JvmMethodSignature
+            classJvmName: String,
+            methodSignature: JvmMethodSignature
         ): Set<JvmMethodModifier> {
-          return lookupMethod(classJvmName, methodSignature, ElementFilter::methodsIn)?.modifiers?.let { modifiers ->
+          return lookupMethod(classJvmName, methodSignature,
+              ElementFilter::methodsIn)?.modifiers?.let { modifiers ->
             modifiers.mapNotNullTo(mutableSetOf()) {
               when (it) {
                 javax.lang.model.element.Modifier.SYNCHRONIZED -> JvmMethodModifier.SYNCHRONIZED
@@ -451,25 +488,25 @@ interface ElementHandler {
         }
 
         override fun constructorAnnotations(
-          classJvmName: String,
-          constructorSignature: JvmMethodSignature
+            classJvmName: String,
+            constructorSignature: JvmMethodSignature
         ): List<AnnotationSpec> {
           return lookupMethod(classJvmName, constructorSignature, ElementFilter::constructorsIn)
-                ?.annotationMirrors
-                .orEmpty()
-                .map { AnnotationSpec.get(it) }
-                .filterOutNullabilityAnnotations()
+              ?.annotationMirrors
+              .orEmpty()
+              .map { AnnotationSpec.get(it) }
+              .filterOutNullabilityAnnotations()
         }
 
         override fun methodAnnotations(
-          classJvmName: String,
-          methodSignature: JvmMethodSignature
+            classJvmName: String,
+            methodSignature: JvmMethodSignature
         ): List<AnnotationSpec> {
           return lookupMethod(classJvmName, methodSignature, ElementFilter::methodsIn)
-                ?.annotationMirrors
-                .orEmpty()
-                .map { AnnotationSpec.get(it) }
-                .filterOutNullabilityAnnotations()
+              ?.annotationMirrors
+              .orEmpty()
+              .map { AnnotationSpec.get(it) }
+              .filterOutNullabilityAnnotations()
         }
 
         override fun enumEntry(enumClassJvmName: String, memberName: String): ImmutableKmClass? {
@@ -487,14 +524,97 @@ interface ElementHandler {
         }
 
         override fun fieldConstant(
-          classJvmName: String,
-          fieldSignature: JvmFieldSignature
+            classJvmName: String,
+            fieldSignature: JvmFieldSignature
         ): CodeBlock? {
           return lookupField(classJvmName, fieldSignature)?.constantValue
               ?.asLiteralCodeBlock()
               ?: error("No field $fieldSignature found in $classJvmName.")
         }
+
+        override fun isMethodOverride(classJvmName: String,
+            methodSignature: JvmMethodSignature): Boolean {
+          val typeElement = lookupTypeElement(classJvmName)
+              ?: error("No type element found for: $classJvmName.")
+          val method = typeElement.lookupMethod(methodSignature, ElementFilter::methodsIn)
+              ?: error("No ExecutableElement found for: $methodSignature.")
+          return method.isOverriddenIn(typeElement)
+        }
+
+        /**
+         * Detects whether [this] given method is overriden in [type].
+         *
+         * Adapted and simplified from AutoCommon's private
+         * [MoreElements.getLocalAndInheritedMethods] methods implementations for detecting
+         * overrides.
+         */
+        private fun ExecutableElement.isOverriddenIn(type: TypeElement): Boolean {
+          val methodMap = LinkedHashMultimap.create<String, ExecutableElement>()
+          type.getAllMethods(MoreElements.getPackage(type), methodMap)
+          // Find methods that are overridden using `Elements.overrides`. We reduce the performance
+          // impact by:
+          //   (a) grouping methods by name, since a method cannot override another method with a
+          //       different name. Since we know the target name, we just inspect the methods with
+          //       that name.
+          //   (b) making sure that methods in ancestor types precede those in descendant types,
+          //       which means we only have to check a method against the ones that follow it in
+          //       that order. Below, this means we just need to find the index of our target method
+          //       and compare against only preceding ones.
+          val methodList = methodMap.asMap()[simpleName.toString()]?.toList()
+              ?: error("No method $simpleName in available ${methodMap.keys()}")
+          val indexOfPossibleOverrider = methodList.indexOf(this)
+          return (indexOfPossibleOverrider downTo 0)
+              .asSequence()
+              .map { methodList[it] }
+              .any { elements.overrides(this, it, type) }
+        }
+
+        /**
+         * Add to [methodsAccumulator] the instance methods from [this] that are visible to code in
+         * the package [pkg]. This means all the instance methods from [this] itself and all
+         * instance methods it inherits from its ancestors, except private methods and
+         * package-private methods in other packages. This method does not take overriding into
+         * account, so it will add both an ancestor method and a descendant method that overrides
+         * it. [methodsAccumulator] is a multimap from a method name to all of the methods with
+         * that name, including methods that override or overload one another. Within those
+         * methods, those in ancestor types always precede those in descendant types.
+         *
+         * Adapted from AutoCommon's private [MoreElements.getLocalAndInheritedMethods] methods'
+         * implementations, before overridden methods are stripped.
+         */
+        private fun TypeElement.getAllMethods(
+          pkg: PackageElement,
+          methodsAccumulator: SetMultimap<String, ExecutableElement>
+        ) {
+          for (superInterface in interfaces) {
+            MoreTypes.asTypeElement(superInterface).getAllMethods(pkg, methodsAccumulator)
+          }
+          if (superclass.kind != TypeKind.NONE) {
+            // Visit the superclass after superinterfaces so we will always see the implementation of a
+            // method after any interfaces that declared it.
+            MoreTypes.asTypeElement(superclass).getAllMethods(pkg, methodsAccumulator)
+          }
+          for (method in ElementFilter.methodsIn(enclosedElements)) {
+            if (!method.modifiers.contains(
+                    javax.lang.model.element.Modifier.STATIC) && method.isVisibleFrom(pkg)) {
+              methodsAccumulator.put(method.simpleName.toString(), method)
+            }
+          }
+        }
+
+        private fun ExecutableElement.isVisibleFrom(pkg: PackageElement): Boolean {
+          // We use Visibility.ofElement rather than [MoreElements.effectiveVisibilityOfElement]
+          // because it doesn't really matter whether the containing class is visible. If you
+          // inherit a public method then you have a public method, regardless of whether you
+          // inherit it from a public class.
+          return when (Visibility.ofElement(this)) {
+            Visibility.PRIVATE -> false
+            Visibility.DEFAULT -> MoreElements.getPackage(this) == pkg
+            else -> true
+          }
+        }
       }
+
     }
   }
 }

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ElementHandler.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ElementHandler.kt
@@ -461,10 +461,11 @@ interface ElementHandler {
 
         override fun enumEntry(enumClassJvmName: String, memberName: String): ImmutableKmClass? {
           return lookupTypeElement(enumClassJvmName)?.let { enumType ->
-            val member = variableElementCache.getOrPut(enumType to memberName) {
-              ElementFilter.fieldsIn(enumType.enclosedElements)
+            val enumTypeAsType = enumType.asType()
+            val member = typeElementCache.getOrPut("$enumClassJvmName.$memberName") {
+              ElementFilter.typesIn(enumType.enclosedElements)
                   .asSequence()
-                  .filter { it.kind == ENUM_CONSTANT }
+                  .filter { types.isSubtype(enumTypeAsType, it.superclass) }
                   .find { it.simpleName.contentEquals(memberName) }.toOptional()
             }.nullableValue
             member?.getAnnotation(Metadata::class.java)

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ElementHandler.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ElementHandler.kt
@@ -261,7 +261,8 @@ interface ElementHandler {
         classJvmName: String,
         methodSignature: JvmMethodSignature
       ): Method? {
-        return lookupClass(classJvmName)?.lookupMethod(methodSignature) ?: error("No class found for: $classJvmName.")
+        val clazz = lookupClass(classJvmName) ?: error("No class found for: $classJvmName.")
+        return clazz.lookupMethod(methodSignature)
       }
 
       private fun Class<*>.lookupMethod(

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/JvmDescriptorUtils.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/JvmDescriptorUtils.kt
@@ -1,0 +1,239 @@
+package com.squareup.kotlinpoet
+
+import kotlinx.metadata.jvm.JvmFieldSignature
+import kotlinx.metadata.jvm.JvmMethodSignature
+import java.lang.reflect.Constructor
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import javax.lang.model.element.Element
+import javax.lang.model.element.ExecutableElement
+import javax.lang.model.element.NestingKind
+import javax.lang.model.element.QualifiedNameable
+import javax.lang.model.element.TypeElement
+import javax.lang.model.element.VariableElement
+import javax.lang.model.type.ArrayType
+import javax.lang.model.type.DeclaredType
+import javax.lang.model.type.ErrorType
+import javax.lang.model.type.ExecutableType
+import javax.lang.model.type.NoType
+import javax.lang.model.type.NullType
+import javax.lang.model.type.PrimitiveType
+import javax.lang.model.type.TypeKind.BOOLEAN
+import javax.lang.model.type.TypeKind.BYTE
+import javax.lang.model.type.TypeKind.CHAR
+import javax.lang.model.type.TypeKind.DOUBLE
+import javax.lang.model.type.TypeKind.FLOAT
+import javax.lang.model.type.TypeKind.INT
+import javax.lang.model.type.TypeKind.LONG
+import javax.lang.model.type.TypeKind.SHORT
+import javax.lang.model.type.TypeMirror
+import javax.lang.model.type.TypeVariable
+import javax.lang.model.type.WildcardType
+import javax.lang.model.util.AbstractTypeVisitor6
+import javax.lang.model.util.Types
+
+/*
+ * Adapted from
+ * - https://github.com/Takhion/kotlin-metadata/blob/e6de126575ad6ca10b093129b7c30d000c9b0c37/lib/src/main/kotlin/me/eugeniomarletti/kotlin/metadata/jvm/JvmDescriptorUtils.kt
+ * - https://github.com/Takhion/kotlin-metadata/pull/13
+ */
+
+/**
+ * For reference, see the [JVM specification, section 4.2](http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.2).
+ *
+ * @return the name of this [Element] in its "internal form".
+ */
+internal val Element.internalName: String
+  get() = when (this) {
+    is TypeElement -> {
+      when (nestingKind) {
+        NestingKind.TOP_LEVEL ->
+          qualifiedName.toString().replace('.', '/')
+        NestingKind.MEMBER ->
+          enclosingElement.internalName + "$" + simpleName
+        NestingKind.LOCAL, NestingKind.ANONYMOUS ->
+          error("Unsupported nesting $nestingKind")
+        else ->
+          error("Unsupported, nestingKind == null")
+      }
+    }
+    is QualifiedNameable -> qualifiedName.toString().replace('.', '/')
+    else -> simpleName.toString()
+  }
+/**
+ * @return the "field descriptor" of this type.
+ * @see [JvmDescriptorTypeVisitor]
+ */
+@Suppress("unused")
+internal val NoType.descriptor: String
+  get() = "V"
+
+/**
+ * @return the "field descriptor" of this type.
+ * @see [JvmDescriptorTypeVisitor]
+ */
+internal val DeclaredType.descriptor: String
+  get() = "L" + asElement().internalName + ";"
+
+/**
+ * @return the "field descriptor" of this type.
+ * @see [JvmDescriptorTypeVisitor]
+ */
+internal val PrimitiveType.descriptor: String
+  get() = when (this.kind) {
+    BYTE -> "B"
+    CHAR -> "C"
+    DOUBLE -> "D"
+    FLOAT -> "F"
+    INT -> "I"
+    LONG -> "J"
+    SHORT -> "S"
+    BOOLEAN -> "Z"
+    else -> error("Unknown primitive type $this")
+  }
+
+/**
+ * @see [JvmDescriptorTypeVisitor]
+ */
+internal fun TypeMirror.descriptor(types: Types): String =
+    accept(JvmDescriptorTypeVisitor, types)
+
+/**
+ * @return the "field descriptor" of this type.
+ * @see [JvmDescriptorTypeVisitor]
+ */
+internal fun WildcardType.descriptor(types: Types): String =
+    types.erasure(this).descriptor(types)
+
+/**
+ * @return the "field descriptor" of this type.
+ * @see [JvmDescriptorTypeVisitor]
+ */
+internal fun TypeVariable.descriptor(types: Types): String =
+    types.erasure(this).descriptor(types)
+
+/**
+ * @return the "field descriptor" of this type.
+ * @see [JvmDescriptorTypeVisitor]
+ */
+internal fun ArrayType.descriptor(types: Types): String =
+    "[" + componentType.descriptor(types)
+
+/**
+ * @return the "method descriptor" of this type.
+ * @see [JvmDescriptorTypeVisitor]
+ */
+internal fun ExecutableType.descriptor(types: Types): String {
+  val parameterDescriptors = parameterTypes.joinToString(separator = "") { it.descriptor(types) }
+  val returnDescriptor = returnType.descriptor(types)
+  return "($parameterDescriptors)$returnDescriptor"
+}
+
+/**
+ * Returns the JVM signature in the form "$Name$MethodDescriptor", for example: `equals(Ljava/lang/Object;)Z`.
+ *
+ * Useful for comparing with [JvmMethodSignature].
+ *
+ * For reference, see the [JVM specification, section 4.3](http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3).
+ */
+internal fun ExecutableElement.jvmMethodSignature(types: Types): String {
+  return "$simpleName${asType().descriptor(types)}"
+}
+
+/**
+ * Returns the JVM signature in the form "$Name:$FieldDescriptor", for example: `"value:Ljava/lang/String;"`.
+ *
+ * Useful for comparing with [JvmFieldSignature].
+ *
+ * For reference, see the [JVM specification, section 4.3](http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3).
+ */
+internal fun VariableElement.jvmFieldSignature(types: Types): String {
+  return "$simpleName:${asType().descriptor(types)}"
+}
+
+/**
+ * When applied over a type, it returns either:
+ * - a "field descriptor", for example: `Ljava/lang/Object;`
+ * - a "method descriptor", for example: `(Ljava/lang/Object;)Z`
+ *
+ * For reference, see the [JVM specification, section 4.3](http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3).
+ */
+internal object JvmDescriptorTypeVisitor : AbstractTypeVisitor6<String, Types>() {
+  override fun visitNoType(t: NoType, types: Types): String = t.descriptor
+  override fun visitDeclared(t: DeclaredType, types: Types): String = t.descriptor
+  override fun visitPrimitive(t: PrimitiveType, types: Types): String = t.descriptor
+
+  override fun visitArray(t: ArrayType, types: Types): String = t.descriptor(types)
+  override fun visitWildcard(t: WildcardType, types: Types): String = t.descriptor(types)
+  override fun visitExecutable(t: ExecutableType, types: Types): String = t.descriptor(types)
+  override fun visitTypeVariable(t: TypeVariable, types: Types): String = t.descriptor(types)
+
+  override fun visitNull(t: NullType, types: Types): String = visitUnknown(t, types)
+  override fun visitError(t: ErrorType, types: Types): String = visitUnknown(t, types)
+
+  override fun visitUnknown(t: TypeMirror, types: Types): String = error("Unsupported type $t")
+}
+
+internal val Class<*>.descriptor: String get() {
+    return when {
+      isPrimitive -> when (kotlin) {
+          Byte::class -> "B"
+          Char::class -> "C"
+          Double::class -> "D"
+          Float::class -> "F"
+          Int::class -> "I"
+          Long::class -> "J"
+          Short::class -> "S"
+          Boolean::class -> "Z"
+          Void::class -> "V"
+          else -> throw RuntimeException("Unrecognized primitive $this")
+      }
+      isArray -> name.replace('.', '/')
+      else -> "L$name;".replace('.', '/')
+    }
+}
+
+internal val Method.descriptor: String get() {
+    return buildString {
+        append('(')
+        parameterTypes.joinTo(this, transform = Class<*>::descriptor)
+        append(')')
+        append(returnType.descriptor)
+    }
+}
+
+/**
+ * Returns the JVM signature in the form "$Name$MethodDescriptor", for example: `equals(Ljava/lang/Object;)Z`.
+ *
+ * Useful for comparing with [JvmMethodSignature].
+ *
+ * For reference, see the [JVM specification, section 4.3](http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3).
+ */
+internal val Method.jvmMethodSignature: String get() = "$name$descriptor"
+
+internal val Constructor<*>.descriptor: String get() {
+    return buildString {
+        append('(')
+        parameterTypes.joinTo(this, transform = Class<*>::descriptor)
+        append(')')
+        append('V')
+    }
+}
+
+/**
+ * Returns the JVM signature in the form "<init>$MethodDescriptor", for example: `"<init>(Ljava/lang/Object;)V")`.
+ *
+ * Useful for comparing with [JvmMethodSignature].
+ *
+ * For reference, see the [JVM specification, section 4.3](http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3).
+ */
+internal val Constructor<*>.jvmMethodSignature: String get() = "<init>$descriptor"
+
+/**
+ * Returns the JVM signature in the form "$Name:$FieldDescriptor", for example: `"value:Ljava/lang/String;"`.
+ *
+ * Useful for comparing with [JvmFieldSignature].
+ *
+ * For reference, see the [JVM specification, section 4.3](http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3).
+ */
+internal val Field.jvmFieldSignature: String get() = "$name:${type.descriptor}"

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/KmSpecs.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/KmSpecs.kt
@@ -15,10 +15,13 @@
  */
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget
 import com.squareup.kotlinpoet.km.ImmutableKmClass
 import com.squareup.kotlinpoet.km.ImmutableKmConstructor
 import com.squareup.kotlinpoet.km.ImmutableKmFunction
 import com.squareup.kotlinpoet.km.ImmutableKmProperty
+import com.squareup.kotlinpoet.km.ImmutableKmType
+import com.squareup.kotlinpoet.km.ImmutableKmTypeParameter
 import com.squareup.kotlinpoet.km.ImmutableKmValueParameter
 import com.squareup.kotlinpoet.km.ImmutableKmWithFlags
 import com.squareup.kotlinpoet.km.KotlinPoetKm
@@ -27,6 +30,8 @@ import com.squareup.kotlinpoet.km.PropertyAccessorFlag.IS_EXTERNAL
 import com.squareup.kotlinpoet.km.PropertyAccessorFlag.IS_INLINE
 import com.squareup.kotlinpoet.km.PropertyAccessorFlag.IS_NOT_DEFAULT
 import com.squareup.kotlinpoet.km.declaresDefaultValue
+import com.squareup.kotlinpoet.km.hasAnnotations
+import com.squareup.kotlinpoet.km.hasConstant
 import com.squareup.kotlinpoet.km.hasGetter
 import com.squareup.kotlinpoet.km.hasSetter
 import com.squareup.kotlinpoet.km.isAbstract
@@ -42,7 +47,6 @@ import com.squareup.kotlinpoet.km.isEnum
 import com.squareup.kotlinpoet.km.isEnumEntry
 import com.squareup.kotlinpoet.km.isExpect
 import com.squareup.kotlinpoet.km.isExternal
-import com.squareup.kotlinpoet.km.isFakeOverride
 import com.squareup.kotlinpoet.km.isFinal
 import com.squareup.kotlinpoet.km.isInfix
 import com.squareup.kotlinpoet.km.isInline
@@ -69,6 +73,8 @@ import com.squareup.kotlinpoet.km.isVar
 import com.squareup.kotlinpoet.km.propertyAccessorFlags
 import com.squareup.kotlinpoet.km.toImmutableKmClass
 import kotlinx.metadata.Flags
+import kotlinx.metadata.KmClassifier
+import kotlinx.metadata.jvm.jvmInternalName
 import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.PackageElement
@@ -77,36 +83,69 @@ import kotlin.reflect.KClass
 
 /** @return a [TypeSpec] ABI representation of this [KClass]. */
 @KotlinPoetKm
-fun KClass<*>.toTypeSpec(): TypeSpec = java.toTypeSpec()
+fun KClass<*>.toTypeSpec(
+  elementHandler: ElementHandler? = null
+): TypeSpec = java.toTypeSpec(elementHandler)
+
 /** @return a [TypeSpec] ABI representation of this [KClass]. */
 @KotlinPoetKm
-fun Class<*>.toTypeSpec(): TypeSpec = toImmutableKmClass().toTypeSpec()
+fun Class<*>.toTypeSpec(
+  elementHandler: ElementHandler? = null
+): TypeSpec = toImmutableKmClass().toTypeSpec(elementHandler)
+
 /** @return a [TypeSpec] ABI representation of this [TypeElement]. */
 @KotlinPoetKm
-fun TypeElement.toTypeSpec(): TypeSpec = toImmutableKmClass().toTypeSpec()
+fun TypeElement.toTypeSpec(
+  elementHandler: ElementHandler? = null
+): TypeSpec = toImmutableKmClass().toTypeSpec(elementHandler)
+
 /** @return a [FileSpec] ABI representation of this [KClass]. */
 @KotlinPoetKm
-fun KClass<*>.toFileSpec(): FileSpec = java.toFileSpec()
+fun KClass<*>.toFileSpec(
+  elementHandler: ElementHandler? = null
+): FileSpec = java.toFileSpec(elementHandler)
+
 /** @return a [FileSpec] ABI representation of this [KClass]. */
 @KotlinPoetKm
-fun Class<*>.toFileSpec(): FileSpec = FileSpec.get(`package`.name, toTypeSpec())
+fun Class<*>.toFileSpec(
+  elementHandler: ElementHandler? = null
+): FileSpec = FileSpec.get(`package`.name, toTypeSpec(elementHandler))
+
 /** @return a [FileSpec] ABI representation of this [TypeElement]. */
 @KotlinPoetKm
-fun TypeElement.toFileSpec(): FileSpec = FileSpec.get(
-    packageName = packageName.toString(),
-    typeSpec = toTypeSpec()
+fun TypeElement.toFileSpec(
+  elementHandler: ElementHandler? = null
+): FileSpec = FileSpec.get(
+    packageName = packageName,
+    typeSpec = toTypeSpec(elementHandler)
 )
 
 private const val TODO_BLOCK = "TODO(\"Stub!\")"
 
 @KotlinPoetKm
-private fun ImmutableKmClass.toTypeSpec(): TypeSpec {
+private fun List<ImmutableKmTypeParameter>.toTypeParamsResolver(
+  fallback: ((Int) -> TypeVariableName)? = null
+): (Int) -> TypeVariableName {
+  val parametersMap = mutableMapOf<Int, TypeVariableName>()
+  val typeParamResolver = { id: Int ->
+    parametersMap[id]
+        ?: fallback?.invoke(id)
+        ?: throw IllegalStateException("No type argument found for $id!")
+  }
   // Fill the parametersMap. Need to do sequentially and allow for referencing previously defined params
-  val parametersMap = mutableMapOf<Int, TypeName>()
-  val typeParamResolver = { id: Int -> parametersMap.getValue(id) }
-  typeParameters.forEach { parametersMap[it.id] = it.toTypeVariableName(typeParamResolver) }
+  forEach { parametersMap[it.id] = it.toTypeVariableName(typeParamResolver) }
+  return typeParamResolver
+}
+
+@KotlinPoetKm
+private fun ImmutableKmClass.toTypeSpec(
+  elementHandler: ElementHandler?,
+  parentName: String? = null
+): TypeSpec {
+  val classTypeParamsResolver = typeParameters.toTypeParamsResolver()
 
   val simpleName = name.substringAfterLast(if (isInline) "/" else ".")
+  val jvmInternalName = name.jvmInternalName
   val builder = when {
     isAnnotation -> TypeSpec.annotationBuilder(simpleName)
     isCompanionObject -> TypeSpec.companionObjectBuilder(companionObjectName(simpleName))
@@ -114,61 +153,169 @@ private fun ImmutableKmClass.toTypeSpec(): TypeSpec {
     isExpect -> TypeSpec.expectClassBuilder(simpleName)
     isObject -> TypeSpec.objectBuilder(simpleName)
     isInterface -> TypeSpec.interfaceBuilder(simpleName)
+    isEnumEntry -> TypeSpec.anonymousClassBuilder()
     else -> TypeSpec.classBuilder(simpleName)
   }
-  addVisibility { builder.addModifiers(it) }
-  builder.addModifiers(flags.modalities
-      .filterNot { it == KModifier.FINAL } // Default
-      .filterNot { isInterface && it == KModifier.ABSTRACT } // Abstract is a default on interfaces
-  )
-  if (isData) {
-    builder.addModifiers(KModifier.DATA)
-  }
-  if (isExternal) {
-    builder.addModifiers(KModifier.EXTERNAL)
-  }
-  if (isInline) {
-    builder.addModifiers(KModifier.INLINE)
-    // TODO these are special.
-    //  - Name is the fqcn
-  }
-  if (isInner) {
-    builder.addModifiers(KModifier.INNER)
-  }
-  if (isEnumEntry) {
-    // TODO
-  }
+
   if (isEnum) {
-    // TODO handle typespec arg for complex enums
-    enumEntries.forEach {
-      builder.addEnumConstant(it)
+    enumEntries.forEach { entryName ->
+      val typeSpec = if (elementHandler != null) {
+        elementHandler.enumEntry(jvmInternalName, entryName)?.toTypeSpec(elementHandler)
+      } else {
+        TypeSpec.anonymousClassBuilder()
+            .addKdoc(
+                "No ElementHandler was available during metadata parsing, so this entry may not be reflected accurately if it has a class body.")
+            .build()
+      }
+      if (typeSpec != null) {
+        builder.addEnumConstant(entryName, typeSpec)
+      } else {
+        builder.addEnumConstant(entryName)
+      }
     }
   }
 
-  builder.addTypeVariables(typeParameters.map { it.toTypeVariableName(typeParamResolver) })
-  if (!isEnum && !isInterface) {
-    supertypes.first().toTypeName(typeParamResolver).takeIf { it != ANY }?.let(builder::superclass)
-  }
-  builder.addSuperinterfaces(supertypes.drop(if (isInterface) 0 else 1).map { it.toTypeName(typeParamResolver) })
-  val primaryConstructorSpec = primaryConstructor?.takeIf { it.valueParameters.isNotEmpty() || flags.visibility != KModifier.PUBLIC }?.let {
-    it.toFunSpec(typeParamResolver).also {
-      builder.primaryConstructor(it)
+  if (!isEnumEntry) {
+    addVisibility { builder.addModifiers(it) }
+    builder.addModifiers(*flags.modalities
+        .filterNot { it == KModifier.FINAL } // Default
+        .filterNot { isInterface && it == KModifier.ABSTRACT } // Abstract is a default on interfaces
+        .toTypedArray()
+    )
+    if (isData) {
+      builder.addModifiers(KModifier.DATA)
     }
-  }
-  constructors.filter { !it.isPrimary }.takeIf { it.isNotEmpty() }?.let { secondaryConstructors ->
-    builder.addFunctions(secondaryConstructors.map { it.toFunSpec(typeParamResolver) })
-  }
-  val primaryConstructorParams = primaryConstructorSpec?.parameters.orEmpty().associateBy { it.name }
-  builder.addProperties(
-      properties
-          .asSequence()
-          .filter { it.isDeclaration }
-          .filterNot { it.isSynthesized }
-          .map { it.toPropertySpec(typeParamResolver, it.name in primaryConstructorParams) }
-          .asIterable()
-  )
-  companionObject?.let {
-    builder.addType(TypeSpec.companionObjectBuilder(companionObjectName(it)).build())
+    if (isExternal) {
+      builder.addModifiers(KModifier.EXTERNAL)
+    }
+    if (isInline) {
+      builder.addModifiers(KModifier.INLINE)
+      // TODO these are special.
+      //  - Name is the fqcn
+    }
+    if (isInner) {
+      builder.addModifiers(KModifier.INNER)
+    }
+    builder.addTypeVariables(typeParameters.map { it.toTypeVariableName(classTypeParamsResolver) })
+    // If we have an element handler, we can check exactly which "supertype" is an interface vs
+    // class. Without a handler though, we have to best-effort guess. Usually, the flow is:
+    // - First element of a non-interface type is the superclass (can be `Any`)
+    // - First element of an interface type is the first superinterface
+    val superClassFilter = elementHandler?.let { handler ->
+      { type: ImmutableKmType ->
+        !handler.isInterface((type.classifier as KmClassifier.Class).name.jvmInternalName)
+      }
+    } ?: { true }
+    val superClass = supertypes.asSequence()
+        .filter { it.classifier is KmClassifier.Class }
+        .find(superClassFilter)
+    if (superClass != null && !isEnum && !isInterface && !isAnnotation) {
+      superClass.toTypeName(classTypeParamsResolver).takeIf { it != ANY }
+          ?.let(builder::superclass)
+    }
+    builder.addSuperinterfaces(
+        supertypes.asSequence()
+            .filterNot { it == superClass }
+            .map { it.toTypeName(classTypeParamsResolver) }
+            .filterNot { it == ANY }
+            .asIterable()
+    )
+    val primaryConstructorSpec = primaryConstructor?.takeIf {
+      it.valueParameters.isNotEmpty() || flags.visibility != KModifier.PUBLIC || it.hasAnnotations
+    }?.let {
+      it.toFunSpec(classTypeParamsResolver, it.annotations(jvmInternalName, elementHandler))
+          .also { spec ->
+            val finalSpec = if (isEnum) {
+              // Metadata specifies the constructor as private, but that's implicit so we can omit it
+              spec.toBuilder().apply { modifiers.remove(KModifier.PRIVATE) }.build()
+            } else spec
+            builder.primaryConstructor(finalSpec)
+          }
+    }
+    constructors.filter { !it.isPrimary }.takeIf { it.isNotEmpty() }?.let { secondaryConstructors ->
+      builder.addFunctions(secondaryConstructors.map {
+        it.toFunSpec(classTypeParamsResolver, it.annotations(jvmInternalName, elementHandler))
+      })
+    }
+    val primaryConstructorParams = primaryConstructorSpec?.parameters.orEmpty().associateBy { it.name }
+    builder.addProperties(
+        properties
+            .asSequence()
+            .filter { it.isDeclaration }
+            .filterNot { it.isSynthesized }
+            .map {
+              val annotations = mutableListOf<AnnotationSpec>()
+              var constant: CodeBlock? = null
+              if (elementHandler != null) {
+                if (it.hasAnnotations) {
+                  annotations += it.syntheticMethodForAnnotations?.let {
+                    elementHandler.methodAnnotations(jvmInternalName, it)
+                  }.orEmpty()
+                }
+                it.fieldSignature?.let { fieldSignature ->
+                  annotations += elementHandler.fieldAnnotations(jvmInternalName, fieldSignature)
+                      .map { it.toBuilder().useSiteTarget(UseSiteTarget.FIELD).build() }
+                  annotations += elementHandler.fieldJvmModifiers(jvmInternalName, fieldSignature)
+                      .map { it.annotationSpec() }
+                  if (it.hasConstant) {
+                    constant = if (isCompanionObject && parentName != null) {
+                      // Constants are relocated to the enclosing class!
+                      elementHandler.fieldConstant(parentName, fieldSignature)
+                    } else {
+                      elementHandler.fieldConstant(jvmInternalName, fieldSignature)
+                    }
+                  }
+                }
+                if (it.hasGetter) {
+                  it.getterSignature?.let { getterSignature ->
+                    if (it.getterFlags.hasAnnotations) {
+                      annotations += elementHandler.methodAnnotations(jvmInternalName,
+                          getterSignature)
+                          .map { it.toBuilder().useSiteTarget(UseSiteTarget.GET).build() }
+                    }
+                    annotations += elementHandler.methodJvmModifiers(jvmInternalName,
+                        getterSignature)
+                        .map {
+                          it.annotationSpec().toBuilder().useSiteTarget(UseSiteTarget.GET).build()
+                        }
+                  }
+                }
+                if (it.hasSetter) {
+                  it.setterSignature?.let { setterSignature ->
+                    if (it.setterFlags.hasAnnotations) {
+                      annotations += elementHandler.methodAnnotations(jvmInternalName,
+                          setterSignature)
+                          .map { it.toBuilder().useSiteTarget(UseSiteTarget.SET).build() }
+                    }
+                    annotations += elementHandler.methodJvmModifiers(jvmInternalName,
+                        setterSignature)
+                        .map {
+                          it.annotationSpec().toBuilder().useSiteTarget(UseSiteTarget.SET).build()
+                        }
+                  }
+                }
+              }
+              it.toPropertySpec(
+                  typeParamResolver = classTypeParamsResolver,
+                  isConstructorParam = it.name in primaryConstructorParams,
+                  annotations = annotations,
+                  constant = constant
+              )
+            }
+            .asIterable()
+    )
+    companionObject?.let { objectName ->
+      val companionType = if (elementHandler != null) {
+        elementHandler.classFor("$jvmInternalName$$objectName")
+            .toTypeSpec(elementHandler, jvmInternalName)
+      } else {
+        TypeSpec.companionObjectBuilder(companionObjectName(objectName))
+            .addKdoc(
+                "No ElementHandler was available during metadata parsing, so this companion object's API/contents may not be reflected accurately.")
+            .build()
+      }
+      builder.addType(companionType)
+    }
   }
   builder.addFunctions(
       functions
@@ -176,13 +323,70 @@ private fun ImmutableKmClass.toTypeSpec(): TypeSpec {
           .filter { it.isDeclaration }
           .filterNot { it.isDelegation }
           .filterNot { it.isSynthesized }
-          .map { it.toFunSpec(typeParamResolver) }
+          .map { func ->
+            val functionTypeParamsResolver = func.typeParameters.toTypeParamsResolver(
+                fallback = classTypeParamsResolver)
+            val annotations = mutableListOf<AnnotationSpec>()
+            if (elementHandler != null) {
+              func.signature?.let { signature ->
+                if (func.hasAnnotations) {
+                  annotations += elementHandler.methodAnnotations(jvmInternalName, signature)
+                }
+                annotations += elementHandler.methodJvmModifiers(jvmInternalName, signature)
+                    .map { it.annotationSpec() }
+              }
+            }
+            func.toFunSpec(functionTypeParamsResolver, annotations).let {
+              // For interface methods, remove any body and mark the methods as abstracte
+              // TODO kotlin interface methods _can_ be implemented. How do we detect that?
+              if (isInterface && annotations.none { it.className == JVM_DEFAULT }) {
+                it.toBuilder()
+                    .addModifiers(KModifier.ABSTRACT)
+                    .apply {
+                      body.clear()
+                    }
+                    .build()
+              } else {
+                it
+              }
+            }
+          }
           .asIterable()
   )
+
+  for (it in nestedClasses) {
+    val nestedClass = elementHandler?.classFor("$jvmInternalName$$it")
+    val nestedType = if (nestedClass != null) {
+      if (nestedClass.isCompanionObject) {
+        // We handle these separately
+        continue
+      } else {
+        nestedClass.toTypeSpec(elementHandler, jvmInternalName)
+      }
+    } else {
+      TypeSpec.classBuilder(it)
+          .addKdoc(
+              "No ElementHandler was available during metadata parsing, so this nested class's API/contents may not be reflected accurately.")
+          .build()
+    }
+    builder.addType(nestedType)
+  }
 
   return builder
       .tag(this)
       .build()
+}
+
+@KotlinPoetKm
+private fun ImmutableKmConstructor.annotations(
+  classJvmName: String,
+  elementHandler: ElementHandler?
+): List<AnnotationSpec> {
+  return if (elementHandler != null && hasAnnotations && signature != null) {
+    elementHandler.constructorAnnotations(classJvmName, signature!!)
+  } else {
+    emptyList()
+  }
 }
 
 private fun companionObjectName(name: String): String? {
@@ -191,10 +395,12 @@ private fun companionObjectName(name: String): String? {
 
 @KotlinPoetKm
 private fun ImmutableKmConstructor.toFunSpec(
-  typeParamResolver: ((index: Int) -> TypeName)
+  typeParamResolver: ((index: Int) -> TypeName),
+  annotations: List<AnnotationSpec>
 ): FunSpec {
   return FunSpec.constructorBuilder()
       .apply {
+        addAnnotations(annotations)
         addVisibility { addModifiers(it) }
         addParameters(this@toFunSpec.valueParameters.map { it.toParameterSpec(typeParamResolver) })
         if (!isPrimary) {
@@ -207,13 +413,22 @@ private fun ImmutableKmConstructor.toFunSpec(
 
 @KotlinPoetKm
 private fun ImmutableKmFunction.toFunSpec(
-  typeParamResolver: ((index: Int) -> TypeName)
+  typeParamResolver: ((index: Int) -> TypeName),
+  annotations: List<AnnotationSpec>
 ): FunSpec {
+  // Only visisble from Elements API as Override is not available at runtime for reflection
+  val isOverride = annotations.any { it.className == OVERRIDE }
   return FunSpec.builder(name)
       .apply {
+        addAnnotations(annotations)
         addVisibility { addModifiers(it) }
-        addParameters(this@toFunSpec.valueParameters.map { it.toParameterSpec(typeParamResolver) })
-        if (isFakeOverride) {
+        if (valueParameters.isNotEmpty()) {
+          addParameters(valueParameters.map { it.toParameterSpec(typeParamResolver) })
+        }
+        if (typeParameters.isNotEmpty()) {
+          addTypeVariables(typeParameters.map { it.toTypeVariableName(typeParamResolver) })
+        }
+        if (isOverride) {
           addModifiers(KModifier.OVERRIDE)
         }
         if (isSynthesized) {
@@ -278,9 +493,12 @@ private fun ImmutableKmValueParameter.toParameterSpec(
 @KotlinPoetKm
 private fun ImmutableKmProperty.toPropertySpec(
   typeParamResolver: ((index: Int) -> TypeName),
-  isConstructorParam: Boolean
+  isConstructorParam: Boolean,
+  annotations: List<AnnotationSpec>,
+  constant: CodeBlock?
 ) = PropertySpec.builder(name, returnType.toTypeName(typeParamResolver))
     .apply {
+      addAnnotations(annotations)
       addVisibility { addModifiers(it) }
       addModifiers(flags.modalities
           .filterNot { it == KModifier.FINAL && !isOverride } // Final is the default
@@ -304,7 +522,8 @@ private fun ImmutableKmProperty.toPropertySpec(
           delegate("%M { %L }", MemberName("kotlin", "lazy"), TODO_BLOCK) // Placeholder
         } else {
           if (type.isNullable) {
-            delegate("%T.observable(null) { _, _, _ -> }", ClassName("kotlin.properties", "Delegates"))
+            delegate("%T.observable(null) { _, _, _ -> }",
+                ClassName("kotlin.properties", "Delegates"))
           } else {
             delegate("%T.notNull()", ClassName("kotlin.properties", "Delegates")) // Placeholder
           }
@@ -320,8 +539,8 @@ private fun ImmutableKmProperty.toPropertySpec(
         addModifiers(KModifier.LATEINIT)
       }
       if (isConstructorParam || (!isDelegated && !isLateinit)) {
-        // TODO if hasConstant + elements, we could look up the constant initializer
         when {
+          constant != null -> initializer(constant)
           isConstructorParam -> initializer(name)
           type.isNullable -> initializer("null")
           else -> initializer(TODO_BLOCK)
@@ -330,7 +549,8 @@ private fun ImmutableKmProperty.toPropertySpec(
       // Delegated properties have setters/getters defined for some reason, ignore here
       // since the delegate handles it
       if (hasGetter && !isDelegated) {
-        propertyAccessor(getterFlags, FunSpec.getterBuilder())?.let(::getter)
+        propertyAccessor(getterFlags, FunSpec.getterBuilder().addStatement(TODO_BLOCK))?.let(
+            ::getter)
       }
       if (hasSetter && !isDelegated) {
         propertyAccessor(setterFlags, FunSpec.setterBuilder())?.let(::setter)
@@ -410,12 +630,15 @@ private inline fun <E> setOf(body: MutableSet<E>.() -> Unit): Set<E> {
   return mutableSetOf<E>().apply(body).toSet()
 }
 
+private val OVERRIDE = Override::class.asClassName()
+private val JVM_DEFAULT = JvmDefault::class.asClassName()
+
 @PublishedApi
-internal val Element.packageName: PackageElement
+internal val Element.packageName: String
   get() {
-      var element = this
-      while (element.kind != ElementKind.PACKAGE) {
-        element = element.enclosingElement
-      }
-      return element as PackageElement
+    var element = this
+    while (element.kind != ElementKind.PACKAGE) {
+      element = element.enclosingElement
+    }
+    return (element as PackageElement).toString()
   }

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Optional.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Optional.kt
@@ -1,0 +1,9 @@
+package com.squareup.kotlinpoet
+
+/**
+ * Simple `Optional` implementation for use in collections that don't allow `null` values.
+ *
+ * TODO: Make this an inline class when inline classes are stable.
+ */
+internal data class Optional<out T : Any>(val nullableValue: T?)
+internal fun <T : Any> T?.toOptional(): Optional<T> = Optional(this)

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -53,7 +53,7 @@ class KmSpecsTest(
     @Suppress("RedundantLambdaArrow") // Needed for lambda type resolution
     @JvmStatic
     @Parameterized.Parameters(name = "{0}")
-    fun data() : Collection<Array<*>> {
+    fun data(): Collection<Array<*>> {
       return listOf(
           arrayOf<Any>(
               ElementHandlerType.REFLECTIVE,
@@ -77,8 +77,8 @@ class KmSpecsTest(
   @Target(AnnotationTarget.FUNCTION)
   @Inherited
   annotation class IgnoreForHandlerType(
-      val reason: String,
-      val handlerType: ElementHandlerType
+    val reason: String,
+    val handlerType: ElementHandlerType
   )
 
   class IgnoreForElementsRule(private val handlerType: ElementHandlerType) : TestRule {
@@ -426,12 +426,12 @@ class KmSpecsTest(
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       abstract class OverriddenThings : com.squareup.kotlinpoet.KmSpecsTest.OverriddenThingsBase(), com.squareup.kotlinpoet.KmSpecsTest.OverriddenThingsInterface {
         override var openProp: kotlin.String = TODO("Stub!")
-      
+
         override var openPropInterface: kotlin.String = TODO("Stub!")
-      
+
         override fun openFunction() {
         }
-      
+
         override fun openFunctionInterface() {
         }
       }
@@ -774,7 +774,6 @@ class KmSpecsTest(
   @Retention(RUNTIME)
   annotation class FunctionAnnotation
 
-
   @IgnoreForHandlerType(
       reason = "Elements properly resolves the regular properties + JvmStatic, but reflection will not",
       handlerType = REFLECTIVE
@@ -792,21 +791,21 @@ class KmSpecsTest(
         val binaryProp: kotlin.Int = 11
 
         val boolProp: kotlin.Boolean = false
-      
+
         val doubleProp: kotlin.Double = 1.0
-      
+
         val floatProp: kotlin.Float = 1.0F
-      
+
         val hexProp: kotlin.Int = 15
-      
+
         val intProp: kotlin.Int = 1
-      
+
         val longProp: kotlin.Long = 1L
-      
+
         val stringProp: kotlin.String = "prop"
-      
+
         val underscoresHexProp: kotlin.Long = 4293713502L
-      
+
         val underscoresProp: kotlin.Int = 1000000
 
         companion object {

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -418,20 +418,20 @@ class KmSpecsTest(
     }
   }
 
-  @Ignore("We need to read @Override annotations off of these in metadata parsing")
   @Test
   fun overriddenThings() {
     val typeSpec = OverriddenThings::class.toTypeSpecWithTestHandler()
 
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
-      abstract class OverriddenThings : OverriddenThingsBase(), OverriddenThingsInterface {
-        override var openProp: String = TODO("Stub!")
-        override var openPropInterface: String = TODO("Stub!")
-
+      abstract class OverriddenThings : com.squareup.kotlinpoet.KmSpecsTest.OverriddenThingsBase(), com.squareup.kotlinpoet.KmSpecsTest.OverriddenThingsInterface {
+        override var openProp: kotlin.String = TODO("Stub!")
+      
+        override var openPropInterface: kotlin.String = TODO("Stub!")
+      
         override fun openFunction() {
         }
-
+      
         override fun openFunctionInterface() {
         }
       }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("RemoveRedundantQualifierName", "RedundantSuspendModifier", "NOTHING_TO_INLINE")
 package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
@@ -24,16 +25,20 @@ import com.squareup.kotlinpoet.km.ImmutableKmValueParameter
 import com.squareup.kotlinpoet.km.KotlinPoetKm
 import org.junit.Ignore
 import org.junit.Test
+import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.properties.Delegates
+import kotlin.reflect.KClass
 import kotlin.test.fail
 
 @KotlinPoetKm
 @Suppress("unused", "UNUSED_PARAMETER")
 class KmSpecsTest {
 
+  private fun KClass<*>.toTypeSpecWithReflectiveHandler() = toTypeSpec(ElementHandler.reflective())
+
   @Test
   fun constructorData() {
-    val typeSpec = ConstructorClass::class.toTypeSpec()
+    val typeSpec = ConstructorClass::class.toTypeSpecWithReflectiveHandler()
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class ConstructorClass(
@@ -53,7 +58,7 @@ class KmSpecsTest {
 
   @Test
   fun supertype() {
-    val typeSpec = Supertype::class.toTypeSpec()
+    val typeSpec = Supertype::class.toTypeSpecWithReflectiveHandler()
 
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
@@ -67,7 +72,7 @@ class KmSpecsTest {
 
   @Test
   fun properties() {
-    val typeSpec = Properties::class.toTypeSpec()
+    val typeSpec = Properties::class.toTypeSpecWithReflectiveHandler()
 
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
@@ -92,7 +97,7 @@ class KmSpecsTest {
 
   @Test
   fun companionObject() {
-    val typeSpec = CompanionObject::class.toTypeSpec()
+    val typeSpec = CompanionObject::class.toTypeSpecWithReflectiveHandler()
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class CompanionObject {
@@ -107,7 +112,7 @@ class KmSpecsTest {
 
   @Test
   fun namedCompanionObject() {
-    val typeSpec = NamedCompanionObject::class.toTypeSpec()
+    val typeSpec = NamedCompanionObject::class.toTypeSpecWithReflectiveHandler()
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class NamedCompanionObject {
@@ -122,7 +127,7 @@ class KmSpecsTest {
 
   @Test
   fun generics() {
-    val typeSpec = Generics::class.toTypeSpec()
+    val typeSpec = Generics::class.toTypeSpecWithReflectiveHandler()
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Generics<T, in R, V>(
@@ -135,7 +140,7 @@ class KmSpecsTest {
 
   @Test
   fun typeAliases() {
-    val typeSpec = TypeAliases::class.toTypeSpec()
+    val typeSpec = TypeAliases::class.toTypeSpecWithReflectiveHandler()
 
     // We always resolve the underlying type of typealiases
     //language=kotlin
@@ -151,7 +156,7 @@ class KmSpecsTest {
 
   @Test
   fun propertyMutability() {
-    val typeSpec = PropertyMutability::class.toTypeSpec()
+    val typeSpec = PropertyMutability::class.toTypeSpecWithReflectiveHandler()
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class PropertyMutability(
@@ -165,7 +170,7 @@ class KmSpecsTest {
 
   @Test
   fun collectionMutability() {
-    val typeSpec = CollectionMutability::class.toTypeSpec()
+    val typeSpec = CollectionMutability::class.toTypeSpecWithReflectiveHandler()
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class CollectionMutability(
@@ -179,7 +184,7 @@ class KmSpecsTest {
 
   @Test
   fun suspendTypes() {
-    val typeSpec = SuspendTypes::class.toTypeSpec()
+    val typeSpec = SuspendTypes::class.toTypeSpecWithReflectiveHandler()
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class SuspendTypes {
@@ -212,7 +217,7 @@ class KmSpecsTest {
 
   @Test
   fun parameters() {
-    val typeSpec = Parameters::class.toTypeSpec()
+    val typeSpec = Parameters::class.toTypeSpecWithReflectiveHandler()
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Parameters {
@@ -243,7 +248,7 @@ class KmSpecsTest {
 
   @Test
   fun lambdaReceiver() {
-    val typeSpec = LambdaReceiver::class.toTypeSpec()
+    val typeSpec = LambdaReceiver::class.toTypeSpecWithReflectiveHandler()
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class LambdaReceiver {
@@ -270,7 +275,7 @@ class KmSpecsTest {
 
   @Test
   fun nestedTypeAlias() {
-    val typeSpec = NestedTypeAliasTest::class.toTypeSpec()
+    val typeSpec = NestedTypeAliasTest::class.toTypeSpecWithReflectiveHandler()
 
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
@@ -286,7 +291,7 @@ class KmSpecsTest {
 
   @Test
   fun inlineClass() {
-    val typeSpec = InlineClass::class.toTypeSpec()
+    val typeSpec = InlineClass::class.toTypeSpecWithReflectiveHandler()
 
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
@@ -298,7 +303,7 @@ class KmSpecsTest {
 
   @Test
   fun functionReferencingTypeParam() {
-    val typeSpec = FunctionsReferencingTypeParameters::class.toTypeSpec()
+    val typeSpec = FunctionsReferencingTypeParameters::class.toTypeSpecWithReflectiveHandler()
 
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
@@ -317,7 +322,7 @@ class KmSpecsTest {
   @Ignore("We need to read @Override annotations off of these in metadata parsing")
   @Test
   fun overriddenThings() {
-    val typeSpec = OverriddenThings::class.toTypeSpec()
+    val typeSpec = OverriddenThings::class.toTypeSpecWithReflectiveHandler()
 
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
@@ -359,7 +364,7 @@ class KmSpecsTest {
 
   @Test
   fun delegatedProperties() {
-    val typeSpec = DelegatedProperties::class.toTypeSpec()
+    val typeSpec = DelegatedProperties::class.toTypeSpecWithReflectiveHandler()
 
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
@@ -397,7 +402,7 @@ class KmSpecsTest {
   @Ignore("Need to be able to know about class delegation in metadata")
   @Test
   fun classDelegation() {
-    val typeSpec = ClassDelegation::class.toTypeSpec()
+    val typeSpec = ClassDelegation::class.toTypeSpecWithReflectiveHandler()
 
     // TODO Assert this also excludes functions handled by the delegate
     //language=kotlin
@@ -412,7 +417,7 @@ class KmSpecsTest {
 
   @Test
   fun simpleEnum() {
-    val typeSpec = SimpleEnum::class.toTypeSpec()
+    val typeSpec = SimpleEnum::class.toTypeSpecWithReflectiveHandler()
 
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
@@ -430,29 +435,32 @@ class KmSpecsTest {
     FOO, BAR, BAZ
   }
 
-  @Ignore("Requires recursively reading metadata for each enum entry")
   @Test
   fun complexEnum() {
-    val typeSpec = ComplexEnum::class.toTypeSpec()
+    val typeSpec = ComplexEnum::class.toTypeSpecWithReflectiveHandler()
 
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
-      enum class SimpleEnum {
-        FOO("foo") {
-          override fun toString(): String {
-            return "foo1"
+      enum class ComplexEnum(
+        val value: kotlin.String
+      ) {
+        FOO {
+          fun toString(): kotlin.String {
+            TODO("Stub!")
           }
         },
-        BAR("bar") {
-          override fun toString(): String {
-            return "bar1"
+
+        BAR {
+          fun toString(): kotlin.String {
+            TODO("Stub!")
           }
         },
-        BAZ("baz") {
-          override fun toString(): String {
-            return "baz1"
+
+        BAZ {
+          fun toString(): kotlin.String {
+            TODO("Stub!")
           }
-        }
+        };
       }
     """.trimIndent())
   }
@@ -477,13 +485,12 @@ class KmSpecsTest {
 
   @Test
   fun interfaces() {
-    val typeSpec = SomeInterface::class.toTypeSpec()
+    val typeSpec = SomeInterface::class.toTypeSpecWithReflectiveHandler()
 
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       interface SomeInterface : com.squareup.kotlinpoet.KmSpecsTest.SomeInterfaceBase {
-        fun testFunction() {
-        }
+        fun testFunction()
       }
     """.trimIndent())
   }
@@ -497,7 +504,7 @@ class KmSpecsTest {
 
   @Test
   fun backwardReferencingTypeVars() {
-    val typeSpec = BackwardReferencingTypeVars::class.toTypeSpec()
+    val typeSpec = BackwardReferencingTypeVars::class.toTypeSpecWithReflectiveHandler()
 
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
@@ -509,7 +516,7 @@ class KmSpecsTest {
 
   @Test
   fun taggedTypes() {
-    val typeSpec = TaggedTypes::class.toTypeSpec()
+    val typeSpec = TaggedTypes::class.toTypeSpecWithReflectiveHandler()
     assertThat(typeSpec.tag<ImmutableKmClass>()).isNotNull()
 
     val constructorSpec = typeSpec.primaryConstructor ?: fail("No constructor found!")
@@ -536,7 +543,341 @@ class KmSpecsTest {
     }
   }
 
-  // TODO Complex companion objects (implementing interfaces)
+  @Test
+  fun annotations() {
+    val typeSpec = MyAnnotation::class.toTypeSpecWithReflectiveHandler()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      annotation class MyAnnotation(
+        val value: kotlin.String
+      )
+    """.trimIndent())
+  }
+
+  annotation class MyAnnotation(val value: String)
+
+  @Test
+  fun functionTypeArgsSupersedeClass() {
+    val typeSpec = GenericClass::class.toTypeSpecWithReflectiveHandler()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class GenericClass<T> {
+        fun <T> functionAlsoWithT(param: T) {
+        }
+
+        fun <R> functionWithADifferentType(param: R) {
+        }
+
+        fun functionWithT(param: T) {
+        }
+      }
+    """.trimIndent())
+
+    val func1TypeVar = typeSpec.funSpecs.find { it.name == "functionAlsoWithT" }!!.typeVariables.first()
+    val classTypeVar = typeSpec.typeVariables.first()
+
+    assertThat(func1TypeVar).isNotSameInstanceAs(classTypeVar)
+  }
+
+  class GenericClass<T> {
+    fun functionWithT(param: T) {
+    }
+    fun <T> functionAlsoWithT(param: T) {
+    }
+    fun <R> functionWithADifferentType(param: R) {
+    }
+  }
+
+  @Test
+  fun complexCompanionObject() {
+    val typeSpec = ComplexCompanionObject::class.toTypeSpecWithReflectiveHandler()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class ComplexCompanionObject {
+        companion object ComplexObject : com.squareup.kotlinpoet.KmSpecsTest.CompanionBase(), com.squareup.kotlinpoet.KmSpecsTest.CompanionInterface
+      }
+    """.trimIndent())
+  }
+
+  interface CompanionInterface
+  open class CompanionBase
+
+  class ComplexCompanionObject {
+    companion object ComplexObject : CompanionBase(), CompanionInterface
+  }
+
+  @Test
+  fun annotationsAreCopied() {
+    val typeSpec = AnnotationHolders::class.toTypeSpecWithReflectiveHandler()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class AnnotationHolders @com.squareup.kotlinpoet.KmSpecsTest.ConstructorAnnotation constructor() {
+        @field:com.squareup.kotlinpoet.KmSpecsTest.FieldAnnotation
+        var field: kotlin.String? = null
+
+        @get:com.squareup.kotlinpoet.KmSpecsTest.GetterAnnotation
+        var getter: kotlin.String? = null
+          get() {
+            TODO("Stub!")
+          }
+
+        @com.squareup.kotlinpoet.KmSpecsTest.HolderAnnotation
+        var holder: kotlin.String? = null
+
+        @set:com.squareup.kotlinpoet.KmSpecsTest.SetterAnnotation
+        var setter: kotlin.String? = null
+          set
+        @com.squareup.kotlinpoet.KmSpecsTest.ConstructorAnnotation
+        constructor(value: kotlin.String)
+
+        @com.squareup.kotlinpoet.KmSpecsTest.FunctionAnnotation
+        fun function() {
+        }
+      }
+    """.trimIndent())
+  }
+
+  class AnnotationHolders @ConstructorAnnotation constructor() {
+
+    @ConstructorAnnotation constructor(value: String) : this()
+
+    @field:FieldAnnotation var field: String? = null
+    @get:GetterAnnotation var getter: String? = null
+    @set:SetterAnnotation var setter: String? = null
+    @HolderAnnotation @JvmField var holder: String? = null
+    @FunctionAnnotation fun function() {
+    }
+  }
+
+  @Retention(RUNTIME)
+  annotation class ConstructorAnnotation
+
+  @Retention(RUNTIME)
+  annotation class FieldAnnotation
+
+  @Retention(RUNTIME)
+  annotation class GetterAnnotation
+
+  @Retention(RUNTIME)
+  annotation class SetterAnnotation
+
+  @Retention(RUNTIME)
+  annotation class HolderAnnotation
+
+  @Retention(RUNTIME)
+  annotation class FunctionAnnotation
+
+  @Test
+  fun constantValues() {
+    val typeSpec = Constants::class.toTypeSpecWithReflectiveHandler()
+
+    // TODO: Regular properties are not resolved with reflection, but should be accessible via
+    //  elements-based API
+
+    // Note: formats like hex/binary/underscore are not available as formatted at runtime
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class Constants(
+        val param: kotlin.String = TODO("Stub!")
+      ) {
+        val binaryProp: kotlin.Int = TODO("Stub!")
+
+        val boolProp: kotlin.Boolean = TODO("Stub!")
+
+        val doubleProp: kotlin.Double = TODO("Stub!")
+
+        val floatProp: kotlin.Float = TODO("Stub!")
+
+        val hexProp: kotlin.Int = TODO("Stub!")
+
+        val intProp: kotlin.Int = TODO("Stub!")
+
+        val longProp: kotlin.Long = TODO("Stub!")
+
+        val stringProp: kotlin.String = TODO("Stub!")
+
+        val underscoresHexProp: kotlin.Long = TODO("Stub!")
+
+        val underscoresProp: kotlin.Int = TODO("Stub!")
+
+        companion object {
+          const val CONST_BINARY_PROP: kotlin.Int = 11
+
+          const val CONST_BOOL_PROP: kotlin.Boolean = false
+
+          const val CONST_DOUBLE_PROP: kotlin.Double = 1.0
+
+          const val CONST_FLOAT_PROP: kotlin.Float = 1.0F
+
+          const val CONST_HEX_PROP: kotlin.Int = 15
+
+          const val CONST_INT_PROP: kotlin.Int = 1
+
+          const val CONST_LONG_PROP: kotlin.Long = 1L
+
+          const val CONST_STRING_PROP: kotlin.String = "prop"
+
+          const val CONST_UNDERSCORES_HEX_PROP: kotlin.Long = 4293713502L
+
+          const val CONST_UNDERSCORES_PROP: kotlin.Int = 1000000
+
+          @kotlin.jvm.JvmStatic
+          val STATIC_CONST_BINARY_PROP: kotlin.Int = 11
+
+          @kotlin.jvm.JvmStatic
+          val STATIC_CONST_BOOL_PROP: kotlin.Boolean = false
+
+          @kotlin.jvm.JvmStatic
+          val STATIC_CONST_DOUBLE_PROP: kotlin.Double = 1.0
+
+          @kotlin.jvm.JvmStatic
+          val STATIC_CONST_FLOAT_PROP: kotlin.Float = 1.0F
+
+          @kotlin.jvm.JvmStatic
+          val STATIC_CONST_HEX_PROP: kotlin.Int = 15
+
+          @kotlin.jvm.JvmStatic
+          val STATIC_CONST_INT_PROP: kotlin.Int = 1
+
+          @kotlin.jvm.JvmStatic
+          val STATIC_CONST_LONG_PROP: kotlin.Long = 1L
+
+          @kotlin.jvm.JvmStatic
+          val STATIC_CONST_STRING_PROP: kotlin.String = "prop"
+
+          @kotlin.jvm.JvmStatic
+          val STATIC_CONST_UNDERSCORES_HEX_PROP: kotlin.Long = 4293713502L
+
+          @kotlin.jvm.JvmStatic
+          val STATIC_CONST_UNDERSCORES_PROP: kotlin.Int = 1000000
+        }
+      }
+    """.trimIndent())
+
+    // TODO check with objects
+  }
+
+  class Constants(
+    val param: String = "param"
+  ) {
+    val boolProp = false
+    val binaryProp = 0b00001011
+    val intProp = 1
+    val underscoresProp = 1_000_000
+    val hexProp = 0x0F
+    val underscoresHexProp = 0xFF_EC_DE_5E
+    val longProp = 1L
+    val floatProp = 1.0F
+    val doubleProp = 1.0
+    val stringProp = "prop"
+
+    companion object {
+      @JvmStatic val STATIC_CONST_BOOL_PROP = false
+      @JvmStatic val STATIC_CONST_BINARY_PROP = 0b00001011
+      @JvmStatic val STATIC_CONST_INT_PROP = 1
+      @JvmStatic val STATIC_CONST_UNDERSCORES_PROP = 1_000_000
+      @JvmStatic val STATIC_CONST_HEX_PROP = 0x0F
+      @JvmStatic val STATIC_CONST_UNDERSCORES_HEX_PROP = 0xFF_EC_DE_5E
+      @JvmStatic val STATIC_CONST_LONG_PROP = 1L
+      @JvmStatic val STATIC_CONST_FLOAT_PROP = 1.0f
+      @JvmStatic val STATIC_CONST_DOUBLE_PROP = 1.0
+      @JvmStatic val STATIC_CONST_STRING_PROP = "prop"
+
+      const val CONST_BOOL_PROP = false
+      const val CONST_BINARY_PROP = 0b00001011
+      const val CONST_INT_PROP = 1
+      const val CONST_UNDERSCORES_PROP = 1_000_000
+      const val CONST_HEX_PROP = 0x0F
+      const val CONST_UNDERSCORES_HEX_PROP = 0xFF_EC_DE_5E
+      const val CONST_LONG_PROP = 1L
+      const val CONST_FLOAT_PROP = 1.0f
+      const val CONST_DOUBLE_PROP = 1.0
+      const val CONST_STRING_PROP = "prop"
+    }
+  }
+
+  @Test
+  fun jvmAnnotations() {
+    val typeSpec = JvmAnnotations::class.toTypeSpecWithReflectiveHandler()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class JvmAnnotations {
+        @get:kotlin.jvm.Synchronized
+        val synchronizedGetProp: kotlin.String? = null
+          get() {
+            TODO("Stub!")
+          }
+
+        @set:kotlin.jvm.Synchronized
+        var synchronizedSetProp: kotlin.String? = null
+          set
+        @kotlin.jvm.Transient
+        val transientProp: kotlin.String? = null
+
+        @kotlin.jvm.Volatile
+        var volatileProp: kotlin.String? = null
+
+        @kotlin.jvm.Synchronized
+        fun synchronizedFun() {
+        }
+      }
+    """.trimIndent())
+
+    val interfaceSpec = JvmAnnotationsInterface::class.toTypeSpecWithReflectiveHandler()
+
+    //language=kotlin
+    assertThat(interfaceSpec.trimmedToString()).isEqualTo("""
+      interface JvmAnnotationsInterface {
+        @kotlin.jvm.JvmDefault
+        fun defaultMethod() {
+        }
+
+        fun notDefaultMethod()
+      }
+    """.trimIndent())
+  }
+
+  class JvmAnnotations {
+    @Transient val transientProp: String? = null
+    @Volatile var volatileProp: String? = null
+    @get:Synchronized val synchronizedGetProp: String? = null
+    @set:Synchronized var synchronizedSetProp: String? = null
+
+    @Synchronized
+    fun synchronizedFun() {
+    }
+  }
+
+  interface JvmAnnotationsInterface {
+    @JvmDefault
+    fun defaultMethod() {
+    }
+    fun notDefaultMethod()
+  }
+
+  @Test
+  fun nestedClasses() {
+    val typeSpec = NestedClasses::class.toTypeSpecWithReflectiveHandler()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class NestedClasses {
+        abstract class NestedClass<T> : kotlin.collections.List<T>
+
+        inner class NestedInnerClass
+      }
+    """.trimIndent())
+  }
+
+  class NestedClasses {
+    abstract class NestedClass<T> : List<T>
+    inner class NestedInnerClass
+  }
 }
 
 private fun TypeSpec.trimmedToString(): String {

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KmSpecsTest.kt
@@ -544,19 +544,19 @@ class KmSpecsTest(
         val value: kotlin.String
       ) {
         FOO {
-          fun toString(): kotlin.String {
+          override fun toString(): kotlin.String {
             TODO("Stub!")
           }
         },
 
         BAR {
-          fun toString(): kotlin.String {
+          override fun toString(): kotlin.String {
             TODO("Stub!")
           }
         },
 
         BAZ {
-          fun toString(): kotlin.String {
+          override fun toString(): kotlin.String {
             TODO("Stub!")
           }
         };


### PR DESCRIPTION
- Functions now correctly report type arguments
- Safer handling of enums with class bodies
- Transient/volatile/synchronized support
- New `ElementHandler` API for retrieving information about related elements
  - Full companion object support
  - Full enum entry class body support
  - Full annotations support
  - Full constant value literals support
  - Full nested classes support
  - Some override support
  - Heavily caches lookups
- Fixed interface generation
  - Don't generate bodies unless it's JvmDefault or has body in source
    - This involved adding a `CodeBlock.Builder#clear()` function, which I think is a useful addition.
  - Don't extend from `Any`
  - Resolve which supertypes are actually interfaces via `ElementHandler`

Talked with @Egorand offline and we'll plan to do an in-person CR of this since it's unfortunately all a bit stuck together and interwoven