### PR TITLE
Introduce ImmutableKmDeclarationContainer

### DIFF
--- a/kotlinpoet-classinspector-elements/src/main/kotlin/com/squareup/kotlinpoet/classinspector/elements/ElementsClassInspector.kt
+++ b/kotlinpoet-classinspector-elements/src/main/kotlin/com/squareup/kotlinpoet/classinspector/elements/ElementsClassInspector.kt
@@ -12,6 +12,7 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.metadata.ImmutableKmClass
+import com.squareup.kotlinpoet.metadata.ImmutableKmDeclarationContainer
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 import com.squareup.kotlinpoet.metadata.hasAnnotations
 import com.squareup.kotlinpoet.metadata.hasConstant
@@ -21,9 +22,10 @@ import com.squareup.kotlinpoet.metadata.isConst
 import com.squareup.kotlinpoet.metadata.isDeclaration
 import com.squareup.kotlinpoet.metadata.isInline
 import com.squareup.kotlinpoet.metadata.isSynthesized
+import com.squareup.kotlinpoet.metadata.readKotlinClassMetadata
 import com.squareup.kotlinpoet.metadata.specs.ClassData
-import com.squareup.kotlinpoet.metadata.specs.ConstructorData
 import com.squareup.kotlinpoet.metadata.specs.ClassInspector
+import com.squareup.kotlinpoet.metadata.specs.ConstructorData
 import com.squareup.kotlinpoet.metadata.specs.FieldData
 import com.squareup.kotlinpoet.metadata.specs.JvmFieldModifier
 import com.squareup.kotlinpoet.metadata.specs.JvmFieldModifier.TRANSIENT
@@ -38,6 +40,7 @@ import com.squareup.kotlinpoet.metadata.specs.internal.ClassInspectorUtil.filter
 import com.squareup.kotlinpoet.metadata.toImmutableKmClass
 import kotlinx.metadata.jvm.JvmFieldSignature
 import kotlinx.metadata.jvm.JvmMethodSignature
+import kotlinx.metadata.jvm.KotlinClassMetadata
 import java.util.concurrent.ConcurrentHashMap
 import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind.INTERFACE
