### PR TITLE
Add taggable typeparameter to TypeVariableName tags

### DIFF
--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -25,6 +25,7 @@ import com.squareup.kotlinpoet.metadata.ImmutableKmClass
 import com.squareup.kotlinpoet.metadata.ImmutableKmConstructor
 import com.squareup.kotlinpoet.metadata.ImmutableKmFunction
 import com.squareup.kotlinpoet.metadata.ImmutableKmProperty
+import com.squareup.kotlinpoet.metadata.ImmutableKmTypeParameter
 import com.squareup.kotlinpoet.metadata.ImmutableKmValueParameter
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 import com.squareup.kotlinpoet.metadata.specs.ElementHandler
@@ -632,9 +633,8 @@ class KotlinPoetMetadataSpecsTest(
     val parameterSpec = constructorSpec.parameters[0]
     assertThat(parameterSpec.tag<ImmutableKmValueParameter>()).isNotNull()
 
-    // TODO taggable TypeNames
-//    val typeVar = typeSpec.typeVariables[0]
-//    assertThat(typeVar.tag<ImmutableKmTypeParameter>()).isNotNull()
+    val typeVar = typeSpec.typeVariables[0]
+    assertThat(typeVar.tag<ImmutableKmTypeParameter>()).isNotNull()
 
     val funSpec = typeSpec.funSpecs[0]
     assertThat(funSpec.tag<ImmutableKmFunction>()).isNotNull()

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KmTypes.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KmTypes.kt
@@ -160,18 +160,11 @@ internal fun ImmutableKmTypeParameter.toTypeVariableName(
       it
     }
   }
-  val typeVariableName = if (upperBounds.isEmpty()) {
-    TypeVariableName(
-        name = name,
-        variance = finalVariance
-    )
-  } else {
-    TypeVariableName(
-        name = name,
-        bounds = upperBounds.map { it.toTypeName(typeParamResolver) },
-        variance = finalVariance
-    )
-  }
+  val typeVariableName = TypeVariableName(
+      name = name,
+      bounds = upperBounds.map { it.toTypeName(typeParamResolver) },
+      variance = finalVariance
+  )
   return typeVariableName.copy(reified = isReified)
 }
 

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KmTypes.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KmTypes.kt
@@ -165,7 +165,10 @@ internal fun ImmutableKmTypeParameter.toTypeVariableName(
       bounds = upperBounds.map { it.toTypeName(typeParamResolver) },
       variance = finalVariance
   )
-  return typeVariableName.copy(reified = isReified)
+  return typeVariableName.copy(
+      reified = isReified,
+      tags = mapOf(ImmutableKmTypeParameter::class to this)
+  )
 }
 
 @KotlinPoetMetadataPreview

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -743,7 +743,7 @@ class TypeVariableName private constructor(
     tags: Map<KClass<*>, Any> = this.tagMap.tags
   ): TypeVariableName {
     return TypeVariableName(name, bounds.withoutImplicitBound(), variance, reified, nullable,
-        annotations)
+        annotations, tags)
   }
 
   private fun List<TypeName>.withoutImplicitBound(): List<TypeName> {

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -807,17 +807,17 @@ class TypeVariableName private constructor(
     /** Returns type variable named `name` with `variance` and `bounds`.  */
     @JvmStatic @JvmName("get") @JvmOverloads
     operator fun invoke(name: String, bounds: List<TypeName>, variance: KModifier? = null) =
-        TypeVariableName.of(name, bounds, variance)
+        TypeVariableName.of(name, bounds.ifEmpty(::NULLABLE_ANY_LIST), variance)
 
     /** Returns type variable named `name` with `variance` and `bounds`.  */
     @JvmStatic @JvmName("getWithClasses") @JvmOverloads
     operator fun invoke(name: String, bounds: Iterable<KClass<*>>, variance: KModifier? = null) =
-        TypeVariableName.of(name, bounds.map { it.asTypeName() }, variance)
+        TypeVariableName.of(name, bounds.map { it.asTypeName() }.ifEmpty(::NULLABLE_ANY_LIST), variance)
 
     /** Returns type variable named `name` with `variance` and `bounds`.  */
     @JvmStatic @JvmName("getWithTypes") @JvmOverloads
     operator fun invoke(name: String, bounds: Iterable<Type>, variance: KModifier? = null) =
-        TypeVariableName.of(name, bounds.map { it.asTypeName() }, variance)
+        TypeVariableName.of(name, bounds.map { it.asTypeName() }.ifEmpty(::NULLABLE_ANY_LIST), variance)
 
     /**
      * Make a TypeVariableName for the given TypeMirror. This form is used internally to avoid


### PR DESCRIPTION
This actually revealed two issues that are fixed along the way:
- `tags` weren't copied in `TypeName#copy()`
- Not all of the `TypeVariableName` `invoke` functions had the empty checks