### PR TITLE
Make ImmutableKmClass.toTypeSpec/toFileSpec public

### DIFF
--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -161,6 +161,25 @@ fun TypeElement.toFileSpec(
     typeSpec = toTypeSpec(elementHandler)
 )
 
+/** @return a [TypeSpec] ABI representation of this [ImmutableKmClass]. */
+@KotlinPoetMetadataPreview
+fun ImmutableKmClass.toTypeSpec(
+    elementHandler: ElementHandler?
+): TypeSpec {
+  return toTypeSpec(elementHandler, null)
+}
+
+/** @return a [FileSpec] ABI representation of this [ImmutableKmClass]. */
+@KotlinPoetMetadataPreview
+fun ImmutableKmClass.toFileSpec(
+    elementHandler: ElementHandler?
+): FileSpec {
+  return FileSpec.get(
+      packageName = name.jvmInternalName.substringBeforeLast("/"),
+      typeSpec = toTypeSpec(elementHandler)
+  )
+}
+
 private const val TODO_BLOCK = "TODO(\"Stub!\")"
 
 @KotlinPoetMetadataPreview
@@ -181,7 +200,7 @@ private fun List<ImmutableKmTypeParameter>.toTypeParamsResolver(
 @KotlinPoetMetadataPreview
 private fun ImmutableKmClass.toTypeSpec(
   elementHandler: ElementHandler?,
-  parentName: String? = null
+  parentName: String?
 ): TypeSpec {
   val classTypeParamsResolver = typeParameters.toTypeParamsResolver()
 

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -164,7 +164,7 @@ fun TypeElement.toFileSpec(
 /** @return a [TypeSpec] ABI representation of this [ImmutableKmClass]. */
 @KotlinPoetMetadataPreview
 fun ImmutableKmClass.toTypeSpec(
-    elementHandler: ElementHandler?
+  elementHandler: ElementHandler?
 ): TypeSpec {
   return toTypeSpec(elementHandler, null)
 }
@@ -172,7 +172,7 @@ fun ImmutableKmClass.toTypeSpec(
 /** @return a [FileSpec] ABI representation of this [ImmutableKmClass]. */
 @KotlinPoetMetadataPreview
 fun ImmutableKmClass.toFileSpec(
-    elementHandler: ElementHandler?
+  elementHandler: ElementHandler?
 ): FileSpec {
   return FileSpec.get(
       packageName = name.jvmInternalName.substringBeforeLast("/"),


### PR DESCRIPTION
It can be useful to read off some parts of metadata before committing to generating the spec representation