### PR TITLE
Replace TODO_BLOCK stub with NOT_IMPLEMENTED

### DIFF
--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -163,13 +163,13 @@ class KotlinPoetMetadataSpecsTest(
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Properties {
-        var aList: kotlin.collections.List<kotlin.Int> = TODO("Stub!")
+        var aList: kotlin.collections.List<kotlin.Int> = throw NotImplementedError("Stub!")
 
         val bar: kotlin.String? = null
 
-        var baz: kotlin.Int = TODO("Stub!")
+        var baz: kotlin.Int = throw NotImplementedError("Stub!")
 
-        val foo: kotlin.String = TODO("Stub!")
+        val foo: kotlin.String = throw NotImplementedError("Stub!")
       }
     """.trimIndent())
   }
@@ -185,11 +185,11 @@ class KotlinPoetMetadataSpecsTest(
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Properties {
-        var aList: kotlin.collections.List<kotlin.Int> = TODO("Stub!")
+        var aList: kotlin.collections.List<kotlin.Int> = throw NotImplementedError("Stub!")
 
         val bar: kotlin.String? = null
 
-        var baz: kotlin.Int = TODO("Stub!")
+        var baz: kotlin.Int = throw NotImplementedError("Stub!")
 
         val foo: kotlin.String = ""
       }
@@ -296,7 +296,7 @@ class KotlinPoetMetadataSpecsTest(
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class SuspendTypes {
-        val testProp: suspend (kotlin.Int, kotlin.Long) -> kotlin.String = TODO("Stub!")
+        val testProp: suspend (kotlin.Int, kotlin.Long) -> kotlin.String = throw NotImplementedError("Stub!")
 
         suspend fun testComplexSuspendFun(body: suspend (kotlin.Int, suspend (kotlin.Long) -> kotlin.String) -> kotlin.String) {
         }
@@ -329,14 +329,14 @@ class KotlinPoetMetadataSpecsTest(
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Parameters {
-        inline fun hasDefault(param1: kotlin.String = TODO("Stub!")) {
+        inline fun hasDefault(param1: kotlin.String = throw NotImplementedError("Stub!")) {
         }
 
         inline fun inline(crossinline param1: () -> kotlin.String) {
         }
 
         inline fun noinline(noinline param1: () -> kotlin.String): kotlin.String {
-          TODO("Stub!")
+          throw NotImplementedError("Stub!")
         }
       }
     """.trimIndent())
