### PR TITLE
Fix empty simple name string in classname best guessing

### DIFF
--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/ClassInspectorUtil.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/ClassInspectorUtil.kt
@@ -172,7 +172,14 @@ object ClassInspectorUtil {
         .removeSuffix(".") // Trailing "." if any
         .removePrefix(packageName)
         .removePrefix("/")
-        .split(".")
+        .let {
+          if (it.isNotEmpty()) {
+            it.split(".")
+          } else {
+            // Don't split, otherwise we end up with an empty string as the first element!
+            emptyList()
+          }
+        }
         .plus(simpleName)
 
     return ClassName(

--- a/kotlinpoet-metadata-specs/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/ClassInspectorUtilTest.kt
+++ b/kotlinpoet-metadata-specs/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/ClassInspectorUtilTest.kt
@@ -55,6 +55,15 @@ class ClassInspectorUtilTest {
         .isEqualTo(ClassName("", "ClassWithNoPackage"))
   }
 
+  // Regression test for avoiding https://github.com/square/kotlinpoet/issues/795
+  @Test fun bestGuess_noEmptyNames() {
+    val noPackage = ClassInspectorUtil.bestGuessClassName("ClassWithNoPackage")
+    assertThat(noPackage.simpleNames.any { it.isEmpty() }).isFalse()
+
+    val withPackage = ClassInspectorUtil.bestGuessClassName("path/to/ClassWithNoPackage")
+    assertThat(withPackage.simpleNames.any { it.isEmpty() }).isFalse()
+  }
+
   @Test fun throwsSpec_normal() {
     assertThat(ClassInspectorUtil.createThrowsSpec(listOf(Exception::class.asClassName())))
         .isEqualTo(AnnotationSpec.builder(Throws::class.asClassName())


### PR DESCRIPTION
This would result in returning `mypackage..Taco` (with package) or `.Taco` (with no package) when requesting the `canonicalName`.

I think there's a larger problem in ClassName's handling of this, but filed that separately in https://github.com/square/kotlinpoet/issues/795