### PR TITLE
Fix reified handling in elementsclassinspector

### DIFF
--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -720,7 +720,6 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         /**
          * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
          */
-        @kotlin.jvm.JvmSynthetic
         inline fun <reified T> reified(param: T) {
         }
       }

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -716,6 +716,13 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
 
         fun functionWithT(param: T) {
         }
+
+        /**
+         * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
+         */
+        @kotlin.jvm.JvmSynthetic
+        inline fun <reified T> reified(param: T) {
+        }
       }
     """.trimIndent())
 
@@ -731,6 +738,9 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     fun <T> functionAlsoWithT(param: T) {
     }
     fun <R> functionWithADifferentType(param: R) {
+    }
+    // Regression for https://github.com/square/kotlinpoet/issues/829
+    inline fun <reified T> reified(param: T) {
     }
   }
 

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -100,6 +100,7 @@ import com.squareup.kotlinpoet.metadata.isPrimary
 import com.squareup.kotlinpoet.metadata.isPrivate
 import com.squareup.kotlinpoet.metadata.isProtected
 import com.squareup.kotlinpoet.metadata.isPublic
+import com.squareup.kotlinpoet.metadata.isReified
 import com.squareup.kotlinpoet.metadata.isSealed
 import com.squareup.kotlinpoet.metadata.isSuspend
 import com.squareup.kotlinpoet.metadata.isSynthesized
@@ -108,6 +109,7 @@ import com.squareup.kotlinpoet.metadata.isVal
 import com.squareup.kotlinpoet.metadata.isVar
 import com.squareup.kotlinpoet.metadata.propertyAccessorFlags
 import com.squareup.kotlinpoet.metadata.specs.internal.ClassInspectorUtil
+import com.squareup.kotlinpoet.metadata.specs.internal.ClassInspectorUtil.JVM_SYNTHETIC
 import com.squareup.kotlinpoet.metadata.specs.internal.ClassInspectorUtil.bestGuessClassName
 import com.squareup.kotlinpoet.metadata.specs.internal.primaryConstructor
 import com.squareup.kotlinpoet.metadata.specs.internal.toTypeName
@@ -526,9 +528,15 @@ private fun ImmutableKmFunction.toFunSpec(
   methodData: MethodData?,
   isInInterface: Boolean
 ): FunSpec {
+  val finalAnnotations = if (typeParameters.any { it.isReified }) {
+    // Functions with reified type parameters are implicitly synthetic
+    annotations.filterNot { it.className == JVM_SYNTHETIC }
+  } else {
+    annotations
+  }
   return FunSpec.builder(name)
       .apply {
-        addAnnotations(annotations)
+        addAnnotations(finalAnnotations)
         addVisibility { addModifiers(it) }
         val isOverride = methodData?.isOverride == true
         addModifiers(flags.modalities

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -540,7 +540,8 @@ private fun ImmutableKmFunction.toFunSpec(
           addParameters(valueParameters.mapIndexed { index, param ->
             param.toParameterSpec(
                 typeParamResolver,
-                methodData?.parameterAnnotations?.getValue(index).orEmpty()
+                // This can be empty if the element is synthetic
+                methodData?.parameterAnnotations?.get(index).orEmpty()
             )
           })
         }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/ClassInspectorUtil.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/ClassInspectorUtil.kt
@@ -36,8 +36,8 @@ import java.util.TreeSet
 object ClassInspectorUtil {
   private val JVM_FIELD = JvmField::class.asClassName()
   internal val JVM_FIELD_SPEC = AnnotationSpec.builder(JVM_FIELD).build()
-  internal val JVM_SYNTHETIC_SPEC =
-      AnnotationSpec.builder(JvmSynthetic::class).build()
+  internal val JVM_SYNTHETIC = JvmSynthetic::class.asClassName()
+  internal val JVM_SYNTHETIC_SPEC = AnnotationSpec.builder(JVM_SYNTHETIC).build()
   private val JVM_TRANSIENT = Transient::class.asClassName()
   private val JVM_VOLATILE = Volatile::class.asClassName()
   private val IMPLICIT_FIELD_ANNOTATIONS = setOf(


### PR DESCRIPTION
Resolves #829. These elements are synthetic, so they can't be assumed to be present in `MethodData`. 