### PR TITLE
Support `@JvmName` annotations in metadata parsing

### DIFF
--- a/km-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/km/specs/test/KmSpecsTest.kt
+++ b/km-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/km/specs/test/KmSpecsTest.kt
@@ -1103,7 +1103,7 @@ class KmSpecsTest(
           get() {
             TODO("Stub!")
           }
-      
+
         @get:kotlin.jvm.JvmName(name = "jvmPropertyGetAndSet")
         @set:kotlin.jvm.JvmName(name = "jvmPropertyGetAndSet")
         var propertyGetAndSet: kotlin.String? = null
@@ -1137,7 +1137,6 @@ class KmSpecsTest(
 
     @JvmName("jvmFunction")
     fun function() {
-
     }
   }
 }

--- a/km-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/km/specs/test/KmSpecsTest.kt
+++ b/km-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/km/specs/test/KmSpecsTest.kt
@@ -1117,6 +1117,18 @@ class KmSpecsTest(
         @kotlin.jvm.JvmName(name = "jvmFunction")
         fun function() {
         }
+
+        interface InterfaceWithJvmName {
+          companion object {
+            @kotlin.jvm.JvmStatic
+            val FOO_BOOL: kotlin.Boolean = false
+
+            @kotlin.jvm.JvmStatic
+            @kotlin.jvm.JvmName(name = "jvmStaticFunction")
+            fun staticFunction() {
+            }
+          }
+        }
       }
     """.trimIndent())
   }
@@ -1137,6 +1149,22 @@ class KmSpecsTest(
 
     @JvmName("jvmFunction")
     fun function() {
+    }
+
+    // Interfaces can't have JvmName, but covering a potential edge case of having a companion
+    // object with JvmName elements. Also covers an edge case where constants have getters
+    interface InterfaceWithJvmName {
+      companion object {
+        @JvmStatic
+        @get:JvmName("fooBoolJvm")
+        val FOO_BOOL = false
+
+        @JvmName("jvmStaticFunction")
+        @JvmStatic
+        fun staticFunction() {
+
+        }
+      }
     }
   }
 }

--- a/km-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/km/specs/test/KmSpecsTest.kt
+++ b/km-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/km/specs/test/KmSpecsTest.kt
@@ -1162,7 +1162,6 @@ class KmSpecsTest(
         @JvmName("jvmStaticFunction")
         @JvmStatic
         fun staticFunction() {
-
         }
       }
     }

--- a/km-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/km/specs/test/KmSpecsTest.kt
+++ b/km-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/km/specs/test/KmSpecsTest.kt
@@ -1087,6 +1087,59 @@ class KmSpecsTest(
     abstract class NestedClass<T> : List<T>
     inner class NestedInnerClass
   }
+
+  @Test
+  fun jvmNames() {
+    val typeSpec = JvmNameData::class.toTypeSpecWithTestHandler()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class JvmNameData(
+        @get:kotlin.jvm.JvmName(name = "jvmParam")
+        val param: kotlin.String
+      ) {
+        @get:kotlin.jvm.JvmName(name = "jvmPropertyGet")
+        val propertyGet: kotlin.String? = null
+          get() {
+            TODO("Stub!")
+          }
+      
+        @get:kotlin.jvm.JvmName(name = "jvmPropertyGetAndSet")
+        @set:kotlin.jvm.JvmName(name = "jvmPropertyGetAndSet")
+        var propertyGetAndSet: kotlin.String? = null
+          get() {
+            TODO("Stub!")
+          }
+          set
+        @set:kotlin.jvm.JvmName(name = "jvmPropertySet")
+        var propertySet: kotlin.String? = null
+          set
+        @kotlin.jvm.JvmName(name = "jvmFunction")
+        fun function() {
+        }
+      }
+    """.trimIndent())
+  }
+
+  class JvmNameData(
+    @get:JvmName("jvmParam") val param: String
+  ) {
+
+    @get:JvmName("jvmPropertyGet")
+    val propertyGet: String? = null
+
+    @set:JvmName("jvmPropertySet")
+    var propertySet: String? = null
+
+    @set:JvmName("jvmPropertyGetAndSet")
+    @get:JvmName("jvmPropertyGetAndSet")
+    var propertyGetAndSet: String? = null
+
+    @JvmName("jvmFunction")
+    fun function() {
+
+    }
+  }
 }
 
 private fun TypeSpec.trimmedToString(): String {

--- a/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
+++ b/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
@@ -51,6 +51,8 @@ class ElementsElementHandler private constructor(
     }.nullableValue
   }
 
