### PR TITLE
Support detection of synthetic elements

### DIFF
--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -117,6 +117,10 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
         .filterOutNullabilityAnnotations()
   }
 
+  override fun isFieldSynthetic(classJvmName: String, fieldSignature: JvmFieldSignature): Boolean {
+    return lookupField(classJvmName, fieldSignature)?.isSynthetic ?: false
+  }
+
   override fun constructorAnnotations(
     classJvmName: String,
     constructorSignature: JvmMethodSignature
@@ -165,6 +169,13 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
     } catch (e: ClassNotFoundException) {
       emptyList()
     }
+  }
+
+  override fun isMethodSynthetic(
+    classJvmName: String,
+    methodSignature: JvmMethodSignature
+  ): Boolean {
+    return lookupMethod(classJvmName, methodSignature)?.isSynthetic ?: false
   }
 
   override fun enumEntry(enumClassJvmName: String, memberName: String): ImmutableKmClass? {

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1357,7 +1357,7 @@ class KotlinPoetMetadataSpecsTest(
   }
 
   class Fields(
-      @JvmField val param1: String
+    @JvmField val param1: String
   ) {
     @JvmField val fieldProp: String = ""
 

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1357,7 +1357,7 @@ class KotlinPoetMetadataSpecsTest(
   }
 
   class Fields(
-    @JvmField val param1: String
+      @JvmField val param1: String
   ) {
     @JvmField val fieldProp: String = ""
 
@@ -1365,6 +1365,171 @@ class KotlinPoetMetadataSpecsTest(
       @JvmField val companionProp: String = ""
       @JvmStatic val staticCompanionProp: String = ""
       const val constCompanionProp: String = ""
+    }
+  }
+
+  @IgnoreForHandlerType(
+      reason = "Synthetic constructs aren't available in elements, so some information like " +
+          "JvmStatic can't be deduced.",
+      handlerType = ELEMENTS
+  )
+  @Test
+  fun synthetics_reflective() {
+    val typeSpec = Synthetics::class.toTypeSpecWithTestHandler()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class Synthetics(
+        @get:kotlin.jvm.JvmSynthetic
+        val param: kotlin.String
+      ) {
+        @field:kotlin.jvm.JvmSynthetic
+        val fieldProperty: kotlin.String? = null
+
+        @field:kotlin.jvm.JvmSynthetic
+        val property: kotlin.String? = null
+
+        @get:kotlin.jvm.JvmSynthetic
+        val propertyGet: kotlin.String? = null
+
+        @get:kotlin.jvm.JvmSynthetic
+        @set:kotlin.jvm.JvmSynthetic
+        var propertyGetAndSet: kotlin.String? = null
+
+        @set:kotlin.jvm.JvmSynthetic
+        var propertySet: kotlin.String? = null
+
+        /**
+         * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
+         */
+        @kotlin.jvm.JvmSynthetic
+        fun function() {
+        }
+
+        interface InterfaceWithJvmName {
+          /**
+           * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
+           */
+          @kotlin.jvm.JvmSynthetic
+          fun interfaceFunction()
+
+          companion object {
+            @kotlin.jvm.JvmStatic
+            val FOO_BOOL: kotlin.Boolean = false
+
+            /**
+             * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
+             */
+            @kotlin.jvm.JvmSynthetic
+            @kotlin.jvm.JvmStatic
+            fun staticFunction() {
+            }
+          }
+        }
+      }
+    """.trimIndent())
+  }
+
+  @IgnoreForHandlerType(
+      reason = "Synthetic constructs aren't available in elements, so some information like " +
+          "JvmStatic can't be deduced.",
+      handlerType = REFLECTIVE
+  )
+  @Test
+  fun synthetics_elements() {
+    val typeSpec = Synthetics::class.toTypeSpecWithTestHandler()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class Synthetics(
+        @get:kotlin.jvm.JvmSynthetic
+        val param: kotlin.String
+      ) {
+        @field:kotlin.jvm.JvmSynthetic
+        val fieldProperty: kotlin.String? = null
+
+        @field:kotlin.jvm.JvmSynthetic
+        val property: kotlin.String? = null
+
+        @get:kotlin.jvm.JvmSynthetic
+        val propertyGet: kotlin.String? = null
+
+        @get:kotlin.jvm.JvmSynthetic
+        @set:kotlin.jvm.JvmSynthetic
+        var propertyGetAndSet: kotlin.String? = null
+
+        @set:kotlin.jvm.JvmSynthetic
+        var propertySet: kotlin.String? = null
+
+        /**
+         * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
+         */
+        @kotlin.jvm.JvmSynthetic
+        fun function() {
+        }
+
+        interface InterfaceWithJvmName {
+          /**
+           * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
+           */
+          @kotlin.jvm.JvmSynthetic
+          fun interfaceFunction()
+
+          companion object {
+            @kotlin.jvm.JvmStatic
+            val FOO_BOOL: kotlin.Boolean = false
+
+            /**
+             * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
+             */
+            @kotlin.jvm.JvmSynthetic
+            fun staticFunction() {
+            }
+          }
+        }
+      }
+    """.trimIndent())
+  }
+
+  class Synthetics(
+    @get:JvmSynthetic val param: String
+  ) {
+
+    @JvmSynthetic
+    val property: String? = null
+
+    @field:JvmSynthetic
+    val fieldProperty: String? = null
+
+    @get:JvmSynthetic
+    val propertyGet: String? = null
+
+    @set:JvmSynthetic
+    var propertySet: String? = null
+
+    @set:JvmSynthetic
+    @get:JvmSynthetic
+    var propertyGetAndSet: String? = null
+
+    @JvmSynthetic
+    fun function() {
+    }
+
+    // Interfaces can have JvmSynthetic, so covering a potential edge case of having a companion
+    // object with JvmSynthetic elements. Also covers an edge case where constants have getters
+    interface InterfaceWithJvmName {
+      @JvmSynthetic
+      fun interfaceFunction()
+      companion object {
+        @JvmStatic
+        @get:JvmSynthetic
+        val FOO_BOOL = false
+
+        @JvmSynthetic
+        @JvmStatic
+        fun staticFunction() {
+        }
+      }
     }
   }
 }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
