### PR TITLE
Fix class name splicing

### DIFF
--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1611,7 +1611,7 @@ class KotlinPoetMetadataSpecsTest(
       class ClassNesting {
         class NestedClass {
           class SuperNestedClass {
-            class SuperDuperNestedClass
+            inner class SuperDuperInnerClass
           }
         }
       }
@@ -1622,7 +1622,7 @@ class KotlinPoetMetadataSpecsTest(
 class ClassNesting {
   class NestedClass {
     class SuperNestedClass {
-      class SuperDuperNestedClass
+      inner class SuperDuperInnerClass
     }
   }
 }

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1574,6 +1574,33 @@ class KotlinPoetMetadataSpecsTest(
     fun testFunction() {
     }
   }
+
+  // The meta-ist of metadata meta-tests.
+  @Test
+  fun metaTest() {
+    val typeSpec = Metadata::class.toTypeSpecWithTestHandler()
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      annotation class Metadata(
+        @get:kotlin.jvm.JvmName(name = "k")
+        val kind: kotlin.Int = TODO("Stub!"),
+        @get:kotlin.jvm.JvmName(name = "mv")
+        val metadataVersion: kotlin.IntArray = TODO("Stub!"),
+        @get:kotlin.jvm.JvmName(name = "bv")
+        val bytecodeVersion: kotlin.IntArray = TODO("Stub!"),
+        @get:kotlin.jvm.JvmName(name = "d1")
+        val data1: kotlin.Array<kotlin.String> = TODO("Stub!"),
+        @get:kotlin.jvm.JvmName(name = "d2")
+        val data2: kotlin.Array<kotlin.String> = TODO("Stub!"),
+        @get:kotlin.jvm.JvmName(name = "xs")
+        val extraString: kotlin.String = TODO("Stub!"),
+        @get:kotlin.jvm.JvmName(name = "pn")
+        val packageName: kotlin.String = TODO("Stub!"),
+        @get:kotlin.jvm.JvmName(name = "xi")
+        val extraInt: kotlin.Int = TODO("Stub!")
+      )
+      """.trimIndent())
+  }
 }
 
 private fun TypeSpec.trimmedToString(): String {

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1601,6 +1601,30 @@ class KotlinPoetMetadataSpecsTest(
       )
       """.trimIndent())
   }
+
+  @Test
+  fun classNamesAndNesting() {
+    // Make sure we parse class names correctly at all levels
+    val typeSpec = ClassNesting::class.toTypeSpecWithTestHandler()
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class ClassNesting {
+        class NestedClass {
+          class SuperNestedClass {
+            class SuperDuperNestedClass
+          }
+        }
+      }
+      """.trimIndent())
+  }
+}
+
+class ClassNesting {
+  class NestedClass {
+    class SuperNestedClass {
+      class SuperDuperNestedClass
+    }
+  }
 }
 
 private fun TypeSpec.trimmedToString(): String {

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -208,10 +208,11 @@ private fun ImmutableKmClass.toTypeSpec(
 
   // package/of/class/MyClass.InnerClass
   // Sometimes it's package/of/class/MyClass$InnerClass
-  val simpleName = name
-      .substringAfterLast("/") // Drop the package name, e.g. "package/of/class/"
-      .substringAfterLast(".") // Drop any enclosing classes, e.g. "MyClass."
-      .substringAfterLast("$") // Drop any enclosing classes, e.g. "MyClass$"
+  val simpleName = name.substringAfterLast(charArrayOf(
+      '/', // Drop the package name, e.g. "package/of/class/"
+      '.', // Drop any enclosing classes, e.g. "MyClass."
+      '$'  // Drop any enclosing classes, e.g. "MyClass$"
+  ))
   val jvmInternalName = name.jvmInternalName
   val builder = when {
     isAnnotation -> TypeSpec.annotationBuilder(simpleName)
@@ -923,6 +924,11 @@ private fun createThrowsSpec(
       )
       .useSiteTarget(useSiteTarget)
       .build()
+}
+
+private fun String.substringAfterLast(delimiters: CharArray): String {
+  val index = lastIndexOfAny(delimiters)
+  return if (index == -1) this else substring(index + 1, length)
 }
 
 @PublishedApi

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -212,7 +212,7 @@ private fun ImmutableKmClass.toTypeSpec(
   val simpleName = name.substringAfterLast(
       '/', // Drop the package name, e.g. "package/of/class/"
       '.', // Drop any enclosing classes, e.g. "MyClass."
-      '$'  // Drop any enclosing classes, e.g. "MyClass$"
+      '$' // Drop any enclosing classes, e.g. "MyClass$"
   )
   val jvmInternalName = name.jvmInternalName
   val builder = when {

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -207,9 +207,11 @@ private fun ImmutableKmClass.toTypeSpec(
   val classTypeParamsResolver = typeParameters.toTypeParamsResolver()
 
   // package/of/class/MyClass.InnerClass
+  // Sometimes it's package/of/class/MyClass$InnerClass
   val simpleName = name
       .substringAfterLast("/") // Drop the package name, e.g. "package/of/class/"
-      .substringAfter(".") // Drop any enclosing classes, e.g. "MyClass."
+      .substringAfterLast(".") // Drop any enclosing classes, e.g. "MyClass."
+      .substringAfterLast("$") // Drop any enclosing classes, e.g. "MyClass$"
   val jvmInternalName = name.jvmInternalName
   val builder = when {
     isAnnotation -> TypeSpec.annotationBuilder(simpleName)

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -209,11 +209,11 @@ private fun ImmutableKmClass.toTypeSpec(
   // Top-level: package/of/class/MyClass
   // Nested A:  package/of/class/MyClass.InnerClass
   // Nested B:  package/of/class/MyClass$InnerClass
-  val simpleName = name.substringAfterLast(charArrayOf(
+  val simpleName = name.substringAfterLast(
       '/', // Drop the package name, e.g. "package/of/class/"
       '.', // Drop any enclosing classes, e.g. "MyClass."
       '$'  // Drop any enclosing classes, e.g. "MyClass$"
-  ))
+  )
   val jvmInternalName = name.jvmInternalName
   val builder = when {
     isAnnotation -> TypeSpec.annotationBuilder(simpleName)
@@ -927,7 +927,7 @@ private fun createThrowsSpec(
       .build()
 }
 
-private fun String.substringAfterLast(delimiters: CharArray): String {
+private fun String.substringAfterLast(vararg delimiters: Char): String {
   val index = lastIndexOfAny(delimiters)
   return if (index == -1) this else substring(index + 1, length)
 }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -206,8 +206,9 @@ private fun ImmutableKmClass.toTypeSpec(
 ): TypeSpec {
   val classTypeParamsResolver = typeParameters.toTypeParamsResolver()
 
-  // package/of/class/MyClass.InnerClass
-  // Sometimes it's package/of/class/MyClass$InnerClass
+  // Top-level: package/of/class/MyClass
+  // Nested A:  package/of/class/MyClass.InnerClass
+  // Nested B:  package/of/class/MyClass$InnerClass
   val simpleName = name.substringAfterLast(charArrayOf(
       '/', // Drop the package name, e.g. "package/of/class/"
       '.', // Drop any enclosing classes, e.g. "MyClass."

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -206,7 +206,10 @@ private fun ImmutableKmClass.toTypeSpec(
 ): TypeSpec {
   val classTypeParamsResolver = typeParameters.toTypeParamsResolver()
 
-  val simpleName = name.substringAfterLast(if (isInline) "/" else ".")
+  // package/of/class/MyClass.InnerClass
+  val simpleName = name
+      .substringAfterLast("/") // Drop the package name, e.g. "package/of/class/"
+      .substringAfter(".") // Drop any enclosing classes, e.g. "MyClass."
   val jvmInternalName = name.jvmInternalName
   val builder = when {
     isAnnotation -> TypeSpec.annotationBuilder(simpleName)


### PR DESCRIPTION
This is a bit of an oversight - before, every test was assuming that every class name in metadata followed this format:

`package/to/class.MyClass`

When in fact this was just coincidence due to all the test classes being nested classes. The actual format is:

`package/to/class/MyClass.Nested` or `package/to/class/MyClass$Nested`

This also made a red herring out of `inline` classes, which can _only_ be top level classes. Thus when that test was set up, it was presumed that the class naming scheme was special, and thus special-cased in the spec generation 😅 