### PR TITLE
Add support for inner nested and companion objects on annotation classes

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -201,9 +201,7 @@ class TypeSpec private constructor(
           codeWriter.emit("\n")
           return // Avoid unnecessary braces "{}".
         }
-        if (!isAnnotation) {
-          codeWriter.emit(" {\n")
-        }
+        codeWriter.emit(" {\n")
       }
 
       codeWriter.pushType(this)
@@ -290,9 +288,7 @@ class TypeSpec private constructor(
       codeWriter.unindent()
       codeWriter.popType()
 
-      if (!isAnnotation) {
-        codeWriter.emit("}")
-      }
+      codeWriter.emit("}")
       if (enumName == null && !isAnonymousClass) {
         codeWriter.emit("\n") // If this type isn't also a value, include a trailing newline.
       }
@@ -368,9 +364,6 @@ class TypeSpec private constructor(
 
   private val hasNoBody: Boolean
     get() {
-      if (isAnnotation) {
-        return true
-      }
       if (propertySpecs.isNotEmpty()) {
         val constructorProperties = constructorProperties()
         for (propertySpec in propertySpecs) {
@@ -756,7 +749,7 @@ class TypeSpec private constructor(
       when (companionObjectsCount) {
         0 -> Unit
         1 -> {
-          require(isSimpleClass || kind == Kind.INTERFACE || isEnum) {
+          require(isSimpleClass || kind == Kind.INTERFACE || isEnum || isAnnotation) {
             "$kind types can't have a companion object"
           }
         }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -941,7 +941,7 @@ class TypeSpecTest {
         |""".trimMargin())
   }
 
-  @Test fun annotationWithInnerTypes() {
+  @Test fun annotationWithNestedTypes() {
     val annotationName = ClassName(tacosPackage, "TacoDelivery")
     val kindName = annotationName.nestedClass("Kind")
     val annotation = TypeSpec.annotationBuilder(annotationName)

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -941,6 +941,58 @@ class TypeSpecTest {
         |""".trimMargin())
   }
 
+  @Test fun annotationWithInnerTypes() {
+    val annotationName = ClassName(tacosPackage, "TacoDelivery")
+    val kindName = annotationName.nestedClass("Kind")
+    val annotation = TypeSpec.annotationBuilder(annotationName)
+            .addModifiers(PUBLIC)
+            .primaryConstructor(FunSpec.constructorBuilder()
+                    .addParameter(ParameterSpec.builder("kind", kindName)
+                            .build())
+                    .addParameter(ParameterSpec.builder("quantity", Int::class)
+                            .defaultValue("QUANTITY_DEFAULT")
+                            .build())
+                    .build())
+            .addProperty(PropertySpec.builder("kind", kindName)
+                    .initializer("kind")
+                    .build())
+            .addProperty(PropertySpec.builder("quantity", Int::class)
+                    .initializer("quantity")
+                    .build())
+            .addType(TypeSpec.enumBuilder("Kind")
+                    .addEnumConstant("SOFT")
+                    .addEnumConstant("HARD")
+                    .build())
+            .addType(TypeSpec.companionObjectBuilder()
+                    .addProperty(PropertySpec
+                            .builder("QUANTITY_DEFAULT", Int::class, KModifier.CONST)
+                            .initializer("%L", 10_000)
+                            .build())
+                    .build())
+            .build()
+
+    assertThat(toString(annotation)).isEqualTo("""
+        |package com.squareup.tacos
+        |
+        |import kotlin.Int
+        |
+        |annotation class TacoDelivery(
+        |  val kind: Kind,
+        |  val quantity: Int = QUANTITY_DEFAULT
+        |) {
+        |  enum class Kind {
+        |    SOFT,
+        |
+        |    HARD
+        |  }
+        |
+        |  companion object {
+        |    const val QUANTITY_DEFAULT: Int = 10000
+        |  }
+        |}
+        |""".trimMargin())
+  }
+
   @Ignore @Test fun innerAnnotationInAnnotationDeclaration() {
     val bar = TypeSpec.annotationBuilder("Bar")
         .primaryConstructor(FunSpec.constructorBuilder()


### PR DESCRIPTION
As of Kotlin 1.3, [annotation classes are permitted to have a body](https://youtrack.jetbrains.com/issue/KT-16962) for nested types and companion objects. This PR updates the checks in `TypeSpec` to remove or update relevant checks.