+  override val supportsNonRuntimeRetainedAnnotations: Boolean = true
+
   override fun classFor(jvmName: String): ImmutableKmClass {
     return lookupTypeElement(jvmName)?.toImmutableKmClass() ?: error(
         "No type element found for: $jvmName.")

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -39,6 +39,8 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
     }.nullableValue
   }
 
+  override val supportsNonRuntimeRetainedAnnotations: Boolean = false
+
   override fun classFor(jvmName: String): ImmutableKmClass {
     return lookupClass(jvmName)?.toImmutableKmClass() ?: error("No class found for: $jvmName.")
   }

--- a/kotlinpoet-km-specs/src/main/kotlin/com/squareup/kotlinpoet/km/specs/ElementHandler.kt
+++ b/kotlinpoet-km-specs/src/main/kotlin/com/squareup/kotlinpoet/km/specs/ElementHandler.kt
@@ -57,6 +57,13 @@ interface ElementHandler {
   }
 
   /**
+   * Indicates if this element handler supports [AnnotationRetention.RUNTIME]-retained annotations.
+   * This is used to indicate if manual inference of certain non-RUNTIME-retained annotations should
+   * be done, such as [JvmName].
+   */
+  val supportsNonRuntimeRetainedAnnotations: Boolean
+
+  /**
    * Looks up other classes, such as for nested members. Note that this class would always be
    * Kotlin, so Metadata can be relied on for this.
    *

--- a/kotlinpoet-km-specs/src/main/kotlin/com/squareup/kotlinpoet/km/specs/KmSpecs.kt
+++ b/kotlinpoet-km-specs/src/main/kotlin/com/squareup/kotlinpoet/km/specs/KmSpecs.kt
@@ -304,8 +304,12 @@ private fun ImmutableKmClass.toTypeSpec(
                   }
                   if (property.hasConstant) {
                     constant = if (isCompanionObject && parentName != null) {
-                      // Constants are relocated to the enclosing class!
-                      elementHandler.fieldConstant(parentName, fieldSignature)
+                      if (elementHandler.classFor(parentName).isInterface) {
+                        elementHandler.fieldConstant(jvmInternalName, fieldSignature)
+                      } else {
+                        // const properties are relocated to the enclosing class
+                        elementHandler.fieldConstant(parentName, fieldSignature)
+                      }
                     } else {
                       elementHandler.fieldConstant(jvmInternalName, fieldSignature)
                     }

--- a/kotlinpoet-km-specs/src/main/kotlin/com/squareup/kotlinpoet/km/specs/KmSpecs.kt
+++ b/kotlinpoet-km-specs/src/main/kotlin/com/squareup/kotlinpoet/km/specs/KmSpecs.kt
@@ -677,7 +677,7 @@ private fun JvmMethodSignature.jvmNameAnnotation(
     null
   } else {
     return AnnotationSpec.builder(JvmName::class)
-        .addMember("%S", name)
+        .addMember("name = %S", name)
         .useSiteTarget(useSiteTarget)
         .build()
   }

--- a/kotlinpoet-km-specs/src/main/kotlin/com/squareup/kotlinpoet/km/specs/KmSpecs.kt
+++ b/kotlinpoet-km-specs/src/main/kotlin/com/squareup/kotlinpoet/km/specs/KmSpecs.kt
@@ -669,17 +669,6 @@ private fun Set<PropertyAccessorFlag>.toKModifiersArray(): Array<KModifier> {
   }.toTypedArray()
 }
 
-private fun JvmFieldSignature.jvmNameAnnotation(metadataName: String): AnnotationSpec? {
-  return if (name == metadataName) {
-    null
-  } else {
-    return AnnotationSpec.builder(JvmName::class)
-        .addMember("%S", name)
-        .useSiteTarget(FIELD)
-        .build()
-  }
-}
-
 private fun JvmMethodSignature.jvmNameAnnotation(
   metadataName: String,
   useSiteTarget: UseSiteTarget? = null


### PR DESCRIPTION
This resolves #753 

Elements API supports it out of the box, for reflection we just compare simple names of methods. Note that `JvmFieldSignature` support (mentioned in the issue) isn't done here, because there's no support for `@JvmName` on fields (TIL)

This also catches a couple corner cases around `val` properties with constant initializers having getters, where to look up field signatures when the enclosing class is an interface