### PR TITLE
Fix abstract element handling

### DIFF
--- a/kotlinpoet-classinspector-elements/src/main/kotlin/com/squareup/kotlinpoet/classinspector/elements/ElementsClassInspector.kt
+++ b/kotlinpoet-classinspector-elements/src/main/kotlin/com/squareup/kotlinpoet/classinspector/elements/ElementsClassInspector.kt
@@ -201,10 +201,10 @@ class ElementsClassInspector private constructor(
     //       and compare against only preceding ones.
     val methodList = methodMap.asMap()[simpleName.toString()]?.toList()
         ?: return false
-    val indexOfPossibleOverrider = methodList.indexOf(this)
-    return (indexOfPossibleOverrider downTo 0)
-        .asSequence()
-        .map { methodList[it] }
+    val signature = jvmMethodSignature(types)
+    return methodList.asSequence()
+        .filter { it.jvmMethodSignature(types) == signature }
+        .take(1)
         .any { elements.overrides(this, it, type) }
   }
 

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1780,11 +1780,11 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       abstract class AbstractClass {
         val baz: kotlin.String? = null
-      
+
         abstract val foo: kotlin.String
-      
+
         abstract fun bar()
-      
+
         fun fuz() {
         }
       }
@@ -1827,17 +1827,17 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     assertThat(abstractModalities.trimmedToString()).isEqualTo("""
       abstract class AbstractModalities : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.ModalitiesInterface {
         val implicitFinalProp: kotlin.String? = null
-      
+
         override val interfaceProp: kotlin.String? = null
-      
+
         open val openProp: kotlin.String? = null
-      
+
         fun implicitFinalFun() {
         }
-      
+
         override fun interfaceFun() {
         }
-      
+
         open fun openFun() {
         }
       }
@@ -1849,7 +1849,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     assertThat(finalAbstractModalities.trimmedToString()).isEqualTo("""
       abstract class FinalAbstractModalities : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.ModalitiesInterface {
         final override val interfaceProp: kotlin.String? = null
-      
+
         final override fun interfaceFun() {
         }
       }
@@ -1861,12 +1861,12 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     assertThat(modalities.trimmedToString()).isEqualTo("""
       class Modalities : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.AbstractModalities() {
         override val interfaceProp: kotlin.String? = null
-      
+
         override val openProp: kotlin.String? = null
-      
+
         override fun interfaceFun() {
         }
-      
+
         override fun openFun() {
         }
       }

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1818,6 +1818,89 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     internal abstract val valProp: String
     internal abstract var varProp: String
   }
+
+  @Test
+  fun modalities() {
+    val abstractModalities = AbstractModalities::class.toTypeSpecWithTestHandler()
+
+    //language=kotlin
+    assertThat(abstractModalities.trimmedToString()).isEqualTo("""
+      abstract class AbstractModalities : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.ModalitiesInterface {
+        val implicitFinalProp: kotlin.String? = null
+      
+        override val interfaceProp: kotlin.String? = null
+      
+        open val openProp: kotlin.String? = null
+      
+        fun implicitFinalFun() {
+        }
+      
+        override fun interfaceFun() {
+        }
+      
+        open fun openFun() {
+        }
+      }
+    """.trimIndent())
+
+    val finalAbstractModalities = FinalAbstractModalities::class.toTypeSpecWithTestHandler()
+
+    //language=kotlin
+    assertThat(finalAbstractModalities.trimmedToString()).isEqualTo("""
+      abstract class FinalAbstractModalities : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.ModalitiesInterface {
+        final override val interfaceProp: kotlin.String? = null
+      
+        final override fun interfaceFun() {
+        }
+      }
+    """.trimIndent())
+
+    val modalities = Modalities::class.toTypeSpecWithTestHandler()
+
+    //language=kotlin
+    assertThat(modalities.trimmedToString()).isEqualTo("""
+      class Modalities : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.AbstractModalities() {
+        override val interfaceProp: kotlin.String? = null
+      
+        override val openProp: kotlin.String? = null
+      
+        override fun interfaceFun() {
+        }
+      
+        override fun openFun() {
+        }
+      }
+    """.trimIndent())
+  }
+
+  interface ModalitiesInterface {
+    val interfaceProp: String?
+    fun interfaceFun()
+  }
+  abstract class AbstractModalities : ModalitiesInterface {
+    override val interfaceProp: String? = null
+    override fun interfaceFun() {
+    }
+    val implicitFinalProp: String? = null
+    fun implicitFinalFun() {
+    }
+    open val openProp: String? = null
+    open fun openFun() {
+    }
+  }
+  abstract class FinalAbstractModalities : ModalitiesInterface {
+    final override val interfaceProp: String? = null
+    final override fun interfaceFun() {
+    }
+  }
+  class Modalities : AbstractModalities() {
+    override val interfaceProp: String? = null
+    override fun interfaceFun() {
+    }
+    override val openProp: String? = null
+    override fun openFun() {
+    }
+  }
 }
 
 class ClassNesting {

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1770,6 +1770,54 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     class AssetOut<out B : AssetOut<B>>
     class AssetIn<in C : AssetIn<C>>
   }
+
+  // Regression test for https://github.com/square/kotlinpoet/issues/821
+  @Test
+  fun abstractClass() {
+    val typeSpec = AbstractClass::class.toTypeSpecWithTestHandler()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      abstract class AbstractClass {
+        val baz: kotlin.String? = null
+      
+        abstract val foo: kotlin.String
+      
+        abstract fun bar()
+      
+        fun fuz() {
+        }
+      }
+    """.trimIndent())
+  }
+
+  abstract class AbstractClass {
+    abstract val foo: String
+    abstract fun bar()
+
+    val baz: String? = null
+    fun fuz() {}
+  }
+
+  // Regression test for https://github.com/square/kotlinpoet/issues/820
+  @Test
+  fun internalAbstractProperty() {
+    val typeSpec = InternalAbstractPropertyHolder::class.toTypeSpecWithTestHandler()
+
+    //language=kotlin
+    assertThat(typeSpec.trimmedToString()).isEqualTo("""
+      abstract class InternalAbstractPropertyHolder {
+        internal abstract val valProp: kotlin.String
+
+        internal abstract var varProp: kotlin.String
+      }
+    """.trimIndent())
+  }
+
+  abstract class InternalAbstractPropertyHolder {
+    internal abstract val valProp: String
+    internal abstract var varProp: String
+  }
 }
 
 class ClassNesting {

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -539,6 +539,9 @@ private fun ImmutableKmFunction.toFunSpec(
         if (methodData?.isOverride == true) {
           addModifiers(KModifier.OVERRIDE)
         }
+        if (isAbstract) {
+          addModifiers(ABSTRACT)
+        }
         if (isOperator) {
           addModifiers(OPERATOR)
         }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -332,7 +332,7 @@ private fun ImmutableKmClass.toTypeSpec(
             .map { (property, propertyData) ->
               val annotations = mutableListOf<AnnotationSpec>()
               if (propertyData != null) {
-                if (property.hasGetter) {
+                if (property.hasGetter && !isAbstract) {
                   property.getterSignature?.let { getterSignature ->
                     if (!isInterface &&
                         classInspector?.supportsNonRuntimeRetainedAnnotations == false) {
@@ -355,7 +355,7 @@ private fun ImmutableKmClass.toTypeSpec(
                     }
                   }
                 }
-                if (property.hasSetter) {
+                if (property.hasSetter && !isAbstract) {
                   property.setterSignature?.let { setterSignature ->
                     if (!isAnnotation &&
                         !isInterface &&
@@ -449,6 +449,9 @@ private fun ImmutableKmClass.toTypeSpec(
                       !isKotlinDefaultInterfaceMethod()
                   ) {
                     addModifiers(ABSTRACT)
+                    clearBody()
+                  } else if (ABSTRACT in modifiers) {
+                    // Remove bodies for abstract functions
                     clearBody()
                   }
                   if (methodData?.isSynthetic == true) {
@@ -682,11 +685,11 @@ private fun ImmutableKmProperty.toPropertySpec(
         // since the delegate handles it
         // vals with initialized constants have a getter in bytecode but not a body in kotlin source
         val modifierSet = modifiers.toSet()
-        if (hasGetter && !isDelegated) {
+        if (hasGetter && !isDelegated && !isAbstract) {
           propertyAccessor(modifierSet, getterFlags,
               FunSpec.getterBuilder().addStatement(NOT_IMPLEMENTED), isOverride)?.let(::getter)
         }
-        if (hasSetter && !isDelegated) {
+        if (hasSetter && !isDelegated && !isAbstract) {
           propertyAccessor(modifierSet, setterFlags, FunSpec.setterBuilder(), isOverride)?.let(::setter)
         }
       }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -528,6 +528,11 @@ private fun ImmutableKmFunction.toFunSpec(
       .apply {
         addAnnotations(annotations)
         addVisibility { addModifiers(it) }
+        val isOverride = methodData?.isOverride == true
+        addModifiers(flags.modalities
+            .filterNot { it == FINAL && !isOverride } // Final is the default
+            .filterNot { it == OPEN && isOverride } // Overrides are implicitly open
+        )
         if (valueParameters.isNotEmpty()) {
           addParameters(valueParameters.mapIndexed { index, param ->
             param.toParameterSpec(
@@ -539,11 +544,8 @@ private fun ImmutableKmFunction.toFunSpec(
         if (typeParameters.isNotEmpty()) {
           addTypeVariables(typeParameters.map { it.toTypeVariableName(typeParamResolver) })
         }
-        if (methodData?.isOverride == true) {
+        if (isOverride) {
           addModifiers(KModifier.OVERRIDE)
-        }
-        if (isAbstract) {
-          addModifiers(ABSTRACT)
         }
         if (isOperator) {
           addModifiers(OPERATOR)

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -534,7 +534,7 @@ private fun ImmutableKmFunction.toFunSpec(
         addModifiers(flags.modalities
             .filterNot { it == FINAL && !isOverride } // Final is the default
             .filterNot { it == OPEN && isOverride } // Overrides are implicitly open
-            .filterNot { it == OPEN && isInInterface } // functions methods are implicitly open
+            .filterNot { it == OPEN && isInInterface } // interface methods are implicitly open
         )
         if (valueParameters.isNotEmpty()) {
           addParameters(valueParameters.mapIndexed { index, param ->

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -672,6 +672,9 @@ private fun ImmutableKmProperty.toPropertySpec(
             constant != null -> initializer(constant)
             isConstructorParam -> initializer(name)
             returnTypeName.isNullable -> initializer("null")
+            isAbstract -> {
+              // No-op, don't emit an initializer for abstract properties
+            }
             else -> initializer(NOT_IMPLEMENTED)
           }
         }


### PR DESCRIPTION
Fixes #821 
Fixes #820 

This revealed that we're not currently detecting if kotlin interface properties have default values currently, but will save addressing that for another PR