@@ -108,6 +108,15 @@ interface ElementHandler {
   fun fieldAnnotations(classJvmName: String, fieldSignature: JvmFieldSignature): List<AnnotationSpec>
 
   /**
+   * Looks up a [JvmFieldSignature] and returns whether or not it is synthetic.
+   *
+   * @param classJvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param fieldSignature The field to look up.
+   * @return whether or not the field is synthetic.
+   */
+  fun isFieldSynthetic(classJvmName: String, fieldSignature: JvmFieldSignature): Boolean
+
+  /**
    * Looks up a given class method given its [JvmMethodSignature] and returns any [JvmMethodModifier]s
    * found on it.
    *
@@ -134,6 +143,15 @@ interface ElementHandler {
    * @return the [AnnotationSpec] representations of the annotations on the target method.
    */
   fun methodAnnotations(classJvmName: String, methodSignature: JvmMethodSignature): List<AnnotationSpec>
+
+  /**
+   * Looks up a [JvmMethodSignature] and returns whether or not it is synthetic.
+   *
+   * @param classJvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param methodSignature The method to look up.
+   * @return whether or not the method is synthetic.
+   */
+  fun isMethodSynthetic(classJvmName: String, methodSignature: JvmMethodSignature): Boolean
 
   /**
    * Looks up the enum entry on a given enum given its member name.

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -326,7 +326,7 @@ private fun ImmutableKmClass.toTypeSpec(
                     isJvmField = false
                   } else {
                     isJvmField = true
-                    annotations += AnnotationSpec.builder(JvmField::class).build()
+                    annotations += AnnotationSpec.builder(JVM_FIELD).build()
                   }
                 } else {
                   isJvmField = false
@@ -341,13 +341,13 @@ private fun ImmutableKmClass.toTypeSpec(
                     annotations += elementHandler.fieldJvmModifiers(parentName, fieldSignature, isJvmField)
                         .map { it.annotationSpec() }
                   }
-                  if (!(isCompanionObject &&
-                          (property.isConst || annotations.any { it.className == JVM_STATIC })) &&
+                  if (!(isCompanionObject && (property.isConst ||
+                          annotations.any { it.className == JVM_STATIC || it.className == JVM_FIELD })) &&
                       elementHandler.isFieldSynthetic(jvmInternalName, fieldSignature)) {
-                    // For static or const fields in a companion object, the companion object's
-                    // field is marked as synthetic to hide it from Java, but in this case it's a
-                    // false positive for this check in kotlin.
-                    annotations += AnnotationSpec.builder(JvmSynthetic::class)
+                    // For static, const, or JvmField fields in a companion object, the companion
+                    // object's field is marked as synthetic to hide it from Java, but in this case
+                    // it's a false positive for this check in kotlin.
+                    annotations += AnnotationSpec.builder(JVM_SYNTHETIC)
                         .useSiteTarget(UseSiteTarget.FIELD)
                         .build()
                   }
@@ -875,6 +875,8 @@ private inline fun <E> setOf(body: MutableSet<E>.() -> Unit): Set<E> {
 
 private val JVM_DEFAULT = JvmDefault::class.asClassName()
 private val JVM_STATIC = JvmStatic::class.asClassName()
+private val JVM_FIELD = JvmField::class.asClassName()
+private val JVM_SYNTHETIC = JvmSynthetic::class.asClassName()
 
 @PublishedApi
 internal val Element.packageName: String


### PR DESCRIPTION
This adds support to kotlin-metadata-specs for detecting and generating `@JvmSynthetic` constructs. This is a bit tricky, as it works fine in reflection but revealed an interesting limitation in elements where synthetic elements are not included in the elements API.

From the docs: https://docs.oracle.com/javase/8/docs/api/javax/lang/model/element/package-summary.html

> ...synthetic constructs in a class file, such as accessor methods used in implementing nested classes and bridge methods used in implementing covariant returns, are translation artifacts outside of this model.

As such, some aspects we read off of the bytecode directly like static, synchronized, etc are not available when using elements. We leave a comment in those cases now to indicate that this information may be missing.