### PR TITLE
Followup fixes for #741 comments

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/JvmDescriptorUtils.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/JvmDescriptorUtils.kt
@@ -53,7 +53,7 @@ internal val Element.internalName: String
           enclosingElement.internalName + "$" + simpleName
         NestingKind.LOCAL, NestingKind.ANONYMOUS ->
           error("Unsupported nesting $nestingKind")
-        else ->
+        null ->
           error("Unsupported, nestingKind == null")
       }
     }

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/JvmDescriptorUtils.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/JvmDescriptorUtils.kt
@@ -60,6 +60,7 @@ internal val Element.internalName: String
     is QualifiedNameable -> qualifiedName.toString().replace('.', '/')
     else -> simpleName.toString()
   }
+
 /**
  * @return the "field descriptor" of this type.
  * @see [JvmDescriptorTypeVisitor]


### PR DESCRIPTION
Note that JvmStatic isn't covered here yet because it's an interface and requires jvm target 1.8, but when they're moved to separate artifacts as extension functions it won't really matter