### PR TITLE
Add support for detecting Kotlin default interface functions

### DIFF
--- a/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
+++ b/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
@@ -196,6 +196,10 @@ class ElementsElementHandler private constructor(
     return method.isOverriddenIn(typeElement)
   }
 
+  override fun methodExists(classJvmName: String, methodSignature: JvmMethodSignature): Boolean {
+    return lookupMethod(classJvmName, methodSignature, ElementFilter::methodsIn) != null
+  }
+
   /**
    * Detects whether [this] given method is overriden in [type].
    *

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -224,6 +224,10 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
         .any { it == signatureString }
   }
 
+  override fun methodExists(classJvmName: String, methodSignature: JvmMethodSignature): Boolean {
+    return lookupMethod(classJvmName, methodSignature) != null
+  }
+
   companion object {
     @JvmStatic
     @KotlinPoetMetadataPreview

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -292,7 +292,7 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
     private val Method.descriptor: String get() {
       return buildString {
         append('(')
-        parameterTypes.joinTo(this, transform = { it.descriptor })
+        parameterTypes.joinTo(this, separator = "", transform = { it.descriptor })
         append(')')
         append(returnType.descriptor)
       }
@@ -310,7 +310,7 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
     private val Constructor<*>.descriptor: String get() {
       return buildString {
         append('(')
-        parameterTypes.joinTo(this, transform = { it.descriptor })
+        parameterTypes.joinTo(this, separator = "", transform = { it.descriptor })
         append(')')
         append('V')
       }

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -225,7 +225,7 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
   }
 
   override fun methodExists(classJvmName: String, methodSignature: JvmMethodSignature): Boolean {
-    return lookupMethod(classJvmName, methodSignature) != null
+    return lookupClass(classJvmName)?.lookupMethod(methodSignature) != null
   }
 
   companion object {

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -592,20 +592,122 @@ class KotlinPoetMetadataSpecsTest(
 
   @Test
   fun interfaces() {
-    val typeSpec = SomeInterface::class.toTypeSpecWithTestHandler()
+    val testInterfaceSpec = TestInterface::class.toTypeSpecWithTestHandler()
 
     //language=kotlin
-    assertThat(typeSpec.trimmedToString()).isEqualTo("""
-      interface SomeInterface : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.SomeInterfaceBase {
-        fun testFunction()
+    assertThat(testInterfaceSpec.trimmedToString()).isEqualTo("""
+      interface TestInterface {
+        fun complex(input: kotlin.String, input2: kotlin.String = TODO("Stub!")): kotlin.String {
+          TODO("Stub!")
+        }
+      
+        fun hasDefault() {
+        }
+      
+        fun hasDefaultMultiParam(input: kotlin.String, input2: kotlin.String): kotlin.String {
+          TODO("Stub!")
+        }
+      
+        fun hasDefaultSingleParam(input: kotlin.String): kotlin.String {
+          TODO("Stub!")
+        }
+      
+        @kotlin.jvm.JvmDefault
+        fun hasJvmDefault() {
+        }
+      
+        fun noDefault()
+      
+        fun noDefaultWithInput(input: kotlin.String)
+      
+        fun noDefaultWithInputDefault(input: kotlin.String = TODO("Stub!"))
+      }
+    """.trimIndent())
+
+    val subInterfaceSpec = SubInterface::class.toTypeSpecWithTestHandler()
+
+    //language=kotlin
+    assertThat(subInterfaceSpec.trimmedToString()).isEqualTo("""
+      interface SubInterface : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TestInterface {
+        override fun hasDefault() {
+        }
+      
+        @kotlin.jvm.JvmDefault
+        override fun hasJvmDefault() {
+        }
+      
+        fun subInterfaceFunction() {
+        }
+      }
+    """.trimIndent())
+
+    val implSpec = TestSubInterfaceImpl::class.toTypeSpecWithTestHandler()
+
+    //language=kotlin
+    assertThat(implSpec.trimmedToString()).isEqualTo("""
+      class TestSubInterfaceImpl : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.SubInterface {
+        override fun noDefault() {
+        }
+      
+        override fun noDefaultWithInput(input: kotlin.String) {
+        }
+      
+        override fun noDefaultWithInputDefault(input: kotlin.String) {
+        }
       }
     """.trimIndent())
   }
 
-  interface SomeInterfaceBase
+  interface TestInterface {
 
-  interface SomeInterface : SomeInterfaceBase {
-    fun testFunction() {
+    fun noDefault()
+
+    fun noDefaultWithInput(input: String)
+
+    fun noDefaultWithInputDefault(input: String = "")
+
+    @JvmDefault
+    fun hasJvmDefault() {
+    }
+
+    fun hasDefault() {
+    }
+
+    fun hasDefaultSingleParam(input: String): String {
+      return "1234"
+    }
+
+    fun hasDefaultMultiParam(input: String, input2: String): String {
+      return "1234"
+    }
+
+    fun complex(input: String, input2: String = ""): String {
+      return "5678"
+    }
+  }
+
+  interface SubInterface : TestInterface {
+    fun subInterfaceFunction() {
+    }
+
+    @JvmDefault
+    override fun hasJvmDefault() {
+      super.hasJvmDefault()
+    }
+
+    override fun hasDefault() {
+      super.hasDefault()
+    }
+  }
+
+  class TestSubInterfaceImpl : SubInterface {
+    override fun noDefault() {
+    }
+
+    override fun noDefaultWithInput(input: String) {
+    }
+
+    override fun noDefaultWithInputDefault(input: String) {
     }
   }
 

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -600,26 +600,26 @@ class KotlinPoetMetadataSpecsTest(
         fun complex(input: kotlin.String, input2: kotlin.String = TODO("Stub!")): kotlin.String {
           TODO("Stub!")
         }
-      
+
         fun hasDefault() {
         }
-      
+
         fun hasDefaultMultiParam(input: kotlin.String, input2: kotlin.String): kotlin.String {
           TODO("Stub!")
         }
-      
+
         fun hasDefaultSingleParam(input: kotlin.String): kotlin.String {
           TODO("Stub!")
         }
-      
+
         @kotlin.jvm.JvmDefault
         fun hasJvmDefault() {
         }
-      
+
         fun noDefault()
-      
+
         fun noDefaultWithInput(input: kotlin.String)
-      
+
         fun noDefaultWithInputDefault(input: kotlin.String = TODO("Stub!"))
       }
     """.trimIndent())
@@ -631,11 +631,11 @@ class KotlinPoetMetadataSpecsTest(
       interface SubInterface : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TestInterface {
         override fun hasDefault() {
         }
-      
+
         @kotlin.jvm.JvmDefault
         override fun hasJvmDefault() {
         }
-      
+
         fun subInterfaceFunction() {
         }
       }
@@ -648,10 +648,10 @@ class KotlinPoetMetadataSpecsTest(
       class TestSubInterfaceImpl : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.SubInterface {
         override fun noDefault() {
         }
-      
+
         override fun noDefaultWithInput(input: kotlin.String) {
         }
-      
+
         override fun noDefaultWithInputDefault(input: kotlin.String) {
         }
       }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
@@ -159,4 +159,13 @@ interface ElementHandler {
    * @return whether or not the method is an override.
    */
   fun isMethodOverride(classJvmName: String, methodSignature: JvmMethodSignature): Boolean
