### PR TITLE
Ensure trailing newlines in kdocs and functions

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -332,7 +332,7 @@ internal class CodeWriter constructor(
         }
       }
     }
-    if (ensureTrailingNewline && out.lastChar != '\n') {
+    if (ensureTrailingNewline && out.hasPendingSegments) {
       emit("\n")
     }
   }

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -134,7 +134,7 @@ internal class CodeWriter constructor(
     emit("/**\n")
     kdoc = true
     try {
-      emitCode(kdocCodeBlock)
+      emitCode(kdocCodeBlock, ensureTrailingNewline = true)
     } finally {
       kdoc = false
     }
@@ -213,7 +213,11 @@ internal class CodeWriter constructor(
 
   fun emitCode(format: String, vararg args: Any?) = emitCode(CodeBlock.of(format, *args))
 
-  fun emitCode(codeBlock: CodeBlock, isConstantContext: Boolean = false) = apply {
+  fun emitCode(
+    codeBlock: CodeBlock,
+    isConstantContext: Boolean = false,
+    ensureTrailingNewline: Boolean = false
+  ) = apply {
     var a = 0
     var deferredTypeName: ClassName? = null // used by "import static" logic
     val partIterator = codeBlock.formatParts.listIterator()
@@ -327,6 +331,9 @@ internal class CodeWriter constructor(
           }
         }
       }
+    }
+    if (ensureTrailingNewline && out.lastChar != '\n') {
+      emit("\n")
     }
   }
 

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -104,7 +104,7 @@ class FunSpec private constructor(
     } else if (!isEmptySetter) {
       codeWriter.emitCode("·{\n")
       codeWriter.indent()
-      codeWriter.emitCode(body)
+      codeWriter.emitCode(body, ensureTrailingNewline = true)
       codeWriter.unindent()
       codeWriter.emit("}\n")
     }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -715,4 +715,58 @@ class FunSpecTest {
       |}
       |""".trimMargin())
   }
+
+  @Test fun ensureTrailingNewline() {
+    val methodSpec = FunSpec.builder("function")
+        .addCode("codeWithNoNewline()")
+        .build()
+
+    assertThat(methodSpec.toString()).isEqualTo("""
+      |fun function() {
+      |  codeWithNoNewline()
+      |}
+      |""".trimMargin())
+  }
+
+  /** Ensures that we don't add a duplicate newline if one is already present.  */
+  @Test fun ensureTrailingNewlineWithExistingNewline() {
+    val methodSpec = FunSpec.builder("function")
+        .addCode("codeWithNoNewline()\n") // Have a newline already, so ensure we're not adding one
+        .build()
+
+    assertThat(methodSpec.toString()).isEqualTo("""
+      |fun function() {
+      |  codeWithNoNewline()
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun ensureKdocTrailingNewline() {
+    val methodSpec = FunSpec.builder("function")
+        .addKdoc("This is a comment with no initial newline")
+        .build()
+
+    assertThat(methodSpec.toString()).isEqualTo("""
+      |/**
+      | * This is a comment with no initial newline
+      | */
+      |fun function() {
+      |}
+      |""".trimMargin())
+  }
+
+  /** Ensures that we don't add a duplicate newline if one is already present.  */
+  @Test fun ensureKdocTrailingNewlineWithExistingNewline() {
+    val methodSpec = FunSpec.builder("function")
+        .addKdoc("This is a comment with an initial newline\n")
+        .build()
+
+    assertThat(methodSpec.toString()).isEqualTo("""
+      |/**
+      | * This is a comment with an initial newline
+      | */
+      |fun function() {
+      |}
+      |""".trimMargin())
+  }
 }


### PR DESCRIPTION
Analogous to https://github.com/square/javapoet/pull/732

There appears to be some existing logic for this for kdocs, but I couldn't really grok how it was intended to work just from reading the code alone. Suggestions welcome and happy to merge them if possible