### PR TITLE
Fix OUT declaration

### DIFF
--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KmTypes.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KmTypes.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.kotlinpoet.metadata.specs
 
-import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.LambdaTypeName
@@ -63,15 +62,7 @@ internal fun ImmutableKmTypeProjection.toTypeName(
   val typename = type?.toTypeName(typeParamResolver) ?: STAR
   return when (variance) {
     IN -> WildcardTypeName.consumerOf(typename)
-    OUT -> {
-      if (typename == ANY) {
-        // This becomes a *, which we actually don't want here.
-        // List<Any> works with List<*>, but List<*> doesn't work with List<Any>
-        typename
-      } else {
-        WildcardTypeName.producerOf(typename)
-      }
-    }
+    OUT -> WildcardTypeName.producerOf(typename)
     INVARIANT -> typename
     null -> STAR
   }


### PR DESCRIPTION
This is is a leftover from the moshi type converting logic, but not actually necessary anymore with Kotlinx-metadata