@@ -73,9 +76,15 @@ class ElementsClassInspector private constructor(
 
   override val supportsNonRuntimeRetainedAnnotations: Boolean = true
 
-  override fun classFor(className: ClassName): ImmutableKmClass {
-    return lookupTypeElement(className)?.toImmutableKmClass() ?: error(
-        "No type element found for: $className.")
+  override fun declarationContainerFor(className: ClassName): ImmutableKmDeclarationContainer {
+    val typeElement = lookupTypeElement(className)
+        ?: error("No type element found for: $className.")
+
+    val metadata = typeElement.getAnnotation(Metadata::class.java)
+    return when (val kotlinClassMetadata = metadata.readKotlinClassMetadata()) {
+      is KotlinClassMetadata.Class -> kotlinClassMetadata.toImmutableKmClass()
+      else -> TODO("Not implemented yet: ${kotlinClassMetadata.javaClass.simpleName}")
+    }
   }
 
   override fun isInterface(className: ClassName): Boolean {
@@ -247,10 +256,14 @@ class ElementsClassInspector private constructor(
   }
 
   override fun classData(
-    kmClass: ImmutableKmClass,
+    declarationContainer: ImmutableKmDeclarationContainer,
     className: ClassName,
     parentClassName: ClassName?
   ): ClassData {
+    if (declarationContainer !is ImmutableKmClass) {
+      TODO("Not implemented yet: ${declarationContainer.javaClass.simpleName}")
+    }
+    val kmClass = declarationContainer
     val typeElement = lookupTypeElement(className)
         ?: error("No class found for: ${kmClass.name}.")
 

--- a/kotlinpoet-classinspector-elements/src/main/kotlin/com/squareup/kotlinpoet/classinspector/elements/ElementsClassInspector.kt
+++ b/kotlinpoet-classinspector-elements/src/main/kotlin/com/squareup/kotlinpoet/classinspector/elements/ElementsClassInspector.kt
@@ -451,7 +451,7 @@ class ElementsClassInspector private constructor(
     }
 
     return ClassData(
-        kmClass = kmClass,
+        declarationContainer = declarationContainer,
         className = className,
         annotations = classAnnotations,
         properties = propertyData,

--- a/kotlinpoet-classinspector-reflective/src/main/kotlin/com/squareup/kotlinpoet/classinspector/reflective/ReflectiveClassInspector.kt
+++ b/kotlinpoet-classinspector-reflective/src/main/kotlin/com/squareup/kotlinpoet/classinspector/reflective/ReflectiveClassInspector.kt
@@ -238,9 +238,9 @@ class ReflectiveClassInspector private constructor() : ClassInspector {
   }
 
   override fun classData(
-      declarationContainer: ImmutableKmDeclarationContainer,
-      className: ClassName,
-      parentClassName: ClassName?
+    declarationContainer: ImmutableKmDeclarationContainer,
+    className: ClassName,
+    parentClassName: ClassName?
   ): ClassData {
     if (declarationContainer !is ImmutableKmClass) {
       TODO("Not implemented yet: ${declarationContainer.javaClass.simpleName}")
@@ -425,7 +425,7 @@ class ReflectiveClassInspector private constructor() : ClassInspector {
     }
 
     return ClassData(
-        kmClass = kmClass,
+        declarationContainer = declarationContainer,
         className = className,
         annotations = classAnnotations,
         properties = propertyData,

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ClassData.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ClassData.kt
@@ -2,8 +2,8 @@ package com.squareup.kotlinpoet.metadata.specs
 
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.metadata.ImmutableKmClass
 import com.squareup.kotlinpoet.metadata.ImmutableKmConstructor
+import com.squareup.kotlinpoet.metadata.ImmutableKmDeclarationContainer
 import com.squareup.kotlinpoet.metadata.ImmutableKmFunction
 import com.squareup.kotlinpoet.metadata.ImmutableKmProperty
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
@@ -12,8 +12,8 @@ import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
  * Represents relevant information on a class used for [ClassInspector]. Can only ever be applied on
  * a Kotlin type (i.e. is annotated with [Metadata]).
  *
- * @property kmClass the [ImmutableKmClass] as parsed from the class's [@Metadata][Metadata]
- *           annotation.
+ * @property declarationContainer the [ImmutableKmDeclarationContainer] as parsed from the class's
+ *           [@Metadata][Metadata] annotation.
  * @property className the KotlinPoet [ClassName] of the class.
  * @property annotations declared annotations on this class.
  * @property properties the mapping of [kmClass]'s properties to parsed [PropertyData].
@@ -22,7 +22,7 @@ import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
  */
 @KotlinPoetMetadataPreview
 data class ClassData(
-  val kmClass: ImmutableKmClass,
+  val declarationContainer: ImmutableKmDeclarationContainer,
   val className: ClassName,
   val annotations: Collection<AnnotationSpec>,
   val properties: Map<ImmutableKmProperty, PropertyData>,

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ClassInspector.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ClassInspector.kt
@@ -17,6 +17,7 @@ package com.squareup.kotlinpoet.metadata.specs
 
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.metadata.ImmutableKmClass
+import com.squareup.kotlinpoet.metadata.ImmutableKmDeclarationContainer
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 import kotlinx.metadata.jvm.JvmMethodSignature
 
@@ -43,14 +44,24 @@ interface ClassInspector {
   }
 
   /**
-   * Creates a new [ClassData] instance for a given [kmClass].
+   * Creates a new [ClassData] instance for a given [declarationContainer].
    *
-   * @param kmClass the source [ImmutableKmClass] to read from.
+   * @param declarationContainer the source [ImmutableKmDeclarationContainer] to read from.
    * @param className the [ClassName] of the target class to to read from.
-   * @param parentClassName the parent [ClassName] name if [kmClass] is nested, inner, or is a
+   * @param parentClassName the parent [ClassName] name if [declarationContainer] is nested, inner, or is a
    *        companion object.
    */
-  fun classData(kmClass: ImmutableKmClass, className: ClassName, parentClassName: ClassName?): ClassData
+  fun classData(declarationContainer: ImmutableKmDeclarationContainer, className: ClassName, parentClassName: ClassName?): ClassData
+
+  /**
+   * Looks up other declaration containers, such as for nested members. Note that this class would
+   * always be Kotlin, so Metadata can be relied on for this.
+   *
+   * @param className The [ClassName] representation of the class.
+   * @return the read [ImmutableKmDeclarationContainer] from its metadata. If no class or facade
+   *         file was found, this should throw an exception.
+   */
+  fun declarationContainerFor(className: ClassName): ImmutableKmDeclarationContainer
 
   /**
    * Looks up other classes, such as for nested members. Note that this class would always be
@@ -60,7 +71,14 @@ interface ClassInspector {
    * @return the read [ImmutableKmClass] from its metadata. If no class was found, this should throw
    *         an exception.
    */
-  fun classFor(className: ClassName): ImmutableKmClass
+  // TODO Extension function this
+  fun classFor(className: ClassName): ImmutableKmClass {
+    val container = declarationContainerFor(className)
+    check(container is ImmutableKmClass) {
+      "Container is not a class! Was ${container.javaClass.simpleName}"
+    }
+    return container
+  }
 
   /**
    * Looks up a class and returns whether or not it is an interface. Note that this class can be

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ClassInspector.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ClassInspector.kt
@@ -33,17 +33,6 @@ interface ClassInspector {
   val supportsNonRuntimeRetainedAnnotations: Boolean
 
   /**
-   * Creates a new [ClassData] instance for a given [className].
-   *
-   * @param className the [ClassName] of the target class to to read from.
-   * @param parentClassName the parent [ClassName] name if [className] is nested, inner, or is a
-   *        companion object.
-   */
-  fun classData(className: ClassName, parentClassName: ClassName?): ClassData {
-    return classData(declarationContainerFor(className), className, parentClassName)
-  }
-
-  /**
    * Creates a new [ClassData] instance for a given [declarationContainer].
    *
    * @param declarationContainer the source [ImmutableKmDeclarationContainer] to read from.
@@ -90,6 +79,18 @@ interface ClassInspector {
    * @return whether or not the method exists.
    */
   fun methodExists(className: ClassName, methodSignature: JvmMethodSignature): Boolean
+}
+
+/**
+ * Creates a new [ClassData] instance for a given [className].
+ *
+ * @param className the [ClassName] of the target class to to read from.
+ * @param parentClassName the parent [ClassName] name if [className] is nested, inner, or is a
+ *        companion object.
+ */
+@KotlinPoetMetadataPreview
+fun ClassInspector.classData(className: ClassName, parentClassName: ClassName?): ClassData {
+  return classData(declarationContainerFor(className), className, parentClassName)
 }
 
 /**

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ClassInspector.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/ClassInspector.kt
@@ -40,7 +40,7 @@ interface ClassInspector {
    *        companion object.
    */
   fun classData(className: ClassName, parentClassName: ClassName?): ClassData {
-    return classData(classFor(className), className, parentClassName)
+    return classData(declarationContainerFor(className), className, parentClassName)
   }
 
   /**
@@ -62,23 +62,6 @@ interface ClassInspector {
    *         file was found, this should throw an exception.
    */
   fun declarationContainerFor(className: ClassName): ImmutableKmDeclarationContainer
-
-  /**
-   * Looks up other classes, such as for nested members. Note that this class would always be
-   * Kotlin, so Metadata can be relied on for this.
-   *
-   * @param className The [ClassName] representation of the class.
-   * @return the read [ImmutableKmClass] from its metadata. If no class was found, this should throw
-   *         an exception.
-   */
-  // TODO Extension function this
-  fun classFor(className: ClassName): ImmutableKmClass {
-    val container = declarationContainerFor(className)
-    check(container is ImmutableKmClass) {
-      "Container is not a class! Was ${container.javaClass.simpleName}"
-    }
-    return container
-  }
 
   /**
    * Looks up a class and returns whether or not it is an interface. Note that this class can be
@@ -107,4 +90,21 @@ interface ClassInspector {
    * @return whether or not the method exists.
    */
   fun methodExists(className: ClassName, methodSignature: JvmMethodSignature): Boolean
+}
+
+/**
+ * Looks up other classes, such as for nested members. Note that this class would always be
+ * Kotlin, so Metadata can be relied on for this.
+ *
+ * @param className The [ClassName] representation of the class.
+ * @return the read [ImmutableKmClass] from its metadata. If no class was found, this should throw
+ *         an exception.
+ */
+@KotlinPoetMetadataPreview
+fun ClassInspector.classFor(className: ClassName): ImmutableKmClass {
+  val container = declarationContainerFor(className)
+  check(container is ImmutableKmClass) {
+    "Container is not a class! Was ${container.javaClass.simpleName}"
+  }
+  return container
 }

--- a/kotlinpoet-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/KotlinPoetMetadata.kt
+++ b/kotlinpoet-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/KotlinPoetMetadata.kt
@@ -59,7 +59,13 @@ fun Metadata.toImmutableKmClass(): ImmutableKmClass {
   }
 }
 
-private fun Metadata.readKotlinClassMetadata(): KotlinClassMetadata {
+/**
+ * Returns the [KotlinClassMetadata] this represents. In general you should only use this function
+ * when you don't know what the underlying [KotlinClassMetadata] subtype is, otherwise you should
+ * use one of the more direct functions like [toImmutableKmClass].
+ */
+@KotlinPoetMetadataPreview
+fun Metadata.readKotlinClassMetadata(): KotlinClassMetadata {
   val metadata = KotlinClassMetadata.read(asClassHeader())
   checkNotNull(metadata) {
     "Could not parse metadata! This should only happen if you're using Kotlin <1.1."

--- a/kotlinpoet-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/immutableNodes.kt
+++ b/kotlinpoet-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/immutableNodes.kt
@@ -28,6 +28,7 @@ import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmConstantValue
 import kotlinx.metadata.KmConstructor
 import kotlinx.metadata.KmContract
+import kotlinx.metadata.KmDeclarationContainer
 import kotlinx.metadata.KmEffect
 import kotlinx.metadata.KmEffectExpression
 import kotlinx.metadata.KmEffectInvocationKind
@@ -72,6 +73,23 @@ import java.util.Collections
 @KotlinPoetMetadataPreview
 interface ImmutableKmWithFlags {
   val flags: Flags
+}
+
+/**
+ * Immutable representation of [KmDeclarationContainer].
+ *
+ * Represents a Kotlin declaration container, such as a class or a package fragment.
+ */
+@KotlinPoetMetadataPreview
+interface ImmutableKmDeclarationContainer {
+  /** Functions in the container. */
+  val functions: List<ImmutableKmFunction>
+
+  /** Properties in the container. */
+  val properties: List<ImmutableKmProperty>
+
+  /** Type aliases in the container. */
+  val typeAliases: List<ImmutableKmTypeAlias>
 }
 
 /**
@@ -132,9 +150,9 @@ data class ImmutableKmClass internal constructor(
   val name: ClassName,
   val typeParameters: List<ImmutableKmTypeParameter>,
   val supertypes: List<ImmutableKmType>,
-  val functions: List<ImmutableKmFunction>,
-  val properties: List<ImmutableKmProperty>,
-  val typeAliases: List<ImmutableKmTypeAlias>,
+  override val functions: List<ImmutableKmFunction>,
+  override val properties: List<ImmutableKmProperty>,
+  override val typeAliases: List<ImmutableKmTypeAlias>,
   val constructors: List<ImmutableKmConstructor>,
   val companionObject: String?,
   val nestedClasses: List<String>,
@@ -157,7 +175,7 @@ data class ImmutableKmClass internal constructor(
    * copied from bodies of inline functions to the use site by the Kotlin compiler.
    */
   val anonymousObjectOriginName: String?
-) : ImmutableKmWithFlags {
+) : ImmutableKmDeclarationContainer, ImmutableKmWithFlags {
   fun toMutable(): KmClass {
     return KmClass().apply {
       flags = this@ImmutableKmClass.flags
@@ -202,9 +220,9 @@ fun KmPackage.toImmutable(): ImmutableKmPackage {
  */
 @KotlinPoetMetadataPreview
 data class ImmutableKmPackage internal constructor(
-  val functions: List<ImmutableKmFunction>,
-  val properties: List<ImmutableKmProperty>,
-  val typeAliases: List<ImmutableKmTypeAlias>,
+  override val functions: List<ImmutableKmFunction>,
+  override val properties: List<ImmutableKmProperty>,
+  override val typeAliases: List<ImmutableKmTypeAlias>,
   /**
    * Metadata of local delegated properties used somewhere inside this package fragment (but not in any class).
    * Note that for classes produced by the Kotlin compiler, such properties will have default accessors.
@@ -216,7 +234,7 @@ data class ImmutableKmPackage internal constructor(
    */
   val localDelegatedProperties: List<ImmutableKmProperty>,
   val moduleName: String?
-) {
+): ImmutableKmDeclarationContainer {
   fun toMutable(): KmPackage {
     return KmPackage().apply {
       functions += this@ImmutableKmPackage.functions.map { it.toMutable() }

--- a/kotlinpoet-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/immutableNodes.kt
+++ b/kotlinpoet-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/immutableNodes.kt
@@ -234,7 +234,7 @@ data class ImmutableKmPackage internal constructor(
    */
   val localDelegatedProperties: List<ImmutableKmProperty>,
   val moduleName: String?
-): ImmutableKmDeclarationContainer {
+) : ImmutableKmDeclarationContainer {
   fun toMutable(): KmPackage {
     return KmPackage().apply {
       functions += this@ImmutableKmPackage.functions.map { it.toMutable() }


### PR DESCRIPTION
Part of work going into supporting `FileFacade` types. In Metadata, a `FileFacade` is just a `KmPackage` declaration containing functions, properties, and typealiases. It shares a common interface with `Class`/`KmClass` -  `KmDeclarationContainer`. This mirrors that now and broadens the classdata APIs in `ClassInspector` to speak them instead. This allows future `FileFacade` support to reuse this infrastructure to read class data.