@@ -388,7 +388,7 @@ class KotlinPoetMetadataSpecsTest(
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class NestedTypeAliasTest {
-        val prop: kotlin.collections.List<kotlin.collections.List<kotlin.String>> = TODO("Stub!")
+        val prop: kotlin.collections.List<kotlin.collections.List<kotlin.String>> = throw NotImplementedError("Stub!")
       }
     """.trimIndent())
   }
@@ -434,9 +434,9 @@ class KotlinPoetMetadataSpecsTest(
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       abstract class OverriddenThings : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.OverriddenThingsBase(), com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.OverriddenThingsInterface {
-        override var openProp: kotlin.String = TODO("Stub!")
+        override var openProp: kotlin.String = throw NotImplementedError("Stub!")
 
-        override var openPropInterface: kotlin.String = TODO("Stub!")
+        override var openPropInterface: kotlin.String = throw NotImplementedError("Stub!")
 
         override fun openFunction() {
         }
@@ -480,12 +480,12 @@ class KotlinPoetMetadataSpecsTest(
         /**
          * Note: delegation is ABI stub only and not guaranteed to match source code.
          */
-        val immutable: kotlin.String by kotlin.lazy { TODO("Stub!") }
+        val immutable: kotlin.String by kotlin.lazy { throw NotImplementedError("Stub!") }
 
         /**
          * Note: delegation is ABI stub only and not guaranteed to match source code.
          */
-        val immutableNullable: kotlin.String? by kotlin.lazy { TODO("Stub!") }
+        val immutableNullable: kotlin.String? by kotlin.lazy { throw NotImplementedError("Stub!") }
 
         /**
          * Note: delegation is ABI stub only and not guaranteed to match source code.
@@ -554,19 +554,19 @@ class KotlinPoetMetadataSpecsTest(
       ) {
         FOO {
           override fun toString(): kotlin.String {
-            TODO("Stub!")
+            throw NotImplementedError("Stub!")
           }
         },
 
         BAR {
           override fun toString(): kotlin.String {
-            TODO("Stub!")
+            throw NotImplementedError("Stub!")
           }
         },
 
         BAZ {
           override fun toString(): kotlin.String {
-            TODO("Stub!")
+            throw NotImplementedError("Stub!")
           }
         };
       }
@@ -598,19 +598,19 @@ class KotlinPoetMetadataSpecsTest(
     //language=kotlin
     assertThat(testInterfaceSpec.trimmedToString()).isEqualTo("""
       interface TestInterface {
-        fun complex(input: kotlin.String, input2: kotlin.String = TODO("Stub!")): kotlin.String {
-          TODO("Stub!")
+        fun complex(input: kotlin.String, input2: kotlin.String = throw NotImplementedError("Stub!")): kotlin.String {
+          throw NotImplementedError("Stub!")
         }
 
         fun hasDefault() {
         }
 
         fun hasDefaultMultiParam(input: kotlin.String, input2: kotlin.String): kotlin.String {
-          TODO("Stub!")
+          throw NotImplementedError("Stub!")
         }
 
         fun hasDefaultSingleParam(input: kotlin.String): kotlin.String {
-          TODO("Stub!")
+          throw NotImplementedError("Stub!")
         }
 
         @kotlin.jvm.JvmDefault
@@ -621,7 +621,7 @@ class KotlinPoetMetadataSpecsTest(
 
         fun noDefaultWithInput(input: kotlin.String)
 
-        fun noDefaultWithInputDefault(input: kotlin.String = TODO("Stub!"))
+        fun noDefaultWithInputDefault(input: kotlin.String = throw NotImplementedError("Stub!"))
       }
     """.trimIndent())
 
@@ -900,7 +900,7 @@ class KotlinPoetMetadataSpecsTest(
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Constants(
-        val param: kotlin.String = TODO("Stub!")
+        val param: kotlin.String = throw NotImplementedError("Stub!")
       ) {
         val binaryProp: kotlin.Int = 11
 
@@ -991,27 +991,27 @@ class KotlinPoetMetadataSpecsTest(
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Constants(
-        val param: kotlin.String = TODO("Stub!")
+        val param: kotlin.String = throw NotImplementedError("Stub!")
       ) {
-        val binaryProp: kotlin.Int = TODO("Stub!")
+        val binaryProp: kotlin.Int = throw NotImplementedError("Stub!")
 
-        val boolProp: kotlin.Boolean = TODO("Stub!")
+        val boolProp: kotlin.Boolean = throw NotImplementedError("Stub!")
 
-        val doubleProp: kotlin.Double = TODO("Stub!")
+        val doubleProp: kotlin.Double = throw NotImplementedError("Stub!")
 
-        val floatProp: kotlin.Float = TODO("Stub!")
+        val floatProp: kotlin.Float = throw NotImplementedError("Stub!")
 
-        val hexProp: kotlin.Int = TODO("Stub!")
+        val hexProp: kotlin.Int = throw NotImplementedError("Stub!")
 
-        val intProp: kotlin.Int = TODO("Stub!")
+        val intProp: kotlin.Int = throw NotImplementedError("Stub!")
 
-        val longProp: kotlin.Long = TODO("Stub!")
+        val longProp: kotlin.Long = throw NotImplementedError("Stub!")
 
-        val stringProp: kotlin.String = TODO("Stub!")
+        val stringProp: kotlin.String = throw NotImplementedError("Stub!")
 
-        val underscoresHexProp: kotlin.Long = TODO("Stub!")
+        val underscoresHexProp: kotlin.Long = throw NotImplementedError("Stub!")
 
-        val underscoresProp: kotlin.Int = TODO("Stub!")
+        val underscoresProp: kotlin.Int = throw NotImplementedError("Stub!")
 
         companion object {
           const val CONST_BINARY_PROP: kotlin.Int = 11
@@ -1269,14 +1269,14 @@ class KotlinPoetMetadataSpecsTest(
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Overloads @kotlin.jvm.JvmOverloads constructor(
         val param1: kotlin.String,
-        val optionalParam2: kotlin.String = TODO("Stub!"),
-        val nullableParam3: kotlin.String? = TODO("Stub!")
+        val optionalParam2: kotlin.String = throw NotImplementedError("Stub!"),
+        val nullableParam3: kotlin.String? = throw NotImplementedError("Stub!")
       ) {
         @kotlin.jvm.JvmOverloads
         fun testFunction(
           param1: kotlin.String,
-          optionalParam2: kotlin.String = TODO("Stub!"),
-          nullableParam3: kotlin.String? = TODO("Stub!")
+          optionalParam2: kotlin.String = throw NotImplementedError("Stub!"),
+          nullableParam3: kotlin.String? = throw NotImplementedError("Stub!")
         ) {
         }
       }
@@ -1312,7 +1312,7 @@ class KotlinPoetMetadataSpecsTest(
         val param1: kotlin.String
       ) {
         @kotlin.jvm.JvmField
-        val fieldProp: kotlin.String = TODO("Stub!")
+        val fieldProp: kotlin.String = throw NotImplementedError("Stub!")
 
         companion object {
           @kotlin.jvm.JvmField
@@ -1586,21 +1586,21 @@ class KotlinPoetMetadataSpecsTest(
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       annotation class Metadata(
         @get:kotlin.jvm.JvmName(name = "k")
-        val kind: kotlin.Int = TODO("Stub!"),
+        val kind: kotlin.Int = throw NotImplementedError("Stub!"),
         @get:kotlin.jvm.JvmName(name = "mv")
-        val metadataVersion: kotlin.IntArray = TODO("Stub!"),
+        val metadataVersion: kotlin.IntArray = throw NotImplementedError("Stub!"),
         @get:kotlin.jvm.JvmName(name = "bv")
-        val bytecodeVersion: kotlin.IntArray = TODO("Stub!"),
+        val bytecodeVersion: kotlin.IntArray = throw NotImplementedError("Stub!"),
         @get:kotlin.jvm.JvmName(name = "d1")
-        val data1: kotlin.Array<kotlin.String> = TODO("Stub!"),
+        val data1: kotlin.Array<kotlin.String> = throw NotImplementedError("Stub!"),
         @get:kotlin.jvm.JvmName(name = "d2")
-        val data2: kotlin.Array<kotlin.String> = TODO("Stub!"),
+        val data2: kotlin.Array<kotlin.String> = throw NotImplementedError("Stub!"),
         @get:kotlin.jvm.JvmName(name = "xs")
-        val extraString: kotlin.String = TODO("Stub!"),
+        val extraString: kotlin.String = throw NotImplementedError("Stub!"),
         @get:kotlin.jvm.JvmName(name = "pn")
-        val packageName: kotlin.String = TODO("Stub!"),
+        val packageName: kotlin.String = throw NotImplementedError("Stub!"),
         @get:kotlin.jvm.JvmName(name = "xi")
-        val extraInt: kotlin.Int = TODO("Stub!")
+        val extraInt: kotlin.Int = throw NotImplementedError("Stub!")
       )
       """.trimIndent())
   }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -178,7 +178,7 @@ fun ImmutableKmClass.toFileSpec(
   )
 }
 
