### PR TITLE
Add support for inferring JvmField annotations

### DIFF
--- a/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
+++ b/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
@@ -99,14 +99,15 @@ class ElementsElementHandler private constructor(
 
   override fun fieldJvmModifiers(
     classJvmName: String,
-    fieldSignature: JvmFieldSignature
+    fieldSignature: JvmFieldSignature,
+    isJvmField: Boolean
   ): Set<JvmFieldModifier> {
     return lookupField(classJvmName, fieldSignature)?.modifiers?.let { modifiers ->
       modifiers.mapNotNullTo(mutableSetOf()) {
-        when (it) {
-          ElementsModifier.TRANSIENT -> TRANSIENT
-          ElementsModifier.VOLATILE -> VOLATILE
-          ElementsModifier.STATIC -> JvmFieldModifier.STATIC
+        when {
+          it == ElementsModifier.TRANSIENT -> TRANSIENT
+          it == ElementsModifier.VOLATILE -> VOLATILE
+          !isJvmField && it == ElementsModifier.STATIC -> JvmFieldModifier.STATIC
           else -> null
         }
       }

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -89,7 +89,8 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
 
   override fun fieldJvmModifiers(
     classJvmName: String,
-    fieldSignature: JvmFieldSignature
+    fieldSignature: JvmFieldSignature,
+    isJvmField: Boolean
   ): Set<JvmFieldModifier> {
     return lookupField(classJvmName, fieldSignature)?.modifiers.let { modifiers ->
       if (modifiers != null) {

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1192,6 +1192,78 @@ class KotlinPoetMetadataSpecsTest(
     ) {
     }
   }
+
+  @IgnoreForHandlerType(
+      reason = "Elements generates initializer values.",
+      handlerType = ELEMENTS
+  )
+  @Test
+  fun jvmFields_reflective() {
+    val typeSpec = Fields::class.toTypeSpecWithTestHandler()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class Fields(
+        @kotlin.jvm.JvmField
+        val param1: kotlin.String
+      ) {
+        @kotlin.jvm.JvmField
+        val fieldProp: kotlin.String = TODO("Stub!")
+
+        companion object {
+          @kotlin.jvm.JvmField
+          val companionProp: kotlin.String = ""
+
+          const val constCompanionProp: kotlin.String = ""
+
+          @kotlin.jvm.JvmStatic
+          val staticCompanionProp: kotlin.String = ""
+        }
+      }
+    """.trimIndent())
+  }
+
+  @IgnoreForHandlerType(
+      reason = "Elements generates initializer values.",
+      handlerType = REFLECTIVE
+  )
+  @Test
+  fun jvmFields_elements() {
+    val typeSpec = Fields::class.toTypeSpecWithTestHandler()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class Fields(
+        @field:kotlin.jvm.JvmField
+        val param1: kotlin.String
+      ) {
+        @field:kotlin.jvm.JvmField
+        val fieldProp: kotlin.String = ""
+
+        companion object {
+          @kotlin.jvm.JvmField
+          val companionProp: kotlin.String = ""
+
+          const val constCompanionProp: kotlin.String = ""
+
+          @kotlin.jvm.JvmStatic
+          val staticCompanionProp: kotlin.String = ""
+        }
+      }
+    """.trimIndent())
+  }
+
+  class Fields(
+    @JvmField val param1: String
+  ) {
+    @JvmField val fieldProp: String = ""
+
+    companion object {
+      @JvmField val companionProp: String = ""
+      @JvmStatic val staticCompanionProp: String = ""
+      const val constCompanionProp: String = ""
+    }
+  }
 }
 
 private fun TypeSpec.trimmedToString(): String {

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -734,6 +734,7 @@ class KotlinPoetMetadataSpecsTest(
         var getter: kotlin.String? = null
 
         @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.HolderAnnotation
+        @kotlin.jvm.JvmField
         var holder: kotlin.String? = null
 
         @set:com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.SetterAnnotation

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
@@ -88,9 +88,15 @@ interface ElementHandler {
    *
    * @param classJvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
    * @param fieldSignature The field to look up.
+   * @param isJvmField Indicates if this field is a JvmField, in which case it should not be marked
+   *                   as JvmStatic.
    * @return the set of found modifiers.
    */
-  fun fieldJvmModifiers(classJvmName: String, fieldSignature: JvmFieldSignature): Set<JvmFieldModifier>
+  fun fieldJvmModifiers(
+    classJvmName: String,
+    fieldSignature: JvmFieldSignature,
+    isJvmField: Boolean
+  ): Set<JvmFieldModifier>
 
   /**
    * Looks up the annotations on a given class field given its [JvmFieldSignature].


### PR DESCRIPTION
This _mostly_ Just Works in elements with the exception of the companion object case (commented inline), and adds support for inferring in reflection or other non-RUNTIME cases