### PR TITLE
Don't emit primary constructor parens with no keyword or params

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
@@ -183,9 +183,13 @@ class ParameterSpec private constructor(
 internal fun List<ParameterSpec>.emit(
   codeWriter: CodeWriter,
   forceNewLines: Boolean = false,
+  forceParensOnEmpty: Boolean = true,
   emitBlock: (ParameterSpec) -> Unit = { it.emit(codeWriter) }
 ) = with(codeWriter) {
-  emit("(")
+  val emitParens = isNotEmpty() || forceParensOnEmpty
+  if (emitParens) {
+    emit("(")
+  }
   if (size > 0) {
     val emitNewLines = size > 2 || forceNewLines
     if (emitNewLines) {
@@ -202,5 +206,7 @@ internal fun List<ParameterSpec>.emit(
       emit("\n")
     }
   }
-  emit(")")
+  if (emitParens) {
+    emit(")")
+  }
 }

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -165,7 +165,7 @@ class TypeSpec private constructor(
             codeWriter.emit("constructor")
           }
 
-          it.parameters.emit(codeWriter, forceNewLines = true) { param ->
+          it.parameters.emit(codeWriter, forceParensOnEmpty = useKeyword, forceNewLines = true) { param ->
             val property = constructorProperties[param.name]
             if (property != null) {
               property.emit(codeWriter, setOf(PUBLIC), withInitializer = false, inline = true,

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -740,7 +740,7 @@ class TypeSpecTest {
         |import kotlin.Comparable
         |import kotlin.Number
         |
-        |class Location<P, Q>() : Number(), Comparable where P : Number, P : Comparable, Q : Number, Q :
+        |class Location<P, Q> : Number(), Comparable where P : Number, P : Comparable, Q : Number, Q :
         |    Comparable {
         |  val x: P
         |
@@ -3342,7 +3342,7 @@ class TypeSpecTest {
         |import kotlin.Int
         |import kotlin.String
         |
-        |class StringToInteger() : Function<String, Int> by Function ({ text -> text.toIntOrNull() ?: 0 }),
+        |class StringToInteger : Function<String, Int> by Function ({ text -> text.toIntOrNull() ?: 0 }),
         |    Runnable by Runnable ({ java.util.logging.Logger.debug("Hello world") })
         |""".trimMargin()
 


### PR DESCRIPTION
Before, if you had a keyword-less primary constructor with no parameters, it would still emit the parentheses. This is legal in kotlin, but redundant