### PR TITLE
Read type annotations from metadata

### DIFF
--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -44,6 +44,8 @@ import org.junit.runners.Parameterized
 import org.junit.runners.model.Statement
 import java.lang.annotation.Inherited
 import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.TYPE
+import kotlin.annotation.AnnotationTarget.TYPE_PARAMETER
 import kotlin.properties.Delegates
 import kotlin.reflect.KClass
 import kotlin.test.fail
@@ -1779,6 +1781,36 @@ class KotlinPoetMetadataSpecsTest(
   @BinaryCustomClassAnnotation("Binary")
   @RuntimeCustomClassAnnotation("Runtime")
   class ClassAnnotations
+
+  @Test
+  fun typeAnnotations() {
+    val typeSpec = TypeAnnotations::class.toTypeSpecWithTestHandler()
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      class TypeAnnotations {
+        val foo: kotlin.collections.List<@com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.String> = throw NotImplementedError("Stub!")
+      
+        fun <T> bar(input: @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.String, input2: @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation (@com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.Int) -> @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.String) {
+        }
+      }
+      """.trimIndent()
+    )
+  }
+
+  @Target(TYPE, TYPE_PARAMETER)
+  annotation class TypeAnnotation
+
+  class TypeAnnotations {
+    val foo: List<@TypeAnnotation String> = emptyList()
+
+    fun <@TypeAnnotation T> bar(
+        input: @TypeAnnotation String,
+        // TODO Needless parens below necessary until Kotlin 1.3.60
+        //  https://youtrack.jetbrains.com/issue/KT-31734
+        input2: @TypeAnnotation() (@TypeAnnotation Int) -> @TypeAnnotation String
+    ) {
+    }
+  }
 }
 
 class ClassNesting {

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1789,7 +1789,7 @@ class KotlinPoetMetadataSpecsTest(
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class TypeAnnotations {
         val foo: kotlin.collections.List<@com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.String> = throw NotImplementedError("Stub!")
-      
+
         fun <T> bar(input: @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.String, input2: @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation (@com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.Int) -> @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.String) {
         }
       }
@@ -1804,10 +1804,10 @@ class KotlinPoetMetadataSpecsTest(
     val foo: List<@TypeAnnotation String> = emptyList()
 
     fun <@TypeAnnotation T> bar(
-        input: @TypeAnnotation String,
+      input: @TypeAnnotation String,
         // TODO Needless parens below necessary until Kotlin 1.3.60
         //  https://youtrack.jetbrains.com/issue/KT-31734
-        input2: @TypeAnnotation() (@TypeAnnotation Int) -> @TypeAnnotation String
+      input2: @TypeAnnotation() (@TypeAnnotation Int) -> @TypeAnnotation String
     ) {
     }
   }

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1805,7 +1805,8 @@ class KotlinPoetMetadataSpecsTest(
 
     fun <@TypeAnnotation T> bar(
       input: @TypeAnnotation String,
-        // TODO Needless parens below necessary until Kotlin 1.3.60
+        // TODO Needless parens below necessary until Kotlin 1.4
+        //  Or enable -XXLanguage:+NonParenthesizedAnnotationsOnFunctionalTypes
         //  https://youtrack.jetbrains.com/issue/KT-31734
       input2: @TypeAnnotation() (@TypeAnnotation Int) -> @TypeAnnotation String
     ) {

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmAnnotations.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmAnnotations.kt
@@ -4,6 +4,7 @@ import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.joinToCode
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+import com.squareup.kotlinpoet.metadata.specs.internal.ClassInspectorUtil.bestGuessClassName
 import kotlinx.metadata.KmAnnotation
 import kotlinx.metadata.KmAnnotationArgument
 import kotlinx.metadata.KmAnnotationArgument.AnnotationValue
@@ -27,7 +28,7 @@ import kotlinx.metadata.KmAnnotationArgument.UShortValue
 
 @KotlinPoetMetadataPreview
 internal fun KmAnnotation.toAnnotationSpec(): AnnotationSpec {
-  val cn = ClassInspectorUtil.bestGuessClassName(className)
+  val cn = bestGuessClassName(className)
   return AnnotationSpec.builder(cn)
       .apply {
         arguments.forEach { (name, arg) ->
@@ -40,21 +41,21 @@ internal fun KmAnnotation.toAnnotationSpec(): AnnotationSpec {
 @KotlinPoetMetadataPreview
 internal fun KmAnnotationArgument<*>.toCodeBlock(): CodeBlock {
   return when (this) {
-    is ByteValue -> CodeBlock.of("%L.toByte()", value)
-    is CharValue -> CodeBlock.of("%L.toChar()", value)
-    is ShortValue -> CodeBlock.of("%L.toShort()", value)
+    is ByteValue -> CodeBlock.of("%L", value)
+    is CharValue -> CodeBlock.of("'%L'", value)
+    is ShortValue -> CodeBlock.of("%L", value)
     is IntValue -> CodeBlock.of("%L", value)
     is LongValue -> CodeBlock.of("%LL", value)
     is FloatValue -> CodeBlock.of("%LF", value)
-    is DoubleValue -> CodeBlock.of("%LF.toDouble()", value)
+    is DoubleValue -> CodeBlock.of("%L", value)
     is BooleanValue -> CodeBlock.of("%L", value)
-    is UByteValue -> CodeBlock.of("%Lu.toUByte()", value)
-    is UShortValue -> CodeBlock.of("%Lu.toUShort()", value)
+    is UByteValue -> CodeBlock.of("%Lu", value)
+    is UShortValue -> CodeBlock.of("%Lu", value)
     is UIntValue -> CodeBlock.of("%Lu", value)
     is ULongValue -> CodeBlock.of("%Lu", value)
     is StringValue -> CodeBlock.of("%S", value)
-    is KClassValue -> CodeBlock.of("%T::class", ClassInspectorUtil.bestGuessClassName(value))
-    is EnumValue -> CodeBlock.of("%T.%L", enumClassName, enumEntryName)
+    is KClassValue -> CodeBlock.of("%T::class", bestGuessClassName(value))
+    is EnumValue -> CodeBlock.of("%T.%L", bestGuessClassName(enumClassName), enumEntryName)
     is AnnotationValue -> CodeBlock.of("%L", value.toAnnotationSpec())
     is ArrayValue -> value.map { it.toCodeBlock() }.joinToCode(", ", "[", "]")
   }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmAnnotations.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmAnnotations.kt
@@ -1,0 +1,61 @@
+package com.squareup.kotlinpoet.metadata.specs.internal
+
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.joinToCode
+import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+import kotlinx.metadata.KmAnnotation
+import kotlinx.metadata.KmAnnotationArgument
+import kotlinx.metadata.KmAnnotationArgument.AnnotationValue
+import kotlinx.metadata.KmAnnotationArgument.ArrayValue
+import kotlinx.metadata.KmAnnotationArgument.BooleanValue
+import kotlinx.metadata.KmAnnotationArgument.ByteValue
+import kotlinx.metadata.KmAnnotationArgument.CharValue
+import kotlinx.metadata.KmAnnotationArgument.DoubleValue
+import kotlinx.metadata.KmAnnotationArgument.EnumValue
+import kotlinx.metadata.KmAnnotationArgument.FloatValue
+import kotlinx.metadata.KmAnnotationArgument.IntValue
+import kotlinx.metadata.KmAnnotationArgument.KClassValue
+import kotlinx.metadata.KmAnnotationArgument.LongValue
+import kotlinx.metadata.KmAnnotationArgument.ShortValue
+import kotlinx.metadata.KmAnnotationArgument.StringValue
+import kotlinx.metadata.KmAnnotationArgument.UByteValue
+import kotlinx.metadata.KmAnnotationArgument.UIntValue
+import kotlinx.metadata.KmAnnotationArgument.ULongValue
+import kotlinx.metadata.KmAnnotationArgument.UShortValue
+
+
+@KotlinPoetMetadataPreview
+internal fun KmAnnotation.toAnnotationSpec(): AnnotationSpec {
+  val cn = ClassInspectorUtil.bestGuessClassName(className)
+  return AnnotationSpec.builder(cn)
+      .apply {
+        arguments.forEach { (name, arg) ->
+          addMember("%L = %L", name, arg.toCodeBlock())
+        }
+      }
+      .build()
+}
+
+@KotlinPoetMetadataPreview
+internal fun KmAnnotationArgument<*>.toCodeBlock(): CodeBlock {
+  return when (this) {
+    is ByteValue -> CodeBlock.of("%L.toByte()", value)
+    is CharValue -> CodeBlock.of("%L.toChar()", value)
+    is ShortValue -> CodeBlock.of("%L.toShort()", value)
+    is IntValue -> CodeBlock.of("%L", value)
+    is LongValue -> CodeBlock.of("%LL", value)
+    is FloatValue -> CodeBlock.of("%LF", value)
+    is DoubleValue -> CodeBlock.of("%LF.toDouble()", value)
+    is BooleanValue -> CodeBlock.of("%L", value)
+    is UByteValue -> CodeBlock.of("%Lu.toUByte()", value)
+    is UShortValue -> CodeBlock.of("%Lu.toUShort()", value)
+    is UIntValue -> CodeBlock.of("%Lu", value)
+    is ULongValue -> CodeBlock.of("%Lu", value)
+    is StringValue -> CodeBlock.of("%S", value)
+    is KClassValue -> CodeBlock.of("%T::class", ClassInspectorUtil.bestGuessClassName(value))
+    is EnumValue -> CodeBlock.of("%T.%L", enumClassName, enumEntryName)
+    is AnnotationValue -> CodeBlock.of("%L", value.toAnnotationSpec())
+    is ArrayValue -> value.map { it.toCodeBlock() }.joinToCode(", ", "[", "]")
+  }
+}

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmAnnotations.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmAnnotations.kt
@@ -25,7 +25,6 @@ import kotlinx.metadata.KmAnnotationArgument.UIntValue
 import kotlinx.metadata.KmAnnotationArgument.ULongValue
 import kotlinx.metadata.KmAnnotationArgument.UShortValue
 
-
 @KotlinPoetMetadataPreview
 internal fun KmAnnotation.toAnnotationSpec(): AnnotationSpec {
   val cn = bestGuessClassName(className)

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmTypes.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmTypes.kt
@@ -136,7 +136,12 @@ internal fun ImmutableKmType.toTypeName(
     }
   }
 
-  return type.copy(nullable = isNullable)
+  val annotations = ClassInspectorUtil.createAnnotations {
+    for (annotation in annotations) {
+      add(annotation.toAnnotationSpec())
+    }
+  }.toList()
+  return type.copy(nullable = isNullable, annotations = annotations)
 }
 
 @KotlinPoetMetadataPreview
@@ -156,9 +161,15 @@ internal fun ImmutableKmTypeParameter.toTypeVariableName(
       bounds = upperBounds.map { it.toTypeName(typeParamResolver) },
       variance = finalVariance
   )
+  val annotations = ClassInspectorUtil.createAnnotations {
+    for (annotation in annotations) {
+      add(annotation.toAnnotationSpec())
+    }
+  }.toList()
   return typeVariableName.copy(
       reified = isReified,
-      tags = mapOf(ImmutableKmTypeParameter::class to this)
+      tags = mapOf(ImmutableKmTypeParameter::class to this),
+      annotations = annotations
   )
 }
 

--- a/kotlinpoet-metadata-specs/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmAnnotationsTest.kt
+++ b/kotlinpoet-metadata-specs/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmAnnotationsTest.kt
@@ -1,0 +1,207 @@
+package com.squareup.kotlinpoet.metadata.specs.internal
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+import kotlinx.metadata.KmAnnotation
+import kotlinx.metadata.KmAnnotationArgument.AnnotationValue
+import kotlinx.metadata.KmAnnotationArgument.ArrayValue
+import kotlinx.metadata.KmAnnotationArgument.BooleanValue
+import kotlinx.metadata.KmAnnotationArgument.ByteValue
+import kotlinx.metadata.KmAnnotationArgument.CharValue
+import kotlinx.metadata.KmAnnotationArgument.DoubleValue
+import kotlinx.metadata.KmAnnotationArgument.EnumValue
+import kotlinx.metadata.KmAnnotationArgument.FloatValue
+import kotlinx.metadata.KmAnnotationArgument.IntValue
+import kotlinx.metadata.KmAnnotationArgument.KClassValue
+import kotlinx.metadata.KmAnnotationArgument.LongValue
+import kotlinx.metadata.KmAnnotationArgument.ShortValue
+import kotlinx.metadata.KmAnnotationArgument.StringValue
+import kotlinx.metadata.KmAnnotationArgument.UByteValue
+import kotlinx.metadata.KmAnnotationArgument.UIntValue
+import kotlinx.metadata.KmAnnotationArgument.ULongValue
+import kotlinx.metadata.KmAnnotationArgument.UShortValue
+import kotlin.test.Test
+
+@KotlinPoetMetadataPreview
+class KmAnnotationsTest {
+
+  @Test fun noMembers() {
+    val annotation = KmAnnotation("test/NoMembersAnnotation", emptyMap())
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.NoMembersAnnotation
+    """.trimIndent())
+  }
+
+  @Test fun byteValue() {
+    val annotation = KmAnnotation(
+        "test/ByteValueAnnotation",
+        mapOf("value" to ByteValue(2))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.ByteValueAnnotation(value = 2)
+    """.trimIndent())
+  }
+
+  @Test fun charValue() {
+    val annotation = KmAnnotation(
+        "test/CharValueAnnotation",
+        mapOf("value" to CharValue('2'))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.CharValueAnnotation(value = '2')
+    """.trimIndent())
+  }
+
+  @Test fun shortValue() {
+    val annotation = KmAnnotation(
+        "test/ShortValueAnnotation",
+        mapOf("value" to ShortValue(2))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.ShortValueAnnotation(value = 2)
+    """.trimIndent())
+  }
+
+  @Test fun intValue() {
+    val annotation = KmAnnotation(
+        "test/IntValueAnnotation",
+        mapOf("value" to IntValue(2))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.IntValueAnnotation(value = 2)
+    """.trimIndent())
+  }
+
+  @Test fun longValue() {
+    val annotation = KmAnnotation(
+        "test/LongValueAnnotation",
+        mapOf("value" to LongValue(2L))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.LongValueAnnotation(value = 2L)
+    """.trimIndent())
+  }
+
+  @Test fun floatValue() {
+    val annotation = KmAnnotation(
+        "test/FloatValueAnnotation",
+        mapOf("value" to FloatValue(2.0F))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.FloatValueAnnotation(value = 2.0F)
+    """.trimIndent())
+  }
+
+  @Test fun doubleValue() {
+    val annotation = KmAnnotation(
+        "test/DoubleValueAnnotation",
+        mapOf("value" to DoubleValue(2.0))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.DoubleValueAnnotation(value = 2.0)
+    """.trimIndent())
+  }
+
+  @Test fun booleanValue() {
+    val annotation = KmAnnotation(
+        "test/BooleanValueAnnotation",
+        mapOf("value" to BooleanValue(true))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.BooleanValueAnnotation(value = true)
+    """.trimIndent())
+  }
+
+  @Test fun uByteValue() {
+    val annotation = KmAnnotation(
+        "test/UByteValueAnnotation",
+        mapOf("value" to UByteValue(2))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.UByteValueAnnotation(value = 2u)
+    """.trimIndent())
+  }
+
+  @Test fun uShortValue() {
+    val annotation = KmAnnotation(
+        "test/UShortValueAnnotation",
+        mapOf("value" to UShortValue(2))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.UShortValueAnnotation(value = 2u)
+    """.trimIndent())
+  }
+
+  @Test fun uIntValue() {
+    val annotation = KmAnnotation(
+        "test/UIntValueAnnotation",
+        mapOf("value" to UIntValue(2))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.UIntValueAnnotation(value = 2u)
+    """.trimIndent())
+  }
+
+  @Test fun uLongValue() {
+    val annotation = KmAnnotation(
+        "test/ULongValueAnnotation",
+        mapOf("value" to ULongValue(2))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.ULongValueAnnotation(value = 2u)
+    """.trimIndent())
+  }
+
+  @Test fun stringValue() {
+    val annotation = KmAnnotation(
+        "test/StringValueAnnotation",
+        mapOf("value" to StringValue("taco"))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.StringValueAnnotation(value = "taco")
+    """.trimIndent())
+  }
+
+  @Test fun kClassValue() {
+    val annotation = KmAnnotation(
+        "test/KClassValueAnnotation",
+        mapOf("value" to KClassValue("test/OtherClass"))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.KClassValueAnnotation(value = test.OtherClass::class)
+    """.trimIndent())
+  }
+
+  @Test fun enumValue() {
+    val annotation = KmAnnotation(
+        "test/EnumValueAnnotation",
+        mapOf("value" to EnumValue("test/OtherClass", "VALUE"))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.EnumValueAnnotation(value = test.OtherClass.VALUE)
+    """.trimIndent())
+  }
+
+  @Test fun annotationValue() {
+    val annotation = KmAnnotation(
+        "test/AnnotationValueAnnotation",
+        mapOf("value" to AnnotationValue(
+            KmAnnotation("test/OtherAnnotation", mapOf("value" to StringValue("Hello!")))
+        ))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.AnnotationValueAnnotation(value = test.OtherAnnotation(value = "Hello!"))
+    """.trimIndent())
+  }
+
+  @Test fun arrayValue() {
+    val annotation = KmAnnotation(
+        "test/ArrayValueAnnotation",
+        mapOf("value" to ArrayValue(listOf(IntValue(1), IntValue(2), IntValue(3))))
+    )
+    assertThat(annotation.toAnnotationSpec().toString()).isEqualTo("""
+      @test.ArrayValueAnnotation(value = [1, 2, 3])
+    """.trimIndent())
+  }
+
+}

--- a/kotlinpoet-metadata-specs/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmAnnotationsTest.kt
+++ b/kotlinpoet-metadata-specs/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmAnnotationsTest.kt
@@ -203,5 +203,4 @@ class KmAnnotationsTest {
       @test.ArrayValueAnnotation(value = [1, 2, 3])
     """.trimIndent())
   }
-
 }


### PR DESCRIPTION
Most of the time we can just read annotations from `ClassInspector`, but there are certain cases where the annotation is only available in metadata. Namely (per the doc): 

> annotations on type parameters and types are serialized to the Kotlin metadata.

Types can mean `KmType`, `KmTypeParameter`, and `KmTypeAlias`. We don't support KmTypeAlias -> TypeAliasSpec yet, but that'll be a different PR