### PR TITLE
Don't emit a leading new line if type KDoc is empty but parameter KDocs are present

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -357,7 +357,7 @@ class TypeSpec private constructor(
     }
     return with(kdoc.ensureEndsWithNewLine().toBuilder()) {
       parametersWithKdoc.forEachIndexed { index, parameter ->
-        if (index == 0) add("\n")
+        if (index == 0 && kdoc.isNotEmpty()) add("\n")
         add("@param %L %L", parameter.name, parameter.kdoc.ensureEndsWithNewLine())
       }
       build()

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -3936,6 +3936,36 @@ class TypeSpecTest {
         """.trimIndent())
   }
 
+  // https://github.com/square/kotlinpoet/issues/843
+  @Test fun kdocWithParametersWithoutClassKdoc() {
+    val taco = TypeSpec.classBuilder("Taco")
+        .primaryConstructor(FunSpec.constructorBuilder()
+            .addParameter(ParameterSpec.builder("mild", Boolean::class)
+                .addKdoc(CodeBlock.of("%L", "Whether the taco is mild (ew) or crunchy (ye).\n"))
+                .build())
+            .build())
+        .addProperty(PropertySpec.builder("mild", Boolean::class)
+            .addKdoc("No one likes mild tacos.")
+            .initializer("mild")
+            .build())
+        .build()
+    assertThat(toString(taco)).isEqualTo("""
+        |package com.squareup.tacos
+        |
+        |import kotlin.Boolean
+        |
+        |/**
+        | * @param mild Whether the taco is mild (ew) or crunchy (ye).
+        | */
+        |class Taco(
+        |  /**
+        |   * No one likes mild tacos.
+        |   */
+        |  val mild: Boolean
+        |)
+        |""".trimMargin())
+  }
+
   companion object {
     private val donutsPackage = "com.squareup.donuts"
   }


### PR DESCRIPTION
Fixes #843 

CC @reneeleung