+
+  /**
+   * Looks up if a given [methodSignature] within [classJvmName] exists.
+   *
+   * @param classJvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param methodSignature The method signature to check.
+   * @return whether or not the method exists.
+   */
+  fun methodExists(classJvmName: String, methodSignature: JvmMethodSignature): Boolean
 }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -469,10 +469,11 @@ private fun ImmutableKmClass.toTypeSpec(
               fun isKotlinDefaultInterfaceMethod(): Boolean {
                 elementHandler?.let { handler ->
                   func.signature?.let { signature ->
+                    val suffix = signature.desc.removePrefix("(")
                     return handler.methodExists(
                         "${jvmInternalName}\$DefaultImpls",
                         signature.copy(
-                            desc = "(L$jvmInternalName;" + signature.desc.removePrefix("(")
+                            desc = "(L$jvmInternalName;$suffix"
                     ))
                   }
                 }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -465,9 +465,23 @@ private fun ImmutableKmClass.toTypeSpec(
               }
             }
             func.toFunSpec(functionTypeParamsResolver, annotations, isOverride).let {
-              // For interface methods, remove any body and mark the methods as abstracte
-              // TODO kotlin interface methods _can_ be implemented. How do we detect that?
-              if (isInterface && annotations.none { it.className == JVM_DEFAULT }) {
+              // For interface methods, remove any body and mark the methods as abstract
+              fun isKotlinDefaultInterfaceMethod(): Boolean {
+                elementHandler?.let { handler ->
+                  func.signature?.let { signature ->
+                    return handler.methodExists(
+                        "${jvmInternalName}\$DefaultImpls",
+                        signature.copy(
+                            desc = "(L$jvmInternalName;" + signature.desc.removePrefix("(")
+                    ))
+                  }
+                }
+                return false
+              }
+              if (isInterface &&
+                  annotations.none { it.className == JVM_DEFAULT } &&
+                  !isKotlinDefaultInterfaceMethod()
+              ) {
                 it.toBuilder()
                     .addModifiers(ABSTRACT)
                     .clearBody()


### PR DESCRIPTION
This adds support for detecting interface functions in Kotlin that have default implementations. This probably merits a separate deep dive blogpost, but in short they way they are implement is a synthetic `DefaultImpls` class in the interface with static functions containing the default implementation. The rules are pretty simple:

- method name is the same
- parameters are the same
- the target interface instance is added as a parameter to the beginning of these parameters

So by looking for the existing of that `DefaultImpls` class + method with the modified signature, we can infer if there is a default implementation for Kotlin. There are slightly different rules for when default parameter arguments are in play, but these methods still exist in those cases too

In short:

```kotlin
interface Foo {
  fun bar(input: String) {
    println("I'm a " + this + " saying " + input)
  }
}
```

Becomes roughly this in bytecode:

```java
interface Foo {

  void bar();

  final class DefaultImpls {
    public static void bar(Foo instance, String input) {
      System.out.println("I'm a " + instance + " saying " + input);
    }
  }
}
```