### PR TITLE
Proposal: always name annotation members

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -21,7 +21,6 @@ import javax.lang.model.element.AnnotationMirror
 import javax.lang.model.element.AnnotationValue
 import javax.lang.model.element.TypeElement
 import javax.lang.model.element.VariableElement
-import javax.lang.model.type.ArrayType
 import javax.lang.model.type.TypeMirror
 import javax.lang.model.util.SimpleAnnotationValueVisitor7
 import kotlin.reflect.KClass
@@ -191,10 +190,7 @@ class AnnotationSpec private constructor(
             }
           }
           val member = CodeBlock.builder()
-          val shouldNameMember = method.name != "value" || method.returnType.isArray
-          if (shouldNameMember) {
-            member.add("%L = ", method.name)
-          }
+          member.add("%L = ", method.name)
           if (value.javaClass.isArray) {
             member.add("[⇥⇥")
             for (i in 0 until Array.getLength(value)) {
@@ -226,10 +222,7 @@ class AnnotationSpec private constructor(
         val member = CodeBlock.builder()
         val visitor = Visitor(member)
         val name = executableElement.simpleName.toString()
-        val shouldNameMember = name != "value" || executableElement.returnType is ArrayType
-        if (shouldNameMember) {
-          member.add("%L = ", name)
-        }
+        member.add("%L = ", name)
         val value = annotation.elementValues[executableElement]!!
         value.accept(visitor, name)
         builder.addMember(member.build())

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
@@ -18,10 +18,10 @@ package com.squareup.kotlinpoet
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.compile.CompilationRule
 import org.junit.Rule
-import kotlin.test.Test
 import java.lang.annotation.Inherited
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.reflect.KClass
+import kotlin.test.Test
 
 class AnnotationSpecTest {
 
@@ -110,7 +110,7 @@ class AnnotationSpecTest {
         |  m = [9, 8, 1],
         |  l = Override::class,
         |  j = AnnotationSpecTest.AnnotationA(),
-        |  q = AnnotationSpecTest.AnnotationC("bar"),
+        |  q = AnnotationSpecTest.AnnotationC(value = "bar"),
         |  r = [Float::class, Double::class]
         |)
         |class Taco
@@ -138,7 +138,7 @@ class AnnotationSpecTest {
         |  m = [9, 8, 1],
         |  l = Override::class,
         |  j = AnnotationSpecTest.AnnotationA(),
-        |  q = AnnotationSpecTest.AnnotationC("bar"),
+        |  q = AnnotationSpecTest.AnnotationC(value = "bar"),
         |  r = [Float::class, Double::class]
         |)
         |class IsAnnotated
@@ -178,7 +178,7 @@ class AnnotationSpecTest {
         |  m = [9, 8, 1],
         |  o = AnnotationSpecTest.Breakfast.PANCAKES,
         |  p = 1701,
-        |  q = AnnotationSpecTest.AnnotationC("bar"),
+        |  q = AnnotationSpecTest.AnnotationC(value = "bar"),
         |  r = [Float::class, Double::class]
         |)
         |class Taco
@@ -214,7 +214,7 @@ class AnnotationSpecTest {
         |  n = [AnnotationSpecTest.Breakfast.WAFFLES, AnnotationSpecTest.Breakfast.PANCAKES],
         |  o = AnnotationSpecTest.Breakfast.PANCAKES,
         |  p = 1701,
-        |  q = AnnotationSpecTest.AnnotationC("bar"),
+        |  q = AnnotationSpecTest.AnnotationC(value = "bar"),
         |  r = [Float::class, Double::class]
         |)
         |class Taco


### PR DESCRIPTION
`value` seems like a holdover from JavaPoet, and actually carries no special meaning in kotlin sources. This would break if a member named `value` was present at the not-first index