### PR TITLE
Revamp ElementHandler API

### DIFF
--- a/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
+++ b/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
@@ -259,7 +259,35 @@ class ElementsElementHandler private constructor(
       }
     }
 
-    val propertyData = TODO()
+    val propertyData = kmClass.properties
+        .asSequence()
+        .filter { it.isDeclaration }
+        .filterNot { it.isSynthesized }
+        .associateWith { property ->
+          val isJvmField = property.computeIsJvmField(
+              elementHandler = this,
+              isCompanionObject = kmClass.isCompanionObject,
+              hasGetter = property.getterSignature != null,
+              hasSetter = property.setterSignature != null,
+              hasField = property.fieldSignature != null
+          )
+
+          val fieldData = TODO()
+
+          val getterData = TODO()
+
+          val setterData = TODO()
+
+          val annotations = TODO()
+
+          PropertyData(
+              annotations = annotations,
+              fieldData = fieldData,
+              getterData = getterData,
+              setterData = setterData,
+              isJvmField = isJvmField
+          )
+        }
 
     val constructorData = kmClass.constructors.associateWith { kmConstructor ->
       if (kmClass.isAnnotation || kmClass.isInline) {

--- a/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
+++ b/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
@@ -332,7 +332,18 @@ class ElementsElementHandler private constructor(
                 ?: return@let MethodData.SYNTHETIC
           }
 
-          val setterData = TODO()
+          val setterData = property.setterSignature?.let { setterSignature ->
+            val method = classIfCompanion.lookupMethod(setterSignature, ElementFilter::methodsIn)
+            method?.methodData(
+                typeElement = typeElement,
+                hasAnnotations = property.setterFlags.hasAnnotations,
+                jvmInformationMethod = classIfCompanion.takeIf { it != typeElement }
+                    ?.lookupMethod(setterSignature, ElementFilter::methodsIn)
+                    ?: method,
+                knownIsOverride = getterData?.isOverride
+            )
+                ?: return@let MethodData.SYNTHETIC
+          }
 
           val annotations = TODO()
 

--- a/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
+++ b/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
@@ -414,7 +414,7 @@ class ElementsElementHandler private constructor(
         kmClass = kmClass,
         simpleName = simpleName,
         properties = propertyData,
-        constructors = constructorData,
+        constructors = constructorData.filterValues { it != ConstructorData.SYNTHETIC },
         methods = methodData
     )
   }

--- a/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
+++ b/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
@@ -345,7 +345,14 @@ class ElementsElementHandler private constructor(
                 ?: return@let MethodData.SYNTHETIC
           }
 
-          val annotations = TODO()
+          val annotations = mutableListOf<AnnotationSpec>()
+          if (property.hasAnnotations) {
+            property.syntheticMethodForAnnotations?.let { annotationsHolderSignature ->
+              val method = typeElement.lookupMethod(annotationsHolderSignature, ElementFilter::methodsIn)
+                  ?: return@let MethodData.SYNTHETIC
+              annotations += method.annotationSpecs()
+            }
+          }
 
           PropertyData(
               annotations = annotations,

--- a/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
+++ b/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
@@ -419,9 +419,9 @@ class ElementsElementHandler private constructor(
     )
   }
 
-  private fun List<VariableElement>.indexedAnnotationSpecs(): Map<Int, List<AnnotationSpec>> {
+  private fun List<VariableElement>.indexedAnnotationSpecs(): Map<Int, Collection<AnnotationSpec>> {
     return withIndex().associate { (index, parameter) ->
-      index to parameter.annotationSpecs()
+      index to ElementHandler.createAnnotations { addAll(parameter.annotationSpecs()) }
     }
   }
 

--- a/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
+++ b/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
@@ -245,8 +245,11 @@ class ElementsElementHandler private constructor(
     }
   }
 
-  override fun classData(kmClass: ImmutableKmClass, parentName: String?,
-      simpleName: String): ClassData {
+  override fun classData(
+    kmClass: ImmutableKmClass,
+    parentName: String?,
+    simpleName: String
+  ): ClassData {
     val typeElement = lookupTypeElement(kmClass.name.jvmInternalName)
         ?: error("No class found for: ${kmClass.name}.")
 
@@ -254,7 +257,7 @@ class ElementsElementHandler private constructor(
     val classIfCompanion by lazy(NONE) {
       if (kmClass.isCompanionObject && parentName != null) {
         lookupTypeElement(parentName)
-            ?: error("No class found for: ${parentName}.")
+            ?: error("No class found for: $parentName.")
       } else {
         typeElement
       }
@@ -273,7 +276,7 @@ class ElementsElementHandler private constructor(
               hasField = property.fieldSignature != null
           )
 
-          val fieldData = property.fieldSignature?.let fieldDataLet@ { fieldSignature ->
+          val fieldData = property.fieldSignature?.let fieldDataLet@{ fieldSignature ->
             // Check the field in the parent first. For const/static/jvmField elements, these only
             // exist in the parent and we want to check that if necessary to avoid looking up a
             // non-existent field in the companion.
@@ -294,7 +297,7 @@ class ElementsElementHandler private constructor(
             val field = classForOriginalField.lookupField(fieldSignature)
                 ?: return@fieldDataLet FieldData.SYNTHETIC
             val constant = if (property.hasConstant) {
-              val fieldWithConstant = classIfCompanion.takeIf { it != typeElement}?.let {
+              val fieldWithConstant = classIfCompanion.takeIf { it != typeElement }?.let {
                 if (it.kind.isInterface) {
                   field
                 } else {
@@ -439,10 +442,10 @@ class ElementsElementHandler private constructor(
   }
 
   private fun ExecutableElement.methodData(
-      typeElement: TypeElement,
-      hasAnnotations: Boolean,
-      jvmInformationMethod: ExecutableElement = this,
-      knownIsOverride: Boolean? = null
+    typeElement: TypeElement,
+    hasAnnotations: Boolean,
+    jvmInformationMethod: ExecutableElement = this,
+    knownIsOverride: Boolean? = null
   ): MethodData {
     return MethodData(
         annotations = if (hasAnnotations) annotationSpecs() else emptyList(),

--- a/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
+++ b/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
@@ -366,7 +366,7 @@ class ElementsElementHandler private constructor(
     val constructorData = kmClass.constructors.associateWith { kmConstructor ->
       if (kmClass.isAnnotation || kmClass.isInline) {
         //
-        // Annotations are interfaces in reflection, but kotlin metadata will still report a
+        // Annotations are interfaces in bytecode, but kotlin metadata will still report a
         // constructor signature
         //
         // Inline classes have no constructors at runtime

--- a/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
+++ b/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
@@ -389,7 +389,7 @@ class ElementsElementHandler private constructor(
       val signature = kmConstructor.signature
       if (signature != null) {
         val constructor = typeElement.lookupMethod(signature, ElementFilter::constructorsIn)
-            ?: return@associateWith ConstructorData.SYNTHETIC
+            ?: return@associateWith ConstructorData.EMPTY
         ConstructorData(
             annotations = if (kmConstructor.hasAnnotations) {
               constructor.annotationSpecs()
@@ -427,7 +427,7 @@ class ElementsElementHandler private constructor(
         kmClass = kmClass,
         simpleName = simpleName,
         properties = propertyData,
-        constructors = constructorData.filterValues { it != ConstructorData.SYNTHETIC },
+        constructors = constructorData,
         methods = methodData
     )
   }

--- a/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
+++ b/kotlinpoet-elementhandler-elements/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/elements/ElementsElementHandler.kt
@@ -320,7 +320,17 @@ class ElementsElementHandler private constructor(
             )
           }
 
-          val getterData = TODO()
+          val getterData = property.getterSignature?.let { getterSignature ->
+            val method = classIfCompanion.lookupMethod(getterSignature, ElementFilter::methodsIn)
+            method?.methodData(
+                typeElement = typeElement,
+                hasAnnotations = property.getterFlags.hasAnnotations,
+                jvmInformationMethod = classIfCompanion.takeIf { it != typeElement }
+                    ?.lookupMethod(getterSignature, ElementFilter::methodsIn)
+                    ?: method
+            )
+                ?: return@let MethodData.SYNTHETIC
+          }
 
           val setterData = TODO()
 

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -6,6 +6,7 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.metadata.ImmutableKmClass
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+import com.squareup.kotlinpoet.metadata.hasAnnotations
 import com.squareup.kotlinpoet.metadata.isCompanionObject
 import com.squareup.kotlinpoet.metadata.specs.ClassData
 import com.squareup.kotlinpoet.metadata.specs.ElementHandler
@@ -239,7 +240,21 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
 
     val constructorData = TODO()
 
-    val methodData = TODO()
+    val methodData = kmClass.functions.associateWith { kmFunction ->
+      val signature = kmFunction.signature
+      if (signature != null) {
+        val method = targetClass.lookupMethod(signature)
+        method?.methodData(
+            clazz = targetClass,
+            signature = signature,
+            hasAnnotations = kmFunction.hasAnnotations,
+            jvmInformationMethod = classIfCompanion.takeIf { it != targetClass }?.lookupMethod(signature) ?: method
+            )
+            ?: error("No method $signature found in $targetClass.")
+      } else {
+        MethodData.EMPTY
+      }
+    }
 
     return ClassData(
         kmClass = kmClass,

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -411,9 +411,9 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
     )
   }
 
-  private fun Array<Parameter>.indexedAnnotationSpecs(): Map<Int, List<AnnotationSpec>> {
+  private fun Array<Parameter>.indexedAnnotationSpecs(): Map<Int, Collection<AnnotationSpec>> {
     return withIndex().associate { (index, parameter) ->
-          index to parameter.annotationSpecs()
+          index to ElementHandler.createAnnotations { addAll(parameter.annotationSpecs()) }
         }
   }
 

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -260,7 +260,17 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
 
           val getterData = TODO()
 
-          val setterData = TODO()
+          val setterData = property.setterSignature?.let { setterSignature ->
+            val method = classIfCompanion.lookupMethod(setterSignature)
+                method?.methodData(
+                    clazz = targetClass,
+                    signature = setterSignature,
+                    hasAnnotations = property.setterFlags.hasAnnotations,
+                    jvmInformationMethod = classIfCompanion.takeIf { it != targetClass }?.lookupMethod(setterSignature) ?: method,
+                    knownIsOverride = getterData?.isOverride
+                )
+                ?: error("No setter method $setterSignature found in $classIfCompanion.")
+          }
 
           val annotations = mutableListOf<AnnotationSpec>()
           if (property.hasAnnotations) {

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -262,7 +262,15 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
 
           val setterData = TODO()
 
-          val annotations = TODO()
+          val annotations = mutableListOf<AnnotationSpec>()
+          if (property.hasAnnotations) {
+            property.syntheticMethodForAnnotations?.let { annotationsHolderSignature ->
+              val method = targetClass.lookupMethod(annotationsHolderSignature)
+                  ?: error("Method $annotationsHolderSignature (synthetic method for annotations)" +
+                      " found in $targetClass.")
+              annotations += method.annotationSpecs()
+            }
+          }
 
           PropertyData(
               annotations = annotations,

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -229,9 +229,9 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
   }
 
   override fun classData(
-      kmClass: ImmutableKmClass,
-      parentName: String?,
-      simpleName: String
+    kmClass: ImmutableKmClass,
+    parentName: String?,
+    simpleName: String
   ): ClassData {
     val targetClass = lookupClass(kmClass.name.jvmInternalName)
         ?: error("No class found for: ${kmClass.name}.")
@@ -240,7 +240,7 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
     val classIfCompanion by lazy(NONE) {
       if (kmClass.isCompanionObject && parentName != null) {
         lookupClass(parentName)
-            ?: error("No class found for: ${parentName}.")
+            ?: error("No class found for: $parentName.")
       } else {
         targetClass
       }
@@ -280,7 +280,7 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
             val field = classForOriginalField.lookupField(fieldSignature)
                 ?: error("No field $fieldSignature found in $classForOriginalField.")
             val constant = if (property.hasConstant) {
-              val fieldWithConstant = classIfCompanion.takeIf { it != targetClass}?.let {
+              val fieldWithConstant = classIfCompanion.takeIf { it != targetClass }?.let {
                 if (it.isInterface) {
                   field
                 } else {
@@ -418,11 +418,11 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
   }
 
   private fun Method.methodData(
-      clazz: Class<*>,
-      signature: JvmMethodSignature,
-      hasAnnotations: Boolean,
-      jvmInformationMethod: Method = this,
-      knownIsOverride: Boolean? = null
+    clazz: Class<*>,
+    signature: JvmMethodSignature,
+    hasAnnotations: Boolean,
+    jvmInformationMethod: Method = this,
+    knownIsOverride: Boolean? = null
   ): MethodData {
     return MethodData(
         annotations = if (hasAnnotations) annotationSpecs() else emptyList(),

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -258,7 +258,16 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
 
           val fieldData = TODO()
 
-          val getterData = TODO()
+          val getterData = property.getterSignature?.let { getterSignature ->
+            val method = classIfCompanion.lookupMethod(getterSignature)
+                method?.methodData(
+                    clazz = targetClass,
+                    signature = getterSignature,
+                    hasAnnotations = property.getterFlags.hasAnnotations,
+                    jvmInformationMethod = classIfCompanion.takeIf { it != targetClass }?.lookupMethod(getterSignature) ?: method
+                )
+                ?: error("No getter method $getterSignature found in $classIfCompanion.")
+          }
 
           val setterData = property.setterSignature?.let { setterSignature ->
             val method = classIfCompanion.lookupMethod(setterSignature)

--- a/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
+++ b/kotlinpoet-elementhandler-reflective/src/main/kotlin/com/squareup/kotlinpoet/elementhandler/reflective/ReflectiveElementHandler.kt
@@ -9,10 +9,13 @@ import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 import com.squareup.kotlinpoet.metadata.hasAnnotations
 import com.squareup.kotlinpoet.metadata.isAnnotation
 import com.squareup.kotlinpoet.metadata.isCompanionObject
+import com.squareup.kotlinpoet.metadata.isDeclaration
 import com.squareup.kotlinpoet.metadata.isInline
+import com.squareup.kotlinpoet.metadata.isSynthesized
 import com.squareup.kotlinpoet.metadata.specs.ClassData
 import com.squareup.kotlinpoet.metadata.specs.ConstructorData
 import com.squareup.kotlinpoet.metadata.specs.ElementHandler
+import com.squareup.kotlinpoet.metadata.specs.ElementHandler.Companion.computeIsJvmField
 import com.squareup.kotlinpoet.metadata.specs.JvmFieldModifier
 import com.squareup.kotlinpoet.metadata.specs.JvmFieldModifier.TRANSIENT
 import com.squareup.kotlinpoet.metadata.specs.JvmFieldModifier.VOLATILE
@@ -20,6 +23,7 @@ import com.squareup.kotlinpoet.metadata.specs.JvmMethodModifier
 import com.squareup.kotlinpoet.metadata.specs.JvmMethodModifier.STATIC
 import com.squareup.kotlinpoet.metadata.specs.JvmMethodModifier.SYNCHRONIZED
 import com.squareup.kotlinpoet.metadata.specs.MethodData
+import com.squareup.kotlinpoet.metadata.specs.PropertyData
 import com.squareup.kotlinpoet.metadata.toImmutableKmClass
 import kotlinx.metadata.jvm.JvmFieldSignature
 import kotlinx.metadata.jvm.JvmMethodSignature
@@ -239,7 +243,35 @@ class ReflectiveElementHandler private constructor() : ElementHandler {
       }
     }
 
-    val propertyData = TODO()
+    val propertyData = kmClass.properties
+        .asSequence()
+        .filter { it.isDeclaration }
+        .filterNot { it.isSynthesized }
+        .associateWith { property ->
+          val isJvmField = property.computeIsJvmField(
+              elementHandler = this,
+              isCompanionObject = kmClass.isCompanionObject,
+              hasGetter = property.getterSignature != null,
+              hasSetter = property.setterSignature != null,
+              hasField = property.fieldSignature != null
+          )
+
+          val fieldData = TODO()
+
+          val getterData = TODO()
+
+          val setterData = TODO()
+
+          val annotations = TODO()
+
+          PropertyData(
+              annotations = annotations,
+              fieldData = fieldData,
+              getterData = getterData,
+              setterData = setterData,
+              isJvmField = isJvmField
+          )
+        }
 
     val constructorData = kmClass.constructors.associateWith { kmConstructor ->
       if (kmClass.isAnnotation || kmClass.isInline) {

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1212,8 +1212,8 @@ class KotlinPoetMetadataSpecsTest(
             @kotlin.jvm.JvmStatic
             val FOO_BOOL: kotlin.Boolean = false
 
-            @kotlin.jvm.JvmStatic
             @kotlin.jvm.JvmName(name = "jvmStaticFunction")
+            @kotlin.jvm.JvmStatic
             fun staticFunction() {
             }
           }

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1209,6 +1209,7 @@ class KotlinPoetMetadataSpecsTest(
 
         interface InterfaceWithJvmName {
           companion object {
+            @get:kotlin.jvm.JvmName(name = "fooBoolJvm")
             @kotlin.jvm.JvmStatic
             val FOO_BOOL: kotlin.Boolean = false
 
@@ -1337,10 +1338,10 @@ class KotlinPoetMetadataSpecsTest(
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Fields(
-        @field:kotlin.jvm.JvmField
+        @property:kotlin.jvm.JvmField
         val param1: kotlin.String
       ) {
-        @field:kotlin.jvm.JvmField
+        @kotlin.jvm.JvmField
         val fieldProp: kotlin.String = ""
 
         companion object {
@@ -1477,6 +1478,7 @@ class KotlinPoetMetadataSpecsTest(
           fun interfaceFunction()
 
           companion object {
+            @get:kotlin.jvm.JvmSynthetic
             @kotlin.jvm.JvmStatic
             val FOO_BOOL: kotlin.Boolean = false
 

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1414,6 +1414,7 @@ class KotlinPoetMetadataSpecsTest(
           fun interfaceFunction()
 
           companion object {
+            @get:kotlin.jvm.JvmSynthetic
             @kotlin.jvm.JvmStatic
             val FOO_BOOL: kotlin.Boolean = false
 

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1420,8 +1420,8 @@ class KotlinPoetMetadataSpecsTest(
             /**
              * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
              */
-            @kotlin.jvm.JvmSynthetic
             @kotlin.jvm.JvmStatic
+            @kotlin.jvm.JvmSynthetic
             fun staticFunction() {
             }
           }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ClassData.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ClassData.kt
@@ -1,0 +1,19 @@
+package com.squareup.kotlinpoet.metadata.specs
+
+import com.squareup.kotlinpoet.metadata.ImmutableKmClass
+import com.squareup.kotlinpoet.metadata.ImmutableKmConstructor
+import com.squareup.kotlinpoet.metadata.ImmutableKmFunction
+import com.squareup.kotlinpoet.metadata.ImmutableKmProperty
+import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+import com.squareup.kotlinpoet.metadata.isInterface
+
+@KotlinPoetMetadataPreview
+data class ClassData(
+    val kmClass: ImmutableKmClass,
+    val simpleName: String,
+    val properties: Map<ImmutableKmProperty, PropertyData>,
+    val constructors: Map<ImmutableKmConstructor, ConstructorData>,
+    val methods: Map<ImmutableKmFunction, MethodData>
+) {
+  val isInterface: Boolean = kmClass.isInterface
+}

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ClassData.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ClassData.kt
@@ -9,11 +9,11 @@ import com.squareup.kotlinpoet.metadata.isInterface
 
 @KotlinPoetMetadataPreview
 data class ClassData(
-    val kmClass: ImmutableKmClass,
-    val simpleName: String,
-    val properties: Map<ImmutableKmProperty, PropertyData>,
-    val constructors: Map<ImmutableKmConstructor, ConstructorData>,
-    val methods: Map<ImmutableKmFunction, MethodData>
+  val kmClass: ImmutableKmClass,
+  val simpleName: String,
+  val properties: Map<ImmutableKmProperty, PropertyData>,
+  val constructors: Map<ImmutableKmConstructor, ConstructorData>,
+  val methods: Map<ImmutableKmFunction, MethodData>
 ) {
   val isInterface: Boolean = kmClass.isInterface
 }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ConstructorData.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ConstructorData.kt
@@ -1,0 +1,44 @@
+package com.squareup.kotlinpoet.metadata.specs
+
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+
+@KotlinPoetMetadataPreview
+data class ConstructorData(
+    val annotations: List<AnnotationSpec>,
+    val parameterAnnotations: Map<Int, List<AnnotationSpec>>,
+    val isSynthetic: Boolean,
+    val jvmModifiers: Set<JvmMethodModifier>,
+    val exceptions: List<TypeName>
+) {
+
+  val allAnnotations = ElementHandler.createAnnotations {
+    addAll(annotations)
+    if (isSynthetic) {
+      add(JVM_SYNTHETIC_SPEC)
+    }
+    addAll(jvmModifiers.map { it.annotationSpec() })
+    exceptions.takeIf { it.isNotEmpty() }
+        ?.let {
+          add(ElementHandler.createThrowsSpec(it))
+        }
+  }
+
+  companion object {
+    val SYNTHETIC = ConstructorData(
+        annotations = emptyList(),
+        parameterAnnotations = emptyMap(),
+        isSynthetic = true,
+        jvmModifiers = emptySet(),
+        exceptions = emptyList()
+    )
+    val EMPTY = ConstructorData(
+        annotations = emptyList(),
+        parameterAnnotations = emptyMap(),
+        isSynthetic = false,
+        jvmModifiers = emptySet(),
+        exceptions = emptyList()
+    )
+  }
+}

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ConstructorData.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ConstructorData.kt
@@ -6,11 +6,11 @@ import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 
 @KotlinPoetMetadataPreview
 data class ConstructorData(
-    val annotations: List<AnnotationSpec>,
-    val parameterAnnotations: Map<Int, Collection<AnnotationSpec>>,
-    val isSynthetic: Boolean,
-    val jvmModifiers: Set<JvmMethodModifier>,
-    val exceptions: List<TypeName>
+  val annotations: List<AnnotationSpec>,
+  val parameterAnnotations: Map<Int, Collection<AnnotationSpec>>,
+  val isSynthetic: Boolean,
+  val jvmModifiers: Set<JvmMethodModifier>,
+  val exceptions: List<TypeName>
 ) {
 
   val allAnnotations = ElementHandler.createAnnotations {

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ConstructorData.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ConstructorData.kt
@@ -7,7 +7,7 @@ import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 @KotlinPoetMetadataPreview
 data class ConstructorData(
     val annotations: List<AnnotationSpec>,
-    val parameterAnnotations: Map<Int, List<AnnotationSpec>>,
+    val parameterAnnotations: Map<Int, Collection<AnnotationSpec>>,
     val isSynthetic: Boolean,
     val jvmModifiers: Set<JvmMethodModifier>,
     val exceptions: List<TypeName>

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
@@ -115,26 +115,14 @@ interface ElementHandler {
       hasSetter: Boolean,
       hasField: Boolean
     ): Boolean {
-      val isJvmField: Boolean
-      if (!hasGetter &&
+      return if (!hasGetter &&
           !hasSetter &&
           hasField &&
           !isConst) {
-        if (elementHandler.supportsNonRuntimeRetainedAnnotations && !isCompanionObject) {
-          // Throwaway value as this kind of element handler should be automatically be
-          // picking up the jvm field annotation.
-          //
-          // We don't do this for companion object fields though as they appear to not
-          // have the JvmField annotation copied over though
-          //
-          isJvmField = false
-        } else {
-          isJvmField = true
-        }
+        !(elementHandler.supportsNonRuntimeRetainedAnnotations && !isCompanionObject)
       } else {
-        isJvmField = false
+        false
       }
-      return isJvmField
     }
 
     /**

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
@@ -30,33 +30,6 @@ import kotlinx.metadata.jvm.JvmMethodSignature
 @KotlinPoetMetadataPreview
 interface ElementHandler {
 
-  interface JvmModifier {
-    fun annotationSpec(): AnnotationSpec
-  }
-
-  /** Modifiers that are annotations in Kotlin but modifier keywords in bytecode. */
-  enum class JvmFieldModifier : JvmModifier {
-    STATIC {
-      override fun annotationSpec(): AnnotationSpec = AnnotationSpec.builder(JvmStatic::class.asClassName()).build()
-    },
-    TRANSIENT {
-      override fun annotationSpec(): AnnotationSpec = AnnotationSpec.builder(Transient::class.asClassName()).build()
-    },
-    VOLATILE {
-      override fun annotationSpec(): AnnotationSpec = AnnotationSpec.builder(Volatile::class.asClassName()).build()
-    };
-  }
-
-  /** Modifiers that are annotations in Kotlin but modifier keywords in bytecode. */
-  enum class JvmMethodModifier : JvmModifier {
-    STATIC {
-      override fun annotationSpec(): AnnotationSpec = AnnotationSpec.builder(JvmStatic::class.asClassName()).build()
-    },
-    SYNCHRONIZED {
-      override fun annotationSpec(): AnnotationSpec = AnnotationSpec.builder(Synchronized::class.asClassName()).build()
-    }
-  }
-
   /**
    * Indicates if this element handler supports [AnnotationRetention.RUNTIME]-retained annotations.
    * This is used to indicate if manual inference of certain non-RUNTIME-retained annotations should

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
@@ -47,9 +47,9 @@ interface ElementHandler {
   }
 
   fun classData(
-      kmClass: ImmutableKmClass,
-      parentName: String?,
-      simpleName: String = kmClass.bestGuessSimpleName()
+    kmClass: ImmutableKmClass,
+    parentName: String?,
+    simpleName: String = kmClass.bestGuessSimpleName()
   ): ClassData
 
   /**
@@ -109,11 +109,11 @@ interface ElementHandler {
     }
 
     fun ImmutableKmProperty.computeIsJvmField(
-        elementHandler: ElementHandler,
-        isCompanionObject: Boolean,
-        hasGetter: Boolean,
-        hasSetter: Boolean,
-        hasField: Boolean
+      elementHandler: ElementHandler,
+      isCompanionObject: Boolean,
+      hasGetter: Boolean,
+      hasSetter: Boolean,
+      hasField: Boolean
     ): Boolean {
       val isJvmField: Boolean
       if (!hasGetter &&
@@ -142,8 +142,8 @@ interface ElementHandler {
      *         input annotations from [body].
      */
     fun createAnnotations(
-        siteTarget: UseSiteTarget? = null,
-        body: MutableCollection<AnnotationSpec>.() -> Unit
+      siteTarget: UseSiteTarget? = null,
+      body: MutableCollection<AnnotationSpec>.() -> Unit
     ): Collection<AnnotationSpec> {
       val result = TreeSet<AnnotationSpec>(compareBy { it.toString() }).apply {
         body()
@@ -165,8 +165,8 @@ interface ElementHandler {
     }
 
     fun createThrowsSpec(
-        exceptions: Collection<TypeName>,
-        useSiteTarget: UseSiteTarget? = null
+      exceptions: Collection<TypeName>,
+      useSiteTarget: UseSiteTarget? = null
     ): AnnotationSpec {
       return AnnotationSpec.builder(Throws::class)
           .addMember(

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/FieldData.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/FieldData.kt
@@ -1,0 +1,33 @@
+package com.squareup.kotlinpoet.metadata.specs
+
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget.FIELD
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+
+@KotlinPoetMetadataPreview
+data class FieldData(
+    private val annotations: List<AnnotationSpec>,
+    val isSynthetic: Boolean,
+    val jvmModifiers: Set<JvmFieldModifier>,
+    val constant: CodeBlock?
+) {
+
+  val allAnnotations = ElementHandler.createAnnotations(
+      FIELD) {
+    addAll(annotations)
+    if (isSynthetic) {
+      add(JVM_SYNTHETIC_SPEC)
+    }
+    addAll(jvmModifiers.map { it.annotationSpec() })
+  }
+
+  companion object {
+    val SYNTHETIC = FieldData(
+        annotations = emptyList(),
+        isSynthetic = true,
+        jvmModifiers = emptySet(),
+        constant = null
+    )
+  }
+}

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/FieldData.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/FieldData.kt
@@ -7,10 +7,10 @@ import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 
 @KotlinPoetMetadataPreview
 data class FieldData(
-    private val annotations: List<AnnotationSpec>,
-    val isSynthetic: Boolean,
-    val jvmModifiers: Set<JvmFieldModifier>,
-    val constant: CodeBlock?
+  private val annotations: List<AnnotationSpec>,
+  val isSynthetic: Boolean,
+  val jvmModifiers: Set<JvmFieldModifier>,
+  val constant: CodeBlock?
 ) {
 
   val allAnnotations = ElementHandler.createAnnotations(

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/JvmFieldModifier.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/JvmFieldModifier.kt
@@ -1,0 +1,20 @@
+package com.squareup.kotlinpoet.metadata.specs
+
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.asClassName
+
+/** Modifiers that are annotations in Kotlin but modifier keywords in bytecode. */
+enum class JvmFieldModifier : JvmModifier {
+  STATIC {
+    override fun annotationSpec(): AnnotationSpec = AnnotationSpec.builder(
+        JvmStatic::class.asClassName()).build()
+  },
+  TRANSIENT {
+    override fun annotationSpec(): AnnotationSpec = AnnotationSpec.builder(
+        Transient::class.asClassName()).build()
+  },
+  VOLATILE {
+    override fun annotationSpec(): AnnotationSpec = AnnotationSpec.builder(
+        Volatile::class.asClassName()).build()
+  };
+}

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/JvmFieldModifier.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/JvmFieldModifier.kt
@@ -2,8 +2,10 @@ package com.squareup.kotlinpoet.metadata.specs
 
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 
 /** Modifiers that are annotations in Kotlin but modifier keywords in bytecode. */
+@KotlinPoetMetadataPreview
 enum class JvmFieldModifier : JvmModifier {
   STATIC {
     override fun annotationSpec(): AnnotationSpec = AnnotationSpec.builder(

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/JvmMethodModifier.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/JvmMethodModifier.kt
@@ -1,0 +1,16 @@
+package com.squareup.kotlinpoet.metadata.specs
+
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.asClassName
+
+/** Modifiers that are annotations in Kotlin but modifier keywords in bytecode. */
+enum class JvmMethodModifier : JvmModifier {
+  STATIC {
+    override fun annotationSpec(): AnnotationSpec = AnnotationSpec.builder(
+        JvmStatic::class.asClassName()).build()
+  },
+  SYNCHRONIZED {
+    override fun annotationSpec(): AnnotationSpec = AnnotationSpec.builder(
+        Synchronized::class.asClassName()).build()
+  }
+}

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/JvmMethodModifier.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/JvmMethodModifier.kt
@@ -2,8 +2,10 @@ package com.squareup.kotlinpoet.metadata.specs
 
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 
 /** Modifiers that are annotations in Kotlin but modifier keywords in bytecode. */
+@KotlinPoetMetadataPreview
 enum class JvmMethodModifier : JvmModifier {
   STATIC {
     override fun annotationSpec(): AnnotationSpec = AnnotationSpec.builder(

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/JvmModifier.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/JvmModifier.kt
@@ -1,0 +1,7 @@
+package com.squareup.kotlinpoet.metadata.specs
+
+import com.squareup.kotlinpoet.AnnotationSpec
+
+interface JvmModifier {
+  fun annotationSpec(): AnnotationSpec
+}

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/JvmModifier.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/JvmModifier.kt
@@ -1,7 +1,9 @@
 package com.squareup.kotlinpoet.metadata.specs
 
 import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 
+@KotlinPoetMetadataPreview
 interface JvmModifier {
   fun annotationSpec(): AnnotationSpec
 }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KmTypes.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KmTypes.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.kotlinpoet.metadata.specs
 
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.LambdaTypeName
@@ -24,6 +25,7 @@ import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.WildcardTypeName
+import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.metadata.ImmutableKmClass
 import com.squareup.kotlinpoet.metadata.ImmutableKmConstructor
 import com.squareup.kotlinpoet.metadata.ImmutableKmFlexibleTypeUpperBound
@@ -169,3 +171,12 @@ private fun ImmutableKmFlexibleTypeUpperBound.toTypeName(
   // TODO tag typeFlexibilityId somehow?
   return WildcardTypeName.producerOf(type.toTypeName(typeParamResolver))
 }
+
+internal val JVM_FIELD = JvmField::class.asClassName()
+internal val JVM_FIELD_SPEC = AnnotationSpec.builder(JVM_FIELD).build()
+internal val JVM_SYNTHETIC_SPEC = AnnotationSpec.builder(JvmSynthetic::class).build()
+internal val JVM_TRANSIENT = Transient::class.asClassName()
+internal val JVM_VOLATILE = Volatile::class.asClassName()
+internal val IMPLICIT_FIELD_ANNOTATIONS = setOf(
+    JVM_FIELD, JVM_TRANSIENT, JVM_VOLATILE
+)

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -595,7 +595,7 @@ private fun ImmutableKmProperty.toPropertySpec(
                 // TODO Ideally don't do this if the annotation use site is only field?
                 //  e.g. JvmField. It's technically fine, but redundant on parameters as it's
                 //  automatically applied to the property for these annotation types.
-                //  his is another thing ElementHandler *could* tell us
+                //  This is another thing ElementHandler *could* tell us
                 it.toBuilder().useSiteTarget(UseSiteTarget.PROPERTY).build()
               } else {
                 it

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -484,7 +484,7 @@ private fun ImmutableKmConstructor.toFunSpec(
               typeParamResolver,
               constructorData?.takeIf { it != ConstructorData.EMPTY }
                   ?.parameterAnnotations
-                  ?.getValue(index)
+                  ?.get(index)
                   .orEmpty()
           )
         })

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -548,7 +548,7 @@ private fun ImmutableKmFunction.toFunSpec(
 @KotlinPoetMetadataPreview
 private fun ImmutableKmValueParameter.toParameterSpec(
   typeParamResolver: ((index: Int) -> TypeName),
-  annotations: List<AnnotationSpec>
+  annotations: Collection<AnnotationSpec>
 ): ParameterSpec {
   val paramType = varargElementType ?: type ?: throw IllegalStateException("No argument type!")
   return ParameterSpec.builder(name, paramType.toTypeName(typeParamResolver))

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -363,7 +363,10 @@ private fun ImmutableKmClass.toTypeSpec(
               property.toPropertySpec(
                   typeParamResolver = classTypeParamsResolver,
                   isConstructorParam = property.name in primaryConstructorParams,
-                  annotations = propertyData?.allAnnotations.orEmpty() + annotations,
+                  annotations = ElementHandler.createAnnotations {
+                    addAll(annotations)
+                    addAll(propertyData?.allAnnotations.orEmpty())
+                  },
                   propertyData = propertyData
               )
             }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -69,7 +69,6 @@ import com.squareup.kotlinpoet.metadata.PropertyAccessorFlag.IS_EXTERNAL
 import com.squareup.kotlinpoet.metadata.PropertyAccessorFlag.IS_INLINE
 import com.squareup.kotlinpoet.metadata.PropertyAccessorFlag.IS_NOT_DEFAULT
 import com.squareup.kotlinpoet.metadata.declaresDefaultValue
-import com.squareup.kotlinpoet.metadata.hasConstant
 import com.squareup.kotlinpoet.metadata.hasGetter
 import com.squareup.kotlinpoet.metadata.hasSetter
 import com.squareup.kotlinpoet.metadata.isAbstract
@@ -319,7 +318,7 @@ private fun ImmutableKmClass.toTypeSpec(
             .map { (property, propertyData) ->
               val annotations = mutableListOf<AnnotationSpec>()
               if (propertyData != null) {
-                if (property.hasGetter && property.canHaveGetterBody) {
+                if (property.hasGetter) {
                   property.getterSignature?.let { getterSignature ->
                     if (!isInterface &&
                         elementHandler?.supportsNonRuntimeRetainedAnnotations == false) {
@@ -661,7 +660,7 @@ private fun ImmutableKmProperty.toPropertySpec(
         // since the delegate handles it
         // vals with initialized constants have a getter in bytecode but not a body in kotlin source
         val modifierSet = modifiers.toSet()
-        if (hasGetter && !isDelegated && canHaveGetterBody) {
+        if (hasGetter && !isDelegated) {
           propertyAccessor(modifierSet, getterFlags,
               FunSpec.getterBuilder().addStatement(TODO_BLOCK), isOverride)?.let(::getter)
         }
@@ -783,9 +782,6 @@ private val Flags.modalities: Set<KModifier>
       add(SEALED)
     }
   }
-
-@KotlinPoetMetadataPreview
-private inline val ImmutableKmProperty.canHaveGetterBody: Boolean get() = !(isVal && hasConstant)
 
 private inline fun <E> setOf(body: MutableSet<E>.() -> Unit): Set<E> {
   return mutableSetOf<E>().apply(body).toSet()

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -21,7 +21,6 @@ import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget
 import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.FunSpec.Builder
@@ -56,7 +55,6 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.asClassName
-import com.squareup.kotlinpoet.joinToCode
 import com.squareup.kotlinpoet.metadata.ImmutableKmClass
 import com.squareup.kotlinpoet.metadata.ImmutableKmConstructor
 import com.squareup.kotlinpoet.metadata.ImmutableKmFunction
@@ -71,7 +69,6 @@ import com.squareup.kotlinpoet.metadata.PropertyAccessorFlag.IS_EXTERNAL
 import com.squareup.kotlinpoet.metadata.PropertyAccessorFlag.IS_INLINE
 import com.squareup.kotlinpoet.metadata.PropertyAccessorFlag.IS_NOT_DEFAULT
 import com.squareup.kotlinpoet.metadata.declaresDefaultValue
-import com.squareup.kotlinpoet.metadata.hasAnnotations
 import com.squareup.kotlinpoet.metadata.hasConstant
 import com.squareup.kotlinpoet.metadata.hasGetter
 import com.squareup.kotlinpoet.metadata.hasSetter
@@ -215,6 +212,9 @@ private fun ImmutableKmClass.toTypeSpec(
       '$' // Drop any enclosing classes, e.g. "MyClass$"
   )
   val jvmInternalName = name.jvmInternalName
+
+  val classData = elementHandler?.classData(jvmInternalName, parentName, simpleName)
+
   val builder = when {
     isAnnotation -> TypeSpec.annotationBuilder(simpleName)
     isCompanionObject -> TypeSpec.companionObjectBuilder(companionObjectName(simpleName))
@@ -290,7 +290,7 @@ private fun ImmutableKmClass.toTypeSpec(
     val primaryConstructorParams = mutableMapOf<String, ParameterSpec>()
     if (isClass || isAnnotation || isEnum) {
       primaryConstructor?.let {
-        it.toFunSpec(classTypeParamsResolver, it.annotations(jvmInternalName, elementHandler), jvmInternalName, elementHandler)
+        it.toFunSpec(classTypeParamsResolver, classData?.constructors?.getValue(it))
             .also { spec ->
               val finalSpec = if (isEnum && spec.annotations.isEmpty()) {
                 // Metadata specifies the constructor as private, but that's implicit so we can omit it
@@ -302,7 +302,7 @@ private fun ImmutableKmClass.toTypeSpec(
       }
       constructors.filter { !it.isPrimary }.takeIf { it.isNotEmpty() }?.let { secondaryConstructors ->
         builder.addFunctions(secondaryConstructors.map {
-          it.toFunSpec(classTypeParamsResolver, it.annotations(jvmInternalName, elementHandler), jvmInternalName, elementHandler)
+          it.toFunSpec(classTypeParamsResolver, classData?.constructors?.getValue(it))
         })
       }
     }
@@ -311,95 +311,14 @@ private fun ImmutableKmClass.toTypeSpec(
             .asSequence()
             .filter { it.isDeclaration }
             .filterNot { it.isSynthesized }
-            .map { property ->
-              val annotations = LinkedHashSet<AnnotationSpec>()
-              var constant: CodeBlock? = null
-              var isOverride = false
-              if (elementHandler != null) {
-                if (property.hasAnnotations) {
-                  annotations += property.syntheticMethodForAnnotations?.let {
-                    elementHandler.methodAnnotations(jvmInternalName, it)
-                  }.orEmpty()
-                }
-                val isJvmField: Boolean
-                if (property.getterSignature == null &&
-                    property.setterSignature == null &&
-                    property.fieldSignature != null &&
-                    !property.isConst) {
-                  if (elementHandler.supportsNonRuntimeRetainedAnnotations && !isCompanionObject) {
-                    // Throwaway value as this kind of element handler should be automatically be
-                    // picking up the jvm field annotation.
-                    //
-                    // We don't do this for companion object fields though as they appear to not
-                    // have the JvmField annotation copied over though
-                    //
-                    isJvmField = false
-                  } else {
-                    isJvmField = true
-                    annotations += AnnotationSpec.builder(JVM_FIELD).build()
-                  }
-                } else {
-                  isJvmField = false
-                }
-                property.fieldSignature?.let { fieldSignature ->
-                  annotations += elementHandler.fieldAnnotations(jvmInternalName, fieldSignature)
-                      .map { it.toBuilder().useSiteTarget(UseSiteTarget.FIELD).build() }
-                  annotations += elementHandler.fieldJvmModifiers(jvmInternalName, fieldSignature, isJvmField)
-                      .map { it.annotationSpec() }
-                  if (isCompanionObject && parentName != null) {
-                    // These are copied into the parent
-                    annotations += elementHandler.fieldJvmModifiers(parentName, fieldSignature, isJvmField)
-                        .map { it.annotationSpec() }
-                  }
-                  if (!(isCompanionObject && (property.isConst ||
-                          annotations.any { it.className == JVM_STATIC || it.className == JVM_FIELD })) &&
-                      elementHandler.isFieldSynthetic(jvmInternalName, fieldSignature)) {
-                    // For static, const, or JvmField fields in a companion object, the companion
-                    // object's field is marked as synthetic to hide it from Java, but in this case
-                    // it's a false positive for this check in kotlin.
-                    annotations += AnnotationSpec.builder(JVM_SYNTHETIC)
-                        .useSiteTarget(UseSiteTarget.FIELD)
-                        .build()
-                  }
-                  if (property.hasConstant) {
-                    constant = if (isCompanionObject && parentName != null) {
-                      if (elementHandler.classFor(parentName).isInterface) {
-                        elementHandler.fieldConstant(jvmInternalName, fieldSignature)
-                      } else {
-                        // const properties are relocated to the enclosing class
-                        elementHandler.fieldConstant(parentName, fieldSignature)
-                      }
-                    } else {
-                      elementHandler.fieldConstant(jvmInternalName, fieldSignature)
-                    }
-                  }
-                }
+            .map { it to classData?.properties?.get(it) }
+            .map { (property, propertyData) ->
+              val annotations = mutableListOf<AnnotationSpec>()
+              if (propertyData != null) {
                 if (property.hasGetter && property.canHaveGetterBody) {
                   property.getterSignature?.let { getterSignature ->
-                    if (!isOverride) {
-                      isOverride = elementHandler.isMethodOverride(jvmInternalName, getterSignature)
-                    }
-                    if (property.getterFlags.hasAnnotations) {
-                      annotations += elementHandler.methodAnnotations(jvmInternalName,
-                          getterSignature)
-                          .map { it.toBuilder().useSiteTarget(UseSiteTarget.GET).build() }
-                    }
-                    annotations += elementHandler.methodJvmModifiers(jvmInternalName,
-                        getterSignature)
-                        .map {
-                          it.annotationSpec().toBuilder().useSiteTarget(UseSiteTarget.GET).build()
-                        }
-                    if (elementHandler.isMethodSynthetic(jvmInternalName, getterSignature)) {
-                      annotations += AnnotationSpec.builder(JvmSynthetic::class)
-                          .useSiteTarget(UseSiteTarget.GET)
-                          .build()
-                    }
-                    if (isCompanionObject && parentName != null) {
-                      // These are copied into the parent
-                      annotations += elementHandler.methodJvmModifiers(jvmInternalName, getterSignature)
-                          .map { it.annotationSpec() }
-                    }
-                    if (!isInterface && !elementHandler.supportsNonRuntimeRetainedAnnotations) {
+                    if (!isInterface &&
+                        elementHandler?.supportsNonRuntimeRetainedAnnotations == false) {
                       // Infer if JvmName was used
                       // We skip interface types for this because they can't have @JvmName.
                       // For annotation properties, kotlinc puts JvmName annotations by default in
@@ -417,42 +336,13 @@ private fun ImmutableKmClass.toTypeSpec(
                         annotations += jvmNameAnnotation
                       }
                     }
-                    elementHandler.methodExceptions(jvmInternalName, getterSignature, false)
-                        .takeIf { it.isNotEmpty() }
-                        ?.let { exceptions ->
-                          annotations += createThrowsSpec(exceptions, UseSiteTarget.GET)
-                        }
                   }
                 }
                 if (property.hasSetter) {
                   property.setterSignature?.let { setterSignature ->
-                    if (!isOverride) {
-                      isOverride = elementHandler.isMethodOverride(jvmInternalName, setterSignature)
-                    }
-                    if (property.setterFlags.hasAnnotations) {
-                      annotations += elementHandler.methodAnnotations(jvmInternalName,
-                          setterSignature)
-                          .map { it.toBuilder().useSiteTarget(UseSiteTarget.SET).build() }
-                    }
-                    annotations += elementHandler.methodJvmModifiers(jvmInternalName,
-                        setterSignature)
-                        .map {
-                          it.annotationSpec().toBuilder().useSiteTarget(UseSiteTarget.SET).build()
-                        }
-                    if (elementHandler.isMethodSynthetic(jvmInternalName, setterSignature)) {
-                      annotations += AnnotationSpec.builder(JvmSynthetic::class)
-                          .useSiteTarget(UseSiteTarget.SET)
-                          .build()
-                    }
-                    if (isCompanionObject && parentName != null) {
-                      // These are copied into the parent
-                      annotations += elementHandler.methodJvmModifiers(jvmInternalName,
-                          setterSignature)
-                          .map { it.annotationSpec() }
-                    }
                     if (!isAnnotation &&
                         !isInterface &&
-                        !elementHandler.supportsNonRuntimeRetainedAnnotations) {
+                        elementHandler?.supportsNonRuntimeRetainedAnnotations == false) {
                       // Infer if JvmName was used
                       // We skip annotation types for this because they can't have vars.
                       // We skip interface types for this because they can't have @JvmName.
@@ -463,20 +353,14 @@ private fun ImmutableKmClass.toTypeSpec(
                         annotations += jvmNameAnnotation
                       }
                     }
-                    elementHandler.methodExceptions(jvmInternalName, setterSignature, false)
-                        .takeIf { it.isNotEmpty() }
-                        ?.let { exceptions ->
-                          annotations += createThrowsSpec(exceptions, UseSiteTarget.SET)
-                        }
                   }
                 }
               }
               property.toPropertySpec(
                   typeParamResolver = classTypeParamsResolver,
                   isConstructorParam = property.name in primaryConstructorParams,
-                  annotations = annotations,
-                  constant = constant,
-                  isOverride = isOverride
+                  annotations = propertyData?.allAnnotations.orEmpty() + annotations,
+                  propertyData = propertyData
               )
             }
             .asIterable()
@@ -500,24 +384,13 @@ private fun ImmutableKmClass.toTypeSpec(
           .filter { it.isDeclaration }
           .filterNot { it.isDelegation }
           .filterNot { it.isSynthesized }
-          .map { func ->
+          .map { it to classData?.methods?.get(it) }
+          .map { (func, methodData) ->
             val functionTypeParamsResolver = func.typeParameters.toTypeParamsResolver(
                 fallback = classTypeParamsResolver)
-            val annotations = LinkedHashSet<AnnotationSpec>()
-            var isOverride = false
-            var isSynthetic = false
+            val annotations = methodData?.allAnnotations().orEmpty().toMutableList()
             if (elementHandler != null) {
               func.signature?.let { signature ->
-                isSynthetic = elementHandler.isMethodSynthetic(jvmInternalName, signature)
-                if (isSynthetic) {
-                  annotations += AnnotationSpec.builder(JvmSynthetic::class).build()
-                }
-                if (func.hasAnnotations) {
-                  annotations += elementHandler.methodAnnotations(jvmInternalName, signature)
-                }
-                annotations += elementHandler.methodJvmModifiers(jvmInternalName, signature)
-                    .map { it.annotationSpec() }
-                isOverride = elementHandler.isMethodOverride(jvmInternalName, signature)
                 if (!isInterface && !elementHandler.supportsNonRuntimeRetainedAnnotations) {
                   // Infer if JvmName was used
                   // We skip interface types for this because they can't have @JvmName.
@@ -525,14 +398,9 @@ private fun ImmutableKmClass.toTypeSpec(
                     annotations += jvmNameAnnotation
                   }
                 }
-                elementHandler.methodExceptions(jvmInternalName, signature, false)
-                    .takeIf { it.isNotEmpty() }
-                    ?.let { exceptions ->
-                      annotations += createThrowsSpec(exceptions)
-                    }
               }
             }
-            func.toFunSpec(functionTypeParamsResolver, annotations, isOverride, jvmInternalName, elementHandler)
+            func.toFunSpec(functionTypeParamsResolver, annotations, methodData)
                 .toBuilder()
                 .apply {
                   // For interface methods, remove any body and mark the methods as abstract
@@ -558,7 +426,7 @@ private fun ImmutableKmClass.toTypeSpec(
                     addModifiers(ABSTRACT)
                     clearBody()
                   }
-                  if (isSynthetic) {
+                  if (methodData?.isSynthetic == true) {
                     addKdoc("Note: Since this is a synthetic function, some JVM information " +
                         "(annotations, modifiers) may be missing.")
                   }
@@ -591,62 +459,26 @@ private fun ImmutableKmClass.toTypeSpec(
       .build()
 }
 
-@KotlinPoetMetadataPreview
-private fun ImmutableKmConstructor.annotations(
-  classJvmName: String,
-  elementHandler: ElementHandler?
-): List<AnnotationSpec> {
-  if (elementHandler != null) {
-    signature?.let { signature ->
-      val annotations = mutableListOf<AnnotationSpec>()
-      if (hasAnnotations) {
-        annotations += elementHandler.constructorAnnotations(classJvmName, signature)
-      }
-      elementHandler.methodExceptions(classJvmName, signature, true)
-          .takeIf { it.isNotEmpty() }
-          ?.let {
-            annotations += createThrowsSpec(it)
-          }
-      return annotations
-    }
-  }
-  return emptyList()
-}
-
 private fun companionObjectName(name: String): String? {
   return if (name == "Companion") null else name
 }
 
 @KotlinPoetMetadataPreview
-private fun ImmutableKmValueParameter.extractAnnotations(
-  elementHandler: ElementHandler?,
-  classJvmName: String,
-  jvmMethodSignature: JvmMethodSignature?,
-  index: Int,
-  isConstructorParam: Boolean
-): List<AnnotationSpec> {
-  return if (hasAnnotations && elementHandler != null && jvmMethodSignature != null) {
-    elementHandler.parameterAnnotations(classJvmName, jvmMethodSignature, index, isConstructorParam)
-  } else {
-    emptyList()
-  }
-}
-
-@KotlinPoetMetadataPreview
 private fun ImmutableKmConstructor.toFunSpec(
   typeParamResolver: ((index: Int) -> TypeName),
-  annotations: List<AnnotationSpec>,
-  classJvmName: String,
-  elementHandler: ElementHandler?
+  constructorData: ConstructorData?
 ): FunSpec {
   return FunSpec.constructorBuilder()
       .apply {
-        addAnnotations(annotations)
+        addAnnotations(constructorData?.allAnnotations.orEmpty())
         addVisibility { addModifiers(it) }
         addParameters(this@toFunSpec.valueParameters.mapIndexed { index, param ->
           param.toParameterSpec(
               typeParamResolver,
-              param.extractAnnotations(elementHandler, classJvmName, signature, index, true)
+              constructorData?.takeIf { it != ConstructorData.EMPTY }
+                  ?.parameterAnnotations
+                  ?.getValue(index)
+                  .orEmpty()
           )
         })
         if (!isPrimary) {
@@ -661,9 +493,7 @@ private fun ImmutableKmConstructor.toFunSpec(
 private fun ImmutableKmFunction.toFunSpec(
   typeParamResolver: ((index: Int) -> TypeName),
   annotations: Iterable<AnnotationSpec>,
-  isOverride: Boolean,
-  classJvmName: String,
-  elementHandler: ElementHandler?
+  methodData: MethodData?
 ): FunSpec {
   return FunSpec.builder(name)
       .apply {
@@ -673,20 +503,14 @@ private fun ImmutableKmFunction.toFunSpec(
           addParameters(valueParameters.mapIndexed { index, param ->
             param.toParameterSpec(
                 typeParamResolver,
-                param.extractAnnotations(
-                    elementHandler,
-                    classJvmName,
-                    signature,
-                    index,
-                    isConstructorParam = false
-                )
+                methodData?.parameterAnnotations?.getValue(index).orEmpty()
             )
           })
         }
         if (typeParameters.isNotEmpty()) {
           addTypeVariables(typeParameters.map { it.toTypeVariableName(typeParamResolver) })
         }
-        if (isOverride) {
+        if (methodData?.isOverride == true) {
           addModifiers(KModifier.OVERRIDE)
         }
         if (isOperator) {
@@ -752,9 +576,9 @@ private fun ImmutableKmProperty.toPropertySpec(
   typeParamResolver: ((index: Int) -> TypeName),
   isConstructorParam: Boolean,
   annotations: Iterable<AnnotationSpec>,
-  constant: CodeBlock?,
-  isOverride: Boolean
+  propertyData: PropertyData?
 ): PropertySpec {
+  val isOverride = propertyData?.isOverride ?: false
   val returnTypeName = returnType.toTypeName(typeParamResolver)
   return PropertySpec.builder(name, returnTypeName)
       .apply {
@@ -814,6 +638,7 @@ private fun ImmutableKmProperty.toPropertySpec(
           addModifiers(LATEINIT)
         }
         if (isConstructorParam || (!isDelegated && !isLateinit)) {
+          val constant = propertyData?.fieldData?.constant
           when {
             constant != null -> initializer(constant)
             isConstructorParam -> initializer(name)
@@ -957,22 +782,6 @@ private inline fun <E> setOf(body: MutableSet<E>.() -> Unit): Set<E> {
 
 private val JVM_DEFAULT = JvmDefault::class.asClassName()
 private val JVM_STATIC = JvmStatic::class.asClassName()
-private val JVM_FIELD = JvmField::class.asClassName()
-private val JVM_SYNTHETIC = JvmSynthetic::class.asClassName()
-
-private fun createThrowsSpec(
-  exceptions: Set<TypeName>,
-  useSiteTarget: UseSiteTarget? = null
-): AnnotationSpec {
-  return AnnotationSpec.builder(Throws::class)
-      .addMember(
-          "exceptionClasses = %L",
-          exceptions.map { CodeBlock.of("%T::class", it) }
-              .joinToCode(prefix = "[", suffix = "]")
-      )
-      .useSiteTarget(useSiteTarget)
-      .build()
-}
 
 private fun String.substringAfterLast(vararg delimiters: Char): String {
   val index = lastIndexOfAny(delimiters)

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/MethodData.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/MethodData.kt
@@ -7,12 +7,12 @@ import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 
 @KotlinPoetMetadataPreview
 data class MethodData(
-    private val annotations: List<AnnotationSpec>,
-    val parameterAnnotations: Map<Int, Collection<AnnotationSpec>>,
-    val isSynthetic: Boolean,
-    val jvmModifiers: Set<JvmMethodModifier>,
-    val isOverride: Boolean,
-    val exceptions: List<TypeName>
+  private val annotations: List<AnnotationSpec>,
+  val parameterAnnotations: Map<Int, Collection<AnnotationSpec>>,
+  val isSynthetic: Boolean,
+  val jvmModifiers: Set<JvmMethodModifier>,
+  val isOverride: Boolean,
+  val exceptions: List<TypeName>
 ) {
 
   fun allAnnotations(useSiteTarget: UseSiteTarget? = null): Collection<AnnotationSpec> {

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/MethodData.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/MethodData.kt
@@ -1,0 +1,52 @@
+package com.squareup.kotlinpoet.metadata.specs
+
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+
+@KotlinPoetMetadataPreview
+data class MethodData(
+    private val annotations: List<AnnotationSpec>,
+    val parameterAnnotations: Map<Int, List<AnnotationSpec>>,
+    val isSynthetic: Boolean,
+    val jvmModifiers: Set<JvmMethodModifier>,
+    val isOverride: Boolean,
+    val exceptions: List<TypeName>
+) {
+
+  fun allAnnotations(useSiteTarget: UseSiteTarget? = null): Collection<AnnotationSpec> {
+    return ElementHandler.createAnnotations(
+        useSiteTarget) {
+      addAll(annotations)
+      if (isSynthetic) {
+        add(JVM_SYNTHETIC_SPEC)
+      }
+      addAll(jvmModifiers.map { it.annotationSpec() })
+      exceptions.takeIf { it.isNotEmpty() }
+          ?.let {
+            add(ElementHandler.createThrowsSpec(it,
+                useSiteTarget))
+          }
+    }
+  }
+
+  companion object {
+    val SYNTHETIC = MethodData(
+        annotations = emptyList(),
+        parameterAnnotations = emptyMap(),
+        isSynthetic = true,
+        jvmModifiers = emptySet(),
+        isOverride = false,
+        exceptions = emptyList()
+    )
+    val EMPTY = MethodData(
+        annotations = emptyList(),
+        parameterAnnotations = emptyMap(),
+        isSynthetic = false,
+        jvmModifiers = emptySet(),
+        isOverride = false,
+        exceptions = emptyList()
+    )
+  }
+}

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/MethodData.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/MethodData.kt
@@ -8,7 +8,7 @@ import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 @KotlinPoetMetadataPreview
 data class MethodData(
     private val annotations: List<AnnotationSpec>,
-    val parameterAnnotations: Map<Int, List<AnnotationSpec>>,
+    val parameterAnnotations: Map<Int, Collection<AnnotationSpec>>,
     val isSynthetic: Boolean,
     val jvmModifiers: Set<JvmMethodModifier>,
     val isOverride: Boolean,

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/PropertyData.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/PropertyData.kt
@@ -7,11 +7,11 @@ import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 
 @KotlinPoetMetadataPreview
 data class PropertyData(
-    val annotations: List<AnnotationSpec>,
-    val fieldData: FieldData?,
-    val getterData: MethodData?,
-    val setterData: MethodData?,
-    val isJvmField: Boolean
+  val annotations: List<AnnotationSpec>,
+  val fieldData: FieldData?,
+  val getterData: MethodData?,
+  val setterData: MethodData?,
+  val isJvmField: Boolean
 ) {
   val isOverride = (getterData?.isOverride ?: false) || (setterData?.isOverride ?: false)
   val allAnnotations: Collection<AnnotationSpec> = ElementHandler.createAnnotations {

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/PropertyData.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/PropertyData.kt
@@ -1,0 +1,31 @@
+package com.squareup.kotlinpoet.metadata.specs
+
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget.GET
+import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget.SET
+import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+
+@KotlinPoetMetadataPreview
+data class PropertyData(
+    val annotations: List<AnnotationSpec>,
+    val fieldData: FieldData?,
+    val getterData: MethodData?,
+    val setterData: MethodData?,
+    val isJvmField: Boolean
+) {
+  val isOverride = (getterData?.isOverride ?: false) || (setterData?.isOverride ?: false)
+  val allAnnotations: Collection<AnnotationSpec> = ElementHandler.createAnnotations {
+    // Don't add annotations that are already defined on the parent
+    val higherScopedAnnotations = annotations.associateBy { it.className }
+    addAll(annotations)
+    addAll(fieldData?.allAnnotations.orEmpty()
+        .filterNot { it.className in higherScopedAnnotations })
+    addAll(getterData?.allAnnotations(GET).orEmpty()
+        .filterNot { it.className in higherScopedAnnotations })
+    addAll(setterData?.allAnnotations(SET).orEmpty()
+        .filterNot { it.className in higherScopedAnnotations })
+    if (isJvmField) {
+      add(JVM_FIELD_SPEC)
+    }
+  }
+}


### PR DESCRIPTION
Resolves #776 

This tries to greatly simplify the ElementHandler API by just driving everything through a single `classData()` API, where a `ClassData` object is returned with information about the class, properties, constructors, and functions. This ensures a single pass for looking up metadata information, and also revealed a number of inconsistencies in tests we were able to fix with it.

Some other things:
- annotations are now strictly ordered for better consistency and cachability
- lots of commits, but tried to make them small for reviewability
- most of the logic in reflective and elements implementations is similar
- Needs a documentation pass, but want to settle on the API first before doing so
- We could return kotlinpoet types for the new "data" types, but I'm pretty against the idea because they're a vast superset of the information we need, and it becomes hard to indicate what information needs to be provided to element handlers in that case.