### PR TITLE
Refactor out parameterized metadata specs test base

### DIFF
--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -34,8 +34,6 @@ import com.squareup.kotlinpoet.metadata.specs.test.MultiClassInspectorTest.Class
 import com.squareup.kotlinpoet.tag
 import org.junit.Ignore
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.TYPE
 import kotlin.annotation.AnnotationTarget.TYPE_PARAMETER

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -44,7 +44,6 @@ import kotlin.test.fail
 
 @KotlinPoetMetadataPreview
 @Suppress("unused", "UNUSED_PARAMETER")
-@RunWith(Parameterized::class)
 class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
 
   @Test

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -28,7 +28,6 @@ import com.squareup.kotlinpoet.metadata.ImmutableKmProperty
 import com.squareup.kotlinpoet.metadata.ImmutableKmTypeParameter
 import com.squareup.kotlinpoet.metadata.ImmutableKmValueParameter
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
-import com.squareup.kotlinpoet.metadata.specs.ClassInspector
 import com.squareup.kotlinpoet.metadata.specs.TypeNameAliasTag
 import com.squareup.kotlinpoet.metadata.specs.test.MultiClassInspectorTest.ClassInspectorType.ELEMENTS
 import com.squareup.kotlinpoet.metadata.specs.test.MultiClassInspectorTest.ClassInspectorType.REFLECTIVE
@@ -46,10 +45,7 @@ import kotlin.test.fail
 @KotlinPoetMetadataPreview
 @Suppress("unused", "UNUSED_PARAMETER")
 @RunWith(Parameterized::class)
