### PR TITLE
Add test and notes for `@JvmOverloads`

### DIFF
--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1152,6 +1152,47 @@ class KotlinPoetMetadataSpecsTest(
       }
     }
   }
+
+  @IgnoreForHandlerType(
+      reason = "JvmOverloads is not runtime retained and thus not visible to reflection.",
+      handlerType = REFLECTIVE
+  )
+  @Test
+  fun overloads() {
+    val typeSpec = Overloads::class.toTypeSpecWithTestHandler()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class Overloads @kotlin.jvm.JvmOverloads constructor(
+        val param1: kotlin.String,
+        val optionalParam2: kotlin.String = TODO("Stub!"),
+        val nullableParam3: kotlin.String? = TODO("Stub!")
+      ) {
+        @kotlin.jvm.JvmOverloads
+        fun testFunction(
+          param1: kotlin.String,
+          optionalParam2: kotlin.String = TODO("Stub!"),
+          nullableParam3: kotlin.String? = TODO("Stub!")
+        ) {
+        }
+      }
+    """.trimIndent())
+  }
+
+  class Overloads @JvmOverloads constructor(
+      val param1: String,
+      val optionalParam2: String = "",
+      val nullableParam3: String? = null
+  ) {
+    @JvmOverloads
+    fun testFunction(
+        param1: String,
+        optionalParam2: String = "",
+        nullableParam3: String? = null
+    ) {
+
+    }
+  }
 }
 
 private fun TypeSpec.trimmedToString(): String {

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1180,17 +1180,16 @@ class KotlinPoetMetadataSpecsTest(
   }
 
   class Overloads @JvmOverloads constructor(
-      val param1: String,
-      val optionalParam2: String = "",
-      val nullableParam3: String? = null
+    val param1: String,
+    val optionalParam2: String = "",
+    val nullableParam3: String? = null
   ) {
     @JvmOverloads
     fun testFunction(
-        param1: String,
-        optionalParam2: String = "",
-        nullableParam3: String? = null
+      param1: String,
+      optionalParam2: String = "",
+      nullableParam3: String? = null
     ) {
-
     }
   }
 }

--- a/kotlinpoet-metadata-specs/README.md
+++ b/kotlinpoet-metadata-specs/README.md
@@ -39,3 +39,4 @@ placeholders.
 
 - Only `KotlinClassMetadata.Class` supported for now. No support for `FileFacade`, `SyntheticClass`, `MultiFileClassFacade`, or `MultiFileClassPart`
 - `@file:` annotations are not supported yet.
+- `@JvmOverloads` annotations are only supported with `kotlinpoet-elemnethandler-reflective` and not reflection.


### PR DESCRIPTION
Thought of this today. Works as expected in elements, but not from reflection due to the annotation retention being only `BINARY`. Would need more work for reflection in the future, perhaps if we just use `kotlin-reflect` directly