### PR TITLE
Parse parameter annotations in metadata

### DIFF
--- a/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
+++ b/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
@@ -171,6 +171,24 @@ class ElementsElementHandler private constructor(
         .filterOutNullabilityAnnotations()
   }
 
+  override fun parameterAnnotations(
+    classJvmName: String,
+    methodSignature: JvmMethodSignature,
+    index: Int,
+    isConstructor: Boolean
+  ): List<AnnotationSpec> {
+    val filter: (Iterable<Element>) -> List<ExecutableElement> = if (isConstructor) {
+      ElementFilter::constructorsIn
+    } else {
+      ElementFilter::methodsIn
+    }
+    return lookupMethod(classJvmName, methodSignature, filter)!!
+        .parameters[index]
+        .annotationMirrors
+        .map { AnnotationSpec.get(it) }
+        .filterOutNullabilityAnnotations()
+  }
+
   override fun isMethodSynthetic(
     classJvmName: String,
     methodSignature: JvmMethodSignature

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -200,7 +200,7 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
     return try {
       parameters[index]
           .declaredAnnotations
-          .map { AnnotationSpec.get(it, true) }
+          .map { AnnotationSpec.get(it, includeDefaultValues = true) }
           .filterOutNullabilityAnnotations()
     } catch (e: ClassNotFoundException) {
       emptyList()

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -186,6 +186,23 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
     }
   }
 
+  override fun parameterAnnotations(classJvmName: String, methodSignature: JvmMethodSignature,
+      index: Int, isConstructor: Boolean): List<AnnotationSpec> {
+    val parameters = if (isConstructor) {
+      lookupConstructor(classJvmName, methodSignature)!!.parameters
+    } else {
+      lookupMethod(classJvmName, methodSignature)!!.parameters
+    }
+    return try {
+      parameters[index]
+          .declaredAnnotations
+          .map { AnnotationSpec.get(it, true) }
+          .filterOutNullabilityAnnotations()
+    } catch (e: ClassNotFoundException) {
+      emptyList()
+    }
+  }
+
   override fun isMethodSynthetic(
     classJvmName: String,
     methodSignature: JvmMethodSignature

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -186,8 +186,12 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
     }
   }
 
