### PR TITLE
Add support for Kotlin `@Throws` in metadata

### DIFF
--- a/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
+++ b/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
@@ -184,19 +184,14 @@ class ElementsElementHandler private constructor(
     classJvmName: String,
     methodSignature: JvmMethodSignature,
     isConstructor: Boolean
-  ): Set<TypeName>? {
+  ): Set<TypeName> {
     val elementFilter: (Iterable<Element>) -> List<ExecutableElement> = if (isConstructor) {
       ElementFilter::constructorsIn
     } else {
       ElementFilter::methodsIn
     }
     val exceptions = lookupMethod(classJvmName, methodSignature, elementFilter)?.thrownTypes
-    return if (exceptions.isNullOrEmpty()) {
-      // We have to check for empty because Kotlinc sometimes puts empty ones!
-      null
-    } else {
-      exceptions.mapTo(mutableSetOf()) { it.asTypeName() }
-    }
+    return exceptions.orEmpty().mapTo(mutableSetOf()) { it.asTypeName() }
   }
 
   override fun enumEntry(enumClassJvmName: String, memberName: String): ImmutableKmClass? {

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -2,6 +2,8 @@ package com.squareup.kotlinpoet.elementhandler.reflective
 
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.metadata.ImmutableKmClass
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 import com.squareup.kotlinpoet.metadata.specs.ElementHandler
@@ -176,6 +178,20 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
     methodSignature: JvmMethodSignature
   ): Boolean {
     return lookupMethod(classJvmName, methodSignature)?.isSynthetic ?: false
+  }
+
+  override fun methodExceptions(
+    classJvmName: String,
+    methodSignature: JvmMethodSignature,
+    isConstructor: Boolean
+  ): Set<TypeName>? {
+    val exceptions = lookupMethod(classJvmName, methodSignature)?.exceptionTypes
+    return if (exceptions.isNullOrEmpty()) {
+      // We have to check for empty because Kotlinc sometimes puts empty ones!
+      null
+    } else {
+      exceptions.mapTo(mutableSetOf()) { it.asTypeName() }
+    }
   }
 
   override fun enumEntry(enumClassJvmName: String, memberName: String): ImmutableKmClass? {

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -90,15 +90,15 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
   }
 
   private fun lookupConstructor(
-      classJvmName: String,
-      constructorSignature: JvmMethodSignature
+    classJvmName: String,
+    constructorSignature: JvmMethodSignature
   ): Constructor<*>? {
     val clazz = lookupClass(classJvmName) ?: error("No class found for: $classJvmName.")
     return clazz.lookupConstructor(constructorSignature)
   }
 
   private fun Class<*>.lookupConstructor(
-      constructorSignature: JvmMethodSignature
+    constructorSignature: JvmMethodSignature
   ): Constructor<*>? {
     val signatureString = constructorSignature.asString()
     return constructorCache.getOrPut(this to signatureString) {

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -197,18 +197,13 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
     classJvmName: String,
     methodSignature: JvmMethodSignature,
     isConstructor: Boolean
-  ): Set<TypeName>? {
+  ): Set<TypeName> {
     val exceptions = if (isConstructor) {
       lookupConstructor(classJvmName, methodSignature)?.exceptionTypes
     } else {
       lookupMethod(classJvmName, methodSignature)?.exceptionTypes
     }
-    return if (exceptions.isNullOrEmpty()) {
-      // We have to check for empty because Kotlinc sometimes puts empty ones!
-      null
-    } else {
-      exceptions.mapTo(mutableSetOf()) { it.asTypeName() }
-    }
+    return exceptions.orEmpty().mapTo(mutableSetOf()) { it.asTypeName() }
   }
 
   override fun enumEntry(enumClassJvmName: String, memberName: String): ImmutableKmClass? {

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1534,7 +1534,7 @@ class KotlinPoetMetadataSpecsTest(
 
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
-      class Throwing {
+      class Throwing @kotlin.jvm.Throws(exceptionClasses = [java.lang.IllegalStateException::class]) constructor() {
         @get:kotlin.jvm.Throws(exceptionClasses = [java.lang.IllegalStateException::class])
         @set:kotlin.jvm.Throws(exceptionClasses = [java.lang.IllegalStateException::class])
         var getterAndSetterThrows: kotlin.String? = null

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1312,13 +1312,10 @@ class KotlinPoetMetadataSpecsTest(
       ) {
         @kotlin.jvm.JvmField
         val fieldProp: kotlin.String = TODO("Stub!")
-
         companion object {
           @kotlin.jvm.JvmField
           val companionProp: kotlin.String = ""
-
           const val constCompanionProp: kotlin.String = ""
-
           @kotlin.jvm.JvmStatic
           val staticCompanionProp: kotlin.String = ""
         }
@@ -1342,13 +1339,10 @@ class KotlinPoetMetadataSpecsTest(
       ) {
         @field:kotlin.jvm.JvmField
         val fieldProp: kotlin.String = ""
-
         companion object {
           @kotlin.jvm.JvmField
           val companionProp: kotlin.String = ""
-
           const val constCompanionProp: kotlin.String = ""
-
           @kotlin.jvm.JvmStatic
           val staticCompanionProp: kotlin.String = ""
         }
@@ -1520,6 +1514,7 @@ class KotlinPoetMetadataSpecsTest(
     interface InterfaceWithJvmName {
       @JvmSynthetic
       fun interfaceFunction()
+
       companion object {
         @JvmStatic
         @get:JvmSynthetic
@@ -1530,6 +1525,47 @@ class KotlinPoetMetadataSpecsTest(
         fun staticFunction() {
         }
       }
+    }
+  }
+
+  @Test
+  fun throws() {
+    val typeSpec = Throwing::class.toTypeSpecWithTestHandler()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class Throwing {
+        @get:kotlin.jvm.Throws(exceptionClasses = [java.lang.IllegalStateException::class])
+        @set:kotlin.jvm.Throws(exceptionClasses = [java.lang.IllegalStateException::class])
+        var getterAndSetterThrows: kotlin.String? = null
+
+        @get:kotlin.jvm.Throws(exceptionClasses = [java.lang.IllegalStateException::class])
+        val getterThrows: kotlin.String? = null
+
+        @set:kotlin.jvm.Throws(exceptionClasses = [java.lang.IllegalStateException::class])
+        var setterThrows: kotlin.String? = null
+
+        @kotlin.jvm.Throws(exceptionClasses = [java.lang.IllegalStateException::class])
+        fun testFunction() {
+        }
+      }
+      """.trimIndent())
+  }
+
+  class Throwing @Throws(IllegalStateException::class) constructor() {
+
+    @get:Throws(IllegalStateException::class)
+    val getterThrows: String? = null
+
+    @set:Throws(IllegalStateException::class)
+    var setterThrows: String? = null
+
+    @get:Throws(IllegalStateException::class)
+    @set:Throws(IllegalStateException::class)
+    var getterAndSetterThrows: String? = null
+
+    @Throws(IllegalStateException::class)
+    fun testFunction() {
     }
   }
 }

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1312,10 +1312,13 @@ class KotlinPoetMetadataSpecsTest(
       ) {
         @kotlin.jvm.JvmField
         val fieldProp: kotlin.String = TODO("Stub!")
+
         companion object {
           @kotlin.jvm.JvmField
           val companionProp: kotlin.String = ""
+
           const val constCompanionProp: kotlin.String = ""
+
           @kotlin.jvm.JvmStatic
           val staticCompanionProp: kotlin.String = ""
         }
@@ -1339,10 +1342,13 @@ class KotlinPoetMetadataSpecsTest(
       ) {
         @field:kotlin.jvm.JvmField
         val fieldProp: kotlin.String = ""
+
         companion object {
           @kotlin.jvm.JvmField
           val companionProp: kotlin.String = ""
+
           const val constCompanionProp: kotlin.String = ""
+
           @kotlin.jvm.JvmStatic
           val staticCompanionProp: kotlin.String = ""
         }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
@@ -17,6 +17,7 @@ package com.squareup.kotlinpoet.metadata.specs
 
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.metadata.ImmutableKmClass
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
@@ -152,6 +153,21 @@ interface ElementHandler {
    * @return whether or not the method is synthetic.
    */
   fun isMethodSynthetic(classJvmName: String, methodSignature: JvmMethodSignature): Boolean
+
+  /**
+   * Looks up a given class method given its [JvmMethodSignature] and returns any thrown types
+   * found on it. Used for [Throws][@Throws]
+   *
+   * @param classJvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param methodSignature The method with annotations to look up.
+   * @param isConstructor Indicates if [methodSignature] is a constructor.
+   * @return the set of found thrown types, or null.
+   */
+  fun methodExceptions(
+    classJvmName: String,
+    methodSignature: JvmMethodSignature,
+    isConstructor: Boolean
+  ): Set<TypeName>?
 
   /**
    * Looks up the enum entry on a given enum given its member name.

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
@@ -161,13 +161,13 @@ interface ElementHandler {
    * @param classJvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
    * @param methodSignature The method with annotations to look up.
    * @param isConstructor Indicates if [methodSignature] is a constructor.
-   * @return the set of found thrown types, or null.
+   * @return the set of found thrown types, or empty.
    */
   fun methodExceptions(
     classJvmName: String,
     methodSignature: JvmMethodSignature,
     isConstructor: Boolean
-  ): Set<TypeName>?
+  ): Set<TypeName>
 
   /**
    * Looks up the enum entry on a given enum given its member name.

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -406,9 +406,11 @@ private fun ImmutableKmClass.toTypeSpec(
                         annotations += jvmNameAnnotation
                       }
                     }
-                    elementHandler.methodExceptions(jvmInternalName, getterSignature, false)?.let { exceptions ->
-                      annotations += createThrowsSpec(exceptions, UseSiteTarget.GET)
-                    }
+                    elementHandler.methodExceptions(jvmInternalName, getterSignature, false)
+                        .takeIf { it.isNotEmpty() }
+                        ?.let { exceptions ->
+                          annotations += createThrowsSpec(exceptions, UseSiteTarget.GET)
+                        }
                   }
                 }
                 if (property.hasSetter) {
@@ -450,9 +452,11 @@ private fun ImmutableKmClass.toTypeSpec(
                         annotations += jvmNameAnnotation
                       }
                     }
-                    elementHandler.methodExceptions(jvmInternalName, setterSignature, false)?.let { exceptions ->
-                      annotations += createThrowsSpec(exceptions, UseSiteTarget.SET)
-                    }
+                    elementHandler.methodExceptions(jvmInternalName, setterSignature, false)
+                        .takeIf { it.isNotEmpty() }
+                        ?.let { exceptions ->
+                          annotations += createThrowsSpec(exceptions, UseSiteTarget.SET)
+                        }
                   }
                 }
               }
@@ -510,9 +514,11 @@ private fun ImmutableKmClass.toTypeSpec(
                     annotations += jvmNameAnnotation
                   }
                 }
-                elementHandler.methodExceptions(jvmInternalName, signature, false)?.let { exceptions ->
-                  annotations += createThrowsSpec(exceptions)
-                }
+                elementHandler.methodExceptions(jvmInternalName, signature, false)
+                    .takeIf { it.isNotEmpty() }
+                    ?.let { exceptions ->
+                      annotations += createThrowsSpec(exceptions)
+                    }
               }
             }
             func.toFunSpec(functionTypeParamsResolver, annotations, isOverride)
@@ -585,9 +591,11 @@ private fun ImmutableKmConstructor.annotations(
       if (hasAnnotations) {
         annotations += elementHandler.constructorAnnotations(classJvmName, signature)
       }
-      elementHandler.methodExceptions(classJvmName, signature, true)?.let {
-        annotations += createThrowsSpec(it)
-      }
+      elementHandler.methodExceptions(classJvmName, signature, true)
+          .takeIf { it.isNotEmpty() }
+          ?.let {
+            annotations += createThrowsSpec(it)
+          }
       return annotations
     }
   }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -284,7 +284,7 @@ private fun ImmutableKmClass.toTypeSpec(
     }?.let {
       it.toFunSpec(classTypeParamsResolver, it.annotations(jvmInternalName, elementHandler))
           .also { spec ->
-            val finalSpec = if (isEnum) {
+            val finalSpec = if (isEnum && spec.annotations.isEmpty()) {
               // Metadata specifies the constructor as private, but that's implicit so we can omit it
               spec.toBuilder().apply { modifiers.remove(PRIVATE) }.build()
             } else spec


### PR DESCRIPTION
This adds support for detecting `@Throws` in metadata. Like some other jvm-specific things (certain modifiers, etc), these have to be inferred from the jvm code as the annotations are not present