### PR TITLE
Enable actions on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Apparently push will only run when a collaborator on the repo opens a PR, and pull_request is necessary to have CI run for external contributors. 

This doesn't duplicate the build jobs though if the PR author is a collaborator - [example](https://github.com/uber/AutoDispose/pull/399).