-  override fun parameterAnnotations(classJvmName: String, methodSignature: JvmMethodSignature,
-      index: Int, isConstructor: Boolean): List<AnnotationSpec> {
+  override fun parameterAnnotations(
+    classJvmName: String,
+    methodSignature: JvmMethodSignature,
+    index: Int,
+    isConstructor: Boolean
+  ): List<AnnotationSpec> {
     val parameters = if (isConstructor) {
       lookupConstructor(classJvmName, methodSignature)!!.parameters
     } else {

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1666,10 +1666,10 @@ class KotlinPoetMetadataSpecsTest(
   annotation class CustomAnnotation(val name: String)
 
   class ParameterAnnotations(
-      @property:CustomAnnotation("\$a") @param:CustomAnnotation("b") val param1: String,
-      @CustomAnnotation("2") param2: String) {
+    @property:CustomAnnotation("\$a") @param:CustomAnnotation("b") val param1: String,
+    @CustomAnnotation("2") param2: String
+  ) {
     fun function(@CustomAnnotation("woo") param1: String) {
-
     }
   }
 }

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1307,7 +1307,7 @@ class KotlinPoetMetadataSpecsTest(
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Fields(
-        @kotlin.jvm.JvmField
+        @property:kotlin.jvm.JvmField
         val param1: kotlin.String
       ) {
         @kotlin.jvm.JvmField

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1617,6 +1617,61 @@ class KotlinPoetMetadataSpecsTest(
       }
       """.trimIndent())
   }
+
+  @IgnoreForHandlerType(
+      reason = "Property site-target annotations are always stored on the synthetic annotations " +
+          "method, which is not accessible in the elements API",
+      handlerType = ELEMENTS
+  )
+  @Test
+  fun parameterAnnotations_reflective() {
+    val typeSpec = ParameterAnnotations::class.toTypeSpecWithTestHandler()
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class ParameterAnnotations(
+        @property:com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "${'$'}{'${'$'}'}a")
+        @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "b")
+        val param1: kotlin.String,
+        @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "2")
+        param2: kotlin.String
+      ) {
+        fun function(@com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "woo") param1: kotlin.String) {
+        }
+      }
+      """.trimIndent())
+  }
+
+  @IgnoreForHandlerType(
+      reason = "Property site-target annotations are always stored on the synthetic annotations " +
+          "method, which is not accessible in the elements API",
+      handlerType = REFLECTIVE
+  )
+  @Test
+  fun parameterAnnotations_elements() {
+    val typeSpec = ParameterAnnotations::class.toTypeSpecWithTestHandler()
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class ParameterAnnotations(
+        @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "b")
+        val param1: kotlin.String,
+        @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "2")
+        param2: kotlin.String
+      ) {
+        fun function(@com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "woo") param1: kotlin.String) {
+        }
+      }
+      """.trimIndent())
+  }
+
+  annotation class CustomAnnotation(val name: String)
+
+  class ParameterAnnotations(
+      @property:CustomAnnotation("\$a") @param:CustomAnnotation("b") val param1: String,
+      @CustomAnnotation("2") param2: String) {
+    fun function(@CustomAnnotation("woo") param1: String) {
+
+    }
+  }
 }
 
 class ClassNesting {

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
@@ -146,6 +146,23 @@ interface ElementHandler {
   fun methodAnnotations(classJvmName: String, methodSignature: JvmMethodSignature): List<AnnotationSpec>
 
   /**
+   * Looks up the annotations on a given parameter given a [JvmMethodSignature] at [index].
+   *
+   * @param classJvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param methodSignature The method with annotations to look up.
+   * @param index The parameter index.
+   * @param isConstructor Indicates if [methodSignature] is a constructor
+   * @return the [AnnotationSpec] representations of the annotations on the target parameter or
+   *         empty.
+   */
+  fun parameterAnnotations(
+    classJvmName: String,
+    methodSignature: JvmMethodSignature,
+    index: Int,
+    isConstructor: Boolean
+  ): List<AnnotationSpec>
+
+  /**
    * Looks up a [JvmMethodSignature] and returns whether or not it is synthetic.
    *
    * @param classJvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -618,6 +618,21 @@ private fun companionObjectName(name: String): String? {
 }
 
 @KotlinPoetMetadataPreview
+private fun ImmutableKmValueParameter.extractAnnotations(
+  elementHandler: ElementHandler?,
+  classJvmName: String,
+  jvmMethodSignature: JvmMethodSignature?,
+  index: Int,
+  isConstructorParam: Boolean
+): List<AnnotationSpec> {
+  return if (hasAnnotations && elementHandler != null && jvmMethodSignature != null) {
+    elementHandler.parameterAnnotations(classJvmName, jvmMethodSignature, index, isConstructorParam)
+  } else {
+    emptyList()
+  }
+}
+
+@KotlinPoetMetadataPreview
 private fun ImmutableKmConstructor.toFunSpec(
   typeParamResolver: ((index: Int) -> TypeName),
   annotations: List<AnnotationSpec>

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -673,7 +673,13 @@ private fun ImmutableKmFunction.toFunSpec(
           addParameters(valueParameters.mapIndexed { index, param ->
             param.toParameterSpec(
                 typeParamResolver,
-                param.extractAnnotations(elementHandler, classJvmName, signature, index, false)
+                param.extractAnnotations(
+                    elementHandler,
+                    classJvmName,
+                    signature,
+                    index,
+                    isConstructorParam = false
+                )
             )
           })
         }


### PR DESCRIPTION
This implements support for parsing and rendering parameter annotations on metadata. It requires another `ElementHandler` API (but can be cleaned up as part of #776).

Interesting insight - Kotlin does roughly the following decision tree for implicit parameter annotation site targets
1. If an annotation is applicable to parameters, then the implicit site-target is `param`
2. If the annotation is applicable to properties, then the implicit target is `property`
3. If the annotation is applicable to fields, then the implicit target is `field`

This tries to make that explicit by, if a site-target-less annotation was found on a property but that property is a constructor param, it applies `property:` designation to it. This is legal for field-only annotations as well like `@JvmField`, but redundant. We can maybe do a lookup to read the given annotation's targets, but for now I figure it's better to err for correctness rather than avoiding redundancy in the rendered source. This is implemented in 42abb39