### PR TITLE
Use full package for shading auto-common

### DIFF
--- a/kotlinpoet-classinspector-elements/shading-config.gradle
+++ b/kotlinpoet-classinspector-elements/shading-config.gradle
@@ -26,9 +26,9 @@ shadowJar {
   minimize()
   classifier = ''
   configurations = [shadedConfig]
-  relocate 'com.google.auto.common', 'kotlinpoet.classinspector.elements.shaded.com.google.auto.common'
-  relocate 'com.google.common', 'kotlinpoet.classinspector.elements.shaded.com.google.common'
-  relocate 'com.google.thirdparty', 'kotlinpoet.classinspector.elements.shaded.com.google.thirdparty'
+  relocate 'com.google.auto.common', 'com.squareup.kotlinpoet.classinspector.elements.shaded.com.google.auto.common'
+  relocate 'com.google.common', 'com.squareup.kotlinpoet.classinspector.elements.shaded.com.google.common'
+  relocate 'com.google.thirdparty', 'com.squareup.kotlinpoet.classinspector.elements.shaded.com.google.thirdparty'
   exclude 'afu/**'
   exclude 'org/**'
   exclude 'com/google/errorprone/annotations/**'


### PR DESCRIPTION
This way if someone shades com.squareup.kotlinpoet.classinspector.elements, it also shades all the (already-shaded) parts