-class KotlinPoetMetadataSpecsTest(
-  override val classInspectorType: ClassInspectorType,
-  override val classInspectorFactoryCreator: (MultiClassInspectorTest) -> (() -> ClassInspector)
-) : MultiClassInspectorTest() {
+class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
 
   @Test
   fun constructorData() {

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/MultiClassInspectorTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/MultiClassInspectorTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.metadata.specs.test
+
+import com.google.testing.compile.CompilationRule
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.classinspector.elements.ElementsClassInspector
+import com.squareup.kotlinpoet.classinspector.reflective.ReflectiveClassInspector
+import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+import com.squareup.kotlinpoet.metadata.specs.ClassInspector
+import com.squareup.kotlinpoet.metadata.specs.toTypeSpec
+import org.junit.Assume
+import org.junit.Rule
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.Parameterized
+import org.junit.runners.model.Statement
+import java.lang.annotation.Inherited
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.reflect.KClass
+
+@KotlinPoetMetadataPreview
+abstract class MultiClassInspectorTest {
+  companion object {
+    @Suppress("RedundantLambdaArrow") // Needed for lambda type resolution
+    @JvmStatic
+    @Parameterized.Parameters(name = "{0}")
+    fun data(): Collection<Array<*>> {
+      return listOf(
+          arrayOf<Any>(
+              ClassInspectorType.REFLECTIVE,
+              { _: MultiClassInspectorTest -> { ReflectiveClassInspector.create() } }
+          ),
+          arrayOf<Any>(
+              ClassInspectorType.ELEMENTS,
+              { test: MultiClassInspectorTest -> {
+                ElementsClassInspector.create(test.compilation.elements, test.compilation.types)
+              } }
+          )
+      )
+    }
+  }
+
+  enum class ClassInspectorType {
+    REFLECTIVE, ELEMENTS
+  }
+
+  @Retention(RUNTIME)
+  @Target(AnnotationTarget.FUNCTION)
+  @Inherited
+  annotation class IgnoreForHandlerType(
+      val reason: String,
+      val handlerType: ClassInspectorType
+  )
+
+  class IgnoreForElementsRule(private val handlerType: ClassInspectorType) : TestRule {
+    override fun apply(base: Statement, description: Description): Statement {
+      return object : Statement() {
+        override fun evaluate() {
+          val annotation = description.getAnnotation(
+              IgnoreForHandlerType::class.java)
+          val shouldIgnore = annotation?.handlerType == handlerType
+          Assume.assumeTrue(
+              "Ignoring ${description.methodName}: ${annotation?.reason}",
+              !shouldIgnore
+          )
+          base.evaluate()
+        }
+      }
+    }
+  }
+  
+  abstract val classInspectorType: ClassInspectorType
+  abstract val classInspectorFactoryCreator: (MultiClassInspectorTest) -> (() -> ClassInspector)
+
+  @Rule
+  @JvmField
+  protected val compilation = CompilationRule()
+
+  @Rule
+  @JvmField
+  protected val ignoreForElementsRule = IgnoreForElementsRule(
+      classInspectorType)
+
+  protected fun KClass<*>.toTypeSpecWithTestHandler(): TypeSpec {
+    return toTypeSpec(classInspectorFactoryCreator(this@MultiClassInspectorTest)())
+  }
+}

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/MultiClassInspectorTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/MultiClassInspectorTest.kt
@@ -25,6 +25,7 @@ import com.squareup.kotlinpoet.metadata.specs.toTypeSpec
 import org.junit.Assume
 import org.junit.Rule
 import org.junit.rules.TestRule
+import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameter
 import org.junit.runners.model.Statement
@@ -32,6 +33,7 @@ import java.lang.annotation.Inherited
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.reflect.KClass
 
+@RunWith(Parameterized::class)
 @KotlinPoetMetadataPreview
 abstract class MultiClassInspectorTest {
   companion object {

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/MultiClassInspectorTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/MultiClassInspectorTest.kt
@@ -69,8 +69,8 @@ abstract class MultiClassInspectorTest {
   @Target(AnnotationTarget.FUNCTION)
   @Inherited
   annotation class IgnoreForHandlerType(
-      val reason: String,
-      val handlerType: ClassInspectorType
+    val reason: String,
+    val handlerType: ClassInspectorType
   )
 
   @JvmField

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/MultiClassInspectorTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/MultiClassInspectorTest.kt
@@ -25,8 +25,8 @@ import com.squareup.kotlinpoet.metadata.specs.toTypeSpec
 import org.junit.Assume
 import org.junit.Rule
 import org.junit.rules.TestRule
-import org.junit.runner.Description
 import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameter
 import org.junit.runners.model.Statement
 import java.lang.annotation.Inherited
 import kotlin.annotation.AnnotationRetention.RUNTIME
@@ -35,27 +35,34 @@ import kotlin.reflect.KClass
 @KotlinPoetMetadataPreview
 abstract class MultiClassInspectorTest {
   companion object {
-    @Suppress("RedundantLambdaArrow") // Needed for lambda type resolution
     @JvmStatic
     @Parameterized.Parameters(name = "{0}")
-    fun data(): Collection<Array<*>> {
+    fun data(): Collection<Array<ClassInspectorType>> {
       return listOf(
-          arrayOf<Any>(
-              ClassInspectorType.REFLECTIVE,
-              { _: MultiClassInspectorTest -> { ReflectiveClassInspector.create() } }
-          ),
-          arrayOf<Any>(
-              ClassInspectorType.ELEMENTS,
-              { test: MultiClassInspectorTest -> {
-                ElementsClassInspector.create(test.compilation.elements, test.compilation.types)
-              } }
-          )
+          arrayOf(ClassInspectorType.REFLECTIVE),
+          arrayOf(ClassInspectorType.ELEMENTS)
       )
     }
   }
 
   enum class ClassInspectorType {
-    REFLECTIVE, ELEMENTS
+    NONE {
+      override fun create(testInstance: MultiClassInspectorTest): ClassInspector {
+        throw IllegalStateException("Should not be called, just here to default the jvmfield to something.")
+      }
+    },
+    REFLECTIVE {
+      override fun create(testInstance: MultiClassInspectorTest): ClassInspector {
+        return ReflectiveClassInspector.create()
+      }
+    },
+    ELEMENTS {
+      override fun create(testInstance: MultiClassInspectorTest): ClassInspector {
+        return ElementsClassInspector.create(testInstance.compilation.elements, testInstance.compilation.types)
+      }
+    };
+
+    abstract fun create(testInstance: MultiClassInspectorTest): ClassInspector
   }
 
   @Retention(RUNTIME)
@@ -66,36 +73,32 @@ abstract class MultiClassInspectorTest {
       val handlerType: ClassInspectorType
   )
 
-  class IgnoreForElementsRule(private val handlerType: ClassInspectorType) : TestRule {
-    override fun apply(base: Statement, description: Description): Statement {
-      return object : Statement() {
-        override fun evaluate() {
-          val annotation = description.getAnnotation(
-              IgnoreForHandlerType::class.java)
-          val shouldIgnore = annotation?.handlerType == handlerType
-          Assume.assumeTrue(
-              "Ignoring ${description.methodName}: ${annotation?.reason}",
-              !shouldIgnore
-          )
-          base.evaluate()
-        }
+  @JvmField
+  @Parameter
+  var classInspectorType: ClassInspectorType = ClassInspectorType.NONE
+
+  @Rule
+  @JvmField
+  val compilation = CompilationRule()
+
+  @Rule
+  @JvmField
+  val ignoreForElementsRule = TestRule { base, description ->
+    object : Statement() {
+      override fun evaluate() {
+        val annotation = description.getAnnotation(
+            IgnoreForHandlerType::class.java)
+        val shouldIgnore = annotation?.handlerType == classInspectorType
+        Assume.assumeTrue(
+            "Ignoring ${description.methodName}: ${annotation?.reason}",
+            !shouldIgnore
+        )
+        base.evaluate()
       }
     }
   }
-  
-  abstract val classInspectorType: ClassInspectorType
-  abstract val classInspectorFactoryCreator: (MultiClassInspectorTest) -> (() -> ClassInspector)
-
-  @Rule
-  @JvmField
-  protected val compilation = CompilationRule()
-
-  @Rule
-  @JvmField
-  protected val ignoreForElementsRule = IgnoreForElementsRule(
-      classInspectorType)
 
   protected fun KClass<*>.toTypeSpecWithTestHandler(): TypeSpec {
-    return toTypeSpec(classInspectorFactoryCreator(this@MultiClassInspectorTest)())
+    return toTypeSpec(classInspectorType.create(this@MultiClassInspectorTest))
   }
 }

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/MultiClassInspectorTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/MultiClassInspectorTest.kt
@@ -21,6 +21,7 @@ import com.squareup.kotlinpoet.classinspector.elements.ElementsClassInspector
 import com.squareup.kotlinpoet.classinspector.reflective.ReflectiveClassInspector
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 import com.squareup.kotlinpoet.metadata.specs.ClassInspector
+import com.squareup.kotlinpoet.metadata.specs.test.MultiClassInspectorTest.ClassInspectorType
 import com.squareup.kotlinpoet.metadata.specs.toTypeSpec
 import org.junit.Assume
 import org.junit.Rule
@@ -33,6 +34,7 @@ import java.lang.annotation.Inherited
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.reflect.KClass
 
+/** Base test class that runs all tests with multiple [ClassInspectorTypes][ClassInspectorType]. */
 @RunWith(Parameterized::class)
 @KotlinPoetMetadataPreview
 abstract class MultiClassInspectorTest {


### PR DESCRIPTION
This'll allow us to better split up tests and still reuse the parameterized logic. The current test class is nearly 2k LoC 😨 