### PR TITLE
Fix typealias handling in metadata

### DIFF
--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -18,6 +18,9 @@ package com.squareup.kotlinpoet.metadata.specs.test
 
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.compile.CompilationRule
+import com.squareup.kotlinpoet.LIST
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.classinspector.elements.ElementsClassInspector
 import com.squareup.kotlinpoet.classinspector.reflective.ReflectiveClassInspector
@@ -29,6 +32,7 @@ import com.squareup.kotlinpoet.metadata.ImmutableKmTypeParameter
 import com.squareup.kotlinpoet.metadata.ImmutableKmValueParameter
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 import com.squareup.kotlinpoet.metadata.specs.ClassInspector
+import com.squareup.kotlinpoet.metadata.specs.TypeNameAliasTag
 import com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.ClassInspectorType.ELEMENTS
 import com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.ClassInspectorType.REFLECTIVE
 import com.squareup.kotlinpoet.metadata.specs.toTypeSpec
@@ -252,14 +256,23 @@ class KotlinPoetMetadataSpecsTest(
   fun typeAliases() {
     val typeSpec = TypeAliases::class.toTypeSpecWithTestHandler()
 
-    // We always resolve the underlying type of typealiases
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class TypeAliases(
-        val foo: kotlin.String,
-        val bar: kotlin.collections.List<kotlin.String>
+        val foo: com.squareup.kotlinpoet.metadata.specs.test.TypeAliasName,
+        val bar: com.squareup.kotlinpoet.metadata.specs.test.GenericTypeAlias
       )
     """.trimIndent())
+
+    val fooPropertyType = typeSpec.propertySpecs.first { it.name == "foo" }.type
+    val fooAliasData = fooPropertyType.tag<TypeNameAliasTag>()
+    checkNotNull(fooAliasData)
+    assertThat(fooAliasData.type).isEqualTo(STRING)
+
+    val barPropertyType = typeSpec.propertySpecs.first { it.name == "bar" }.type
+    val barAliasData = barPropertyType.tag<TypeNameAliasTag>()
+    checkNotNull(barAliasData)
+    assertThat(barAliasData.type).isEqualTo(LIST.parameterizedBy(STRING))
   }
 
   class TypeAliases(val foo: TypeAliasName, val bar: GenericTypeAlias)
@@ -390,7 +403,7 @@ class KotlinPoetMetadataSpecsTest(
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class NestedTypeAliasTest {
-        val prop: kotlin.collections.List<kotlin.collections.List<kotlin.String>> = throw NotImplementedError("Stub!")
+        val prop: com.squareup.kotlinpoet.metadata.specs.test.NestedTypeAlias = throw NotImplementedError("Stub!")
       }
     """.trimIndent())
   }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/tags.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/tags.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.metadata.specs
+
+import com.squareup.kotlinpoet.TypeName
+
+/**
+ * This tag indicates that this [TypeName] represents a `typealias` type.
+ *
+ * @property [type] the underlying type for this alias.
+ */
+class TypeNameAliasTag(val type: TypeName)

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Taggable.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Taggable.kt
@@ -20,6 +20,9 @@ import kotlin.reflect.KClass
 /** A type that can be tagged with extra metadata of the user's choice. */
 interface Taggable {
 
+  /** Returns all tags. */
+  val tags: Map<KClass<*>, Any> get() = emptyMap()
+
   /** Returns the tag attached with [type] as a key, or null if no tag is attached with that key. */
   fun <T : Any> tag(type: Class<T>): T? = tag(type.kotlin)
 
@@ -137,7 +140,9 @@ inline fun <reified T : Any> TypeSpec.Builder.tag(tag: T?): TypeSpec.Builder = t
 
 internal fun Taggable.Builder<*>.buildTagMap(): TagMap = TagMap(LinkedHashMap(tags)) // Defensive copy
 
-internal class TagMap(val tags: Map<KClass<*>, Any>) : Taggable {
+internal class TagMap(tags: Map<KClass<*>, Any>) : Taggable {
+  override val tags: Map<KClass<*>, Any> = tags.toImmutableMap()
+
   override fun <T : Any> tag(type: KClass<T>): T? {
     @Suppress("UNCHECKED_CAST")
     return tags[type] as T?

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -92,7 +92,7 @@ sealed class TypeName constructor(
   abstract fun copy(
     nullable: Boolean = this.isNullable,
     annotations: List<AnnotationSpec> = this.annotations.toList(),
-    tags: Map<KClass<*>, Any> = this.tagMap.tags.toMap()
+    tags: Map<KClass<*>, Any> = this.tags
   ): TypeName
 
   val isAnnotated get() = annotations.isNotEmpty()
@@ -519,7 +519,7 @@ class LambdaTypeName private constructor(
     nullable: Boolean = this.isNullable,
     annotations: List<AnnotationSpec> = this.annotations.toList(),
     suspending: Boolean = this.isSuspending,
-    tags: Map<KClass<*>, Any> = this.tagMap.tags.toMap()
+    tags: Map<KClass<*>, Any> = this.tags.toMap()
   ): LambdaTypeName {
     return LambdaTypeName(receiver, parameters, returnType, nullable, suspending, annotations, tags)
   }


### PR DESCRIPTION
Another leftover from moshi metadata - we would always use the underlying type rather than the actual alias. This flips that and stores the underlying type in a tag for reference.