### PR TITLE
Use ClassName directly in ElementHandler API for simpler name management

### DIFF
--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1662,6 +1662,27 @@ class KotlinPoetMetadataSpecsTest(
   }
 
   @IgnoreForHandlerType(
+      reason = "compile-testing can't handle class names with dashes, will throw " +
+          "\"class file for com.squareup.kotlinpoet.metadata.specs.test.Fuzzy\$ClassNesting\$-Nested not found\"",
+      handlerType = ELEMENTS
+  )
+  @Test
+  fun classNamesAndNesting_pathological() {
+    // Make sure we parse class names correctly at all levels
+    val typeSpec = `Fuzzy$ClassNesting`::class.toTypeSpecWithTestHandler()
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class Fuzzy${'$'}ClassNesting {
+        class `-Nested` {
+          class SuperNestedClass {
+            inner class `-${'$'}Fuzzy${'$'}Super${'$'}Weird-Nested${'$'}Name`
+          }
+        }
+      }
+      """.trimIndent())
+  }
+
+  @IgnoreForHandlerType(
       reason = "Property site-target annotations are always stored on the synthetic annotations " +
           "method, which is not accessible in the elements API",
       handlerType = ELEMENTS
@@ -1764,6 +1785,14 @@ class ClassNesting {
   class NestedClass {
     class SuperNestedClass {
       inner class SuperDuperInnerClass
+    }
+  }
+}
+
+class `Fuzzy$ClassNesting` {
+  class `-Nested` {
+    class SuperNestedClass {
+      inner class `-$Fuzzy$Super$Weird-Nested$Name`
     }
   }
 }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ClassData.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ClassData.kt
@@ -1,6 +1,7 @@
 package com.squareup.kotlinpoet.metadata.specs
 
 import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.metadata.ImmutableKmClass
 import com.squareup.kotlinpoet.metadata.ImmutableKmConstructor
 import com.squareup.kotlinpoet.metadata.ImmutableKmFunction
@@ -13,8 +14,7 @@ import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
  *
  * @property kmClass the [ImmutableKmClass] as parsed from the class's [@Metadata][Metadata]
  *           annotation.
- * @property simpleName the simple name of the class. This is important to specify when possible
- *           since Kotlin allows for classes to contain characters like `$` or `-`.
+ * @property className the KotlinPoet [ClassName] of the class.
  * @property annotations declared annotations on this class.
  * @property properties the mapping of [kmClass]'s properties to parsed [PropertyData].
  * @property constructors the mapping of [kmClass]'s constructors to parsed [ConstructorData].
@@ -23,7 +23,7 @@ import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 @KotlinPoetMetadataPreview
 data class ClassData(
   val kmClass: ImmutableKmClass,
-  val simpleName: String,
+  val className: ClassName,
   val annotations: Collection<AnnotationSpec>,
   val properties: Map<ImmutableKmProperty, PropertyData>,
   val constructors: Map<ImmutableKmConstructor, ConstructorData>,

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ElementHandler.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.kotlinpoet.metadata.specs
 
+import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.metadata.ImmutableKmClass
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 import kotlinx.metadata.jvm.JvmMethodSignature
@@ -33,88 +34,61 @@ interface ElementHandler {
   val supportsNonRuntimeRetainedAnnotations: Boolean
 
   /**
-   * Creates a new [ClassData] instance for a given [classJvmName].
+   * Creates a new [ClassData] instance for a given [className].
    *
-   * @param classJvmName the jvm name of the target class to to read from.
-   * @param parentName the parent class JVM name if [classJvmName] is nested, inner, or is a
+   * @param className the [ClassName] of the target class to to read from.
+   * @param parentClassName the parent [ClassName] name if [className] is nested, inner, or is a
    *        companion object.
-   * @param simpleName the simple name of the class. This is important to specify when since Kotlin
-   *        allows for classes to contain characters like `$` or `-`.
    */
-  fun classData(classJvmName: String, parentName: String?, simpleName: String): ClassData {
-    return classData(classFor(classJvmName), parentName, simpleName)
+  fun classData(className: ClassName, parentClassName: ClassName?): ClassData {
+    return classData(classFor(className), className, parentClassName)
   }
 
   /**
    * Creates a new [ClassData] instance for a given [kmClass].
    *
    * @param kmClass the source [ImmutableKmClass] to read from.
-   * @param parentName the parent class JVM name if [kmClass] is nested, inner, or is a companion
-   *        object.
-   * @param simpleName the simple name of the class. This is important to specify when possible
-   *        since Kotlin allows for classes to contain characters like `$` or `-`. The default is
-   *        a best-effort inference.
+   * @param className the [ClassName] of the target class to to read from.
+   * @param parentClassName the parent [ClassName] name if [kmClass] is nested, inner, or is a
+   *        companion object.
    */
-  fun classData(
-    kmClass: ImmutableKmClass,
-    parentName: String?,
-    simpleName: String = kmClass.bestGuessSimpleName()
-  ): ClassData
+  fun classData(kmClass: ImmutableKmClass, className: ClassName, parentClassName: ClassName?): ClassData
 
   /**
    * Looks up other classes, such as for nested members. Note that this class would always be
    * Kotlin, so Metadata can be relied on for this.
    *
-   * @param jvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param className The [ClassName] representation of the class.
    * @return the read [ImmutableKmClass] from its metadata. If no class was found, this should throw
    *         an exception.
    */
-  fun classFor(jvmName: String): ImmutableKmClass
+  fun classFor(className: ClassName): ImmutableKmClass
 
   /**
    * Looks up a class and returns whether or not it is an interface. Note that this class can be
    * Java or Kotlin, so Metadata should not be relied on for this.
    *
-   * @param jvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param className The [ClassName] representation of the class.
    * @return whether or not it is an interface.
    */
-  fun isInterface(jvmName: String): Boolean
+  fun isInterface(className: ClassName): Boolean
 
   /**
    * Looks up the enum entry on a given enum given its member name.
    *
-   * @param enumClassJvmName The JVM name of the enum class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param enumClassName The [ClassName] representation of the enum class.
    * @param memberName The simple member name.
    * @return the read [ImmutableKmClass] from its metadata, if any. For simple enum members with no
    *         class bodies, this should always be null.
    */
-  fun enumEntry(enumClassJvmName: String, memberName: String): ImmutableKmClass?
+  fun enumEntry(enumClassName: ClassName, memberName: String): ImmutableKmClass?
 
   /**
-   * Looks up if a given [methodSignature] within [classJvmName] exists.
+   * Looks up if a given [methodSignature] within [className] exists.
    *
-   * @param classJvmName The JVM name of the class (example: `"org/foo/bar/Baz$Nested"`).
+   * @param className The [ClassName] representation of the class.
    * @param methodSignature The method signature to check.
    * @return whether or not the method exists.
    */
-  fun methodExists(classJvmName: String, methodSignature: JvmMethodSignature): Boolean
-
-  companion object {
-
-    // Top-level: package/of/class/MyClass
-    // Nested A:  package/of/class/MyClass.InnerClass
-    // Nested B:  package/of/class/MyClass$InnerClass
-    private fun ImmutableKmClass.bestGuessSimpleName(): String {
-      return name.substringAfterLast(
-          '/', // Drop the package name, e.g. "package/of/class/"
-          '.', // Drop any enclosing classes, e.g. "MyClass."
-          '$' // Drop any enclosing classes, e.g. "MyClass$"
-      )
-    }
-
-    private fun String.substringAfterLast(vararg delimiters: Char): String {
-      val index = lastIndexOfAny(delimiters)
-      return if (index == -1) this else substring(index + 1, length)
-    }
-  }
+  fun methodExists(className: ClassName, methodSignature: JvmMethodSignature): Boolean
 }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/ElementHandlerUtil.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/ElementHandlerUtil.kt
@@ -3,8 +3,22 @@ package com.squareup.kotlinpoet.metadata.specs.internal
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget
 import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget.FIELD
+import com.squareup.kotlinpoet.CHAR_SEQUENCE
+import com.squareup.kotlinpoet.COLLECTION
+import com.squareup.kotlinpoet.COMPARABLE
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.ITERABLE
+import com.squareup.kotlinpoet.LIST
+import com.squareup.kotlinpoet.MAP
+import com.squareup.kotlinpoet.MAP_ENTRY
+import com.squareup.kotlinpoet.MUTABLE_COLLECTION
+import com.squareup.kotlinpoet.MUTABLE_ITERABLE
+import com.squareup.kotlinpoet.MUTABLE_LIST
+import com.squareup.kotlinpoet.MUTABLE_MAP
+import com.squareup.kotlinpoet.MUTABLE_MAP_ENTRY
+import com.squareup.kotlinpoet.MUTABLE_SET
+import com.squareup.kotlinpoet.SET
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.joinToCode
@@ -31,20 +45,20 @@ object ElementHandlerUtil {
   )
 
   val KOTLIN_INTRINSIC_INTERFACES = setOf(
-      "kotlin.CharSequence",
-      "kotlin.Comparable",
-      "kotlin.collections.Iterable",
-      "kotlin.collections.Collection",
-      "kotlin.collections.List",
-      "kotlin.collections.Set",
-      "kotlin.collections.Map",
-      "kotlin.collections.Map.Entry",
-      "kotlin.collections.MutableIterable",
-      "kotlin.collections.MutableCollection",
-      "kotlin.collections.MutableList",
-      "kotlin.collections.MutableSet",
-      "kotlin.collections.MutableMap",
-      "kotlin.collections.MutableMap.Entry"
+      CHAR_SEQUENCE,
+      COMPARABLE,
+      ITERABLE,
+      COLLECTION,
+      LIST,
+      SET,
+      MAP,
+      MAP_ENTRY,
+      MUTABLE_ITERABLE,
+      MUTABLE_COLLECTION,
+      MUTABLE_LIST,
+      MUTABLE_SET,
+      MUTABLE_MAP,
+      MUTABLE_MAP_ENTRY
   )
 
   private val KOTLIN_NULLABILITY_ANNOTATIONS = setOf(


### PR DESCRIPTION
In trying to improve handling of weirder kotlin class names, it occurred to me that `ClassName` has all the information we could want for a class name, and we can just pass this directly in the API rather than a jvm internal name and leaving `ElementHandler` implementers to parse the information they need out of it. This also ends up solving our fuzzy name problem and makes the bestGuess handling when we don't know the ClassName already much more accurate.

Note: tests will fail until #790 merges and this is rebased