-private const val TODO_BLOCK = "TODO(\"Stub!\")"
+private const val NOT_IMPLEMENTED = "throw·NotImplementedError(\"Stub!\")"
 
 @KotlinPoetMetadataPreview
 private fun List<ImmutableKmTypeParameter>.toTypeParamsResolver(
@@ -547,7 +547,7 @@ private fun ImmutableKmFunction.toFunSpec(
         val returnTypeName = this@toFunSpec.returnType.toTypeName(typeParamResolver)
         if (returnTypeName != UNIT) {
           returns(returnTypeName)
-          addStatement(TODO_BLOCK)
+          addStatement(NOT_IMPLEMENTED)
         }
         receiverParameterType?.toTypeName(typeParamResolver)?.let { receiver(it) }
       }
@@ -574,7 +574,7 @@ private fun ImmutableKmValueParameter.toParameterSpec(
           addModifiers(NOINLINE)
         }
         if (declaresDefaultValue) {
-          defaultValue(TODO_BLOCK)
+          defaultValue(NOT_IMPLEMENTED)
         }
       }
       .tag(this)
@@ -628,7 +628,7 @@ private fun ImmutableKmProperty.toPropertySpec(
           // Placeholders for these are tricky
           addKdoc("Note: delegation is ABI stub only and not guaranteed to match source code.")
           if (isVal) {
-            delegate("%M { %L }", MemberName("kotlin", "lazy"), TODO_BLOCK) // Placeholder
+            delegate("%M { %L }", MemberName("kotlin", "lazy"), NOT_IMPLEMENTED) // Placeholder
           } else {
             if (returnTypeName.isNullable) {
               delegate("%T.observable(null) { _, _, _ -> }",
@@ -653,7 +653,7 @@ private fun ImmutableKmProperty.toPropertySpec(
             constant != null -> initializer(constant)
             isConstructorParam -> initializer(name)
             returnTypeName.isNullable -> initializer("null")
-            else -> initializer(TODO_BLOCK)
+            else -> initializer(NOT_IMPLEMENTED)
           }
         }
         // Delegated properties have setters/getters defined for some reason, ignore here
@@ -662,7 +662,7 @@ private fun ImmutableKmProperty.toPropertySpec(
         val modifierSet = modifiers.toSet()
         if (hasGetter && !isDelegated) {
           propertyAccessor(modifierSet, getterFlags,
-              FunSpec.getterBuilder().addStatement(TODO_BLOCK), isOverride)?.let(::getter)
+              FunSpec.getterBuilder().addStatement(NOT_IMPLEMENTED), isOverride)?.let(::getter)
         }
         if (hasSetter && !isDelegated) {
           propertyAccessor(modifierSet, setterFlags, FunSpec.setterBuilder(), isOverride)?.let(::setter)


### PR DESCRIPTION
This replaces the TODO() placeholders in returned specs with a more correct (and less noisy in the IDE) `throw NotImplementedError("Stub!")`. I think this is a better approach to the code as it makes it clear it's just not implemented period, rather than possibly not implemented "yet".

No type token needed since it's a top-level type.