### PR TITLE
Clean up bestGuessClassName usage

### DIFF
--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -110,7 +110,7 @@ import com.squareup.kotlinpoet.metadata.isVar
 import com.squareup.kotlinpoet.metadata.propertyAccessorFlags
 import com.squareup.kotlinpoet.metadata.specs.internal.ClassInspectorUtil
 import com.squareup.kotlinpoet.metadata.specs.internal.ClassInspectorUtil.JVM_SYNTHETIC
-import com.squareup.kotlinpoet.metadata.specs.internal.ClassInspectorUtil.bestGuessClassName
+import com.squareup.kotlinpoet.metadata.specs.internal.ClassInspectorUtil.createClassName
 import com.squareup.kotlinpoet.metadata.specs.internal.primaryConstructor
 import com.squareup.kotlinpoet.metadata.specs.internal.toTypeName
 import com.squareup.kotlinpoet.metadata.specs.internal.toTypeVariableName
@@ -170,7 +170,7 @@ fun TypeElement.toFileSpec(
 @KotlinPoetMetadataPreview
 fun ImmutableKmClass.toTypeSpec(
   classInspector: ClassInspector?,
-  className: ClassName = bestGuessClassName(name)
+  className: ClassName = createClassName(name)
 ): TypeSpec {
   return toTypeSpec(classInspector, className, null)
 }
@@ -179,7 +179,7 @@ fun ImmutableKmClass.toTypeSpec(
 @KotlinPoetMetadataPreview
 fun ImmutableKmClass.toFileSpec(
   classInspector: ClassInspector?,
-  className: ClassName = bestGuessClassName(name)
+  className: ClassName = createClassName(name)
 ): FileSpec {
   return FileSpec.get(
       packageName = className.packageName,
@@ -285,7 +285,7 @@ private fun ImmutableKmClass.toTypeSpec(
     // - First element of an interface type is the first superinterface
     val superClassFilter = classInspector?.let { handler ->
       { type: ImmutableKmType ->
-        !handler.isInterface(bestGuessClassName((type.classifier as KmClassifier.Class).name))
+        !handler.isInterface(createClassName((type.classifier as KmClassifier.Class).name))
       }
     } ?: { true }
     val superClass = supertypes.asSequence()

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/ClassInspectorUtil.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/ClassInspectorUtil.kt
@@ -175,7 +175,7 @@ object ClassInspectorUtil {
    * Local classes are prefixed with ".", but for KotlinPoetMetadataSpecs' use case we don't deal
    * with those.
    */
-  fun bestGuessClassName(kotlinMetadataName: String): ClassName {
+  fun createClassName(kotlinMetadataName: String): ClassName {
     require(!kotlinMetadataName.isLocal) {
       "Local/anonymous classes are not supported!"
     }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmAnnotations.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmAnnotations.kt
@@ -4,7 +4,7 @@ import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.joinToCode
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
-import com.squareup.kotlinpoet.metadata.specs.internal.ClassInspectorUtil.bestGuessClassName
+import com.squareup.kotlinpoet.metadata.specs.internal.ClassInspectorUtil.createClassName
 import kotlinx.metadata.KmAnnotation
 import kotlinx.metadata.KmAnnotationArgument
 import kotlinx.metadata.KmAnnotationArgument.AnnotationValue
@@ -27,7 +27,7 @@ import kotlinx.metadata.KmAnnotationArgument.UShortValue
 
 @KotlinPoetMetadataPreview
 internal fun KmAnnotation.toAnnotationSpec(): AnnotationSpec {
-  val cn = bestGuessClassName(className)
+  val cn = createClassName(className)
   return AnnotationSpec.builder(cn)
       .apply {
         arguments.forEach { (name, arg) ->
@@ -53,8 +53,8 @@ internal fun KmAnnotationArgument<*>.toCodeBlock(): CodeBlock {
     is UIntValue -> CodeBlock.of("%Lu", value)
     is ULongValue -> CodeBlock.of("%Lu", value)
     is StringValue -> CodeBlock.of("%S", value)
-    is KClassValue -> CodeBlock.of("%T::class", bestGuessClassName(value))
-    is EnumValue -> CodeBlock.of("%T.%L", bestGuessClassName(enumClassName), enumEntryName)
+    is KClassValue -> CodeBlock.of("%T::class", createClassName(value))
+    is EnumValue -> CodeBlock.of("%T.%L", createClassName(enumClassName), enumEntryName)
     is AnnotationValue -> CodeBlock.of("%L", value.toAnnotationSpec())
     is ArrayValue -> value.map { it.toCodeBlock() }.joinToCode(", ", "[", "]")
   }

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmTypes.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmTypes.kt
@@ -86,7 +86,7 @@ internal fun ImmutableKmType.toTypeName(
     is KmClassifier.Class -> {
       flexibleTypeUpperBound?.toTypeName(typeParamResolver)?.let { return it }
       outerType?.toTypeName(typeParamResolver)?.let { return it }
-      var finalType: TypeName = ClassInspectorUtil.bestGuessClassName(valClassifier.name.replace("/", "."))
+      var finalType: TypeName = ClassInspectorUtil.createClassName(valClassifier.name.replace("/", "."))
       if (argumentList.isNotEmpty()) {
         val finalTypeString = finalType.toString()
         if (finalTypeString.startsWith("kotlin.Function")) {
@@ -128,7 +128,7 @@ internal fun ImmutableKmType.toTypeName(
       finalType
     }
     is TypeAlias -> {
-      ClassInspectorUtil.bestGuessClassName(valClassifier.name)
+      ClassInspectorUtil.createClassName(valClassifier.name)
     }
   }
 

--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmTypes.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmTypes.kt
@@ -86,7 +86,7 @@ internal fun ImmutableKmType.toTypeName(
     is KmClassifier.Class -> {
       flexibleTypeUpperBound?.toTypeName(typeParamResolver)?.let { return it }
       outerType?.toTypeName(typeParamResolver)?.let { return it }
-      var finalType: TypeName = ClassName.bestGuess(valClassifier.name.replace("/", "."))
+      var finalType: TypeName = ClassInspectorUtil.bestGuessClassName(valClassifier.name.replace("/", "."))
       if (argumentList.isNotEmpty()) {
         val finalTypeString = finalType.toString()
         if (finalTypeString.startsWith("kotlin.Function")) {

--- a/kotlinpoet-metadata-specs/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/ClassInspectorUtilTest.kt
+++ b/kotlinpoet-metadata-specs/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/ClassInspectorUtilTest.kt
@@ -11,56 +11,56 @@ import kotlin.test.Test
 class ClassInspectorUtilTest {
 
   @Test fun bestGuess_simple() {
-    assertThat(ClassInspectorUtil.bestGuessClassName("some/path/Foo"))
+    assertThat(ClassInspectorUtil.createClassName("some/path/Foo"))
         .isEqualTo(ClassName("some.path", "Foo"))
   }
 
   @Test fun bestGuess_nested() {
-    assertThat(ClassInspectorUtil.bestGuessClassName("some/path/Foo.Nested"))
+    assertThat(ClassInspectorUtil.createClassName("some/path/Foo.Nested"))
         .isEqualTo(ClassName("some.path", "Foo", "Nested"))
   }
 
   @Test fun bestGuess_simple_dollarNameStart() {
-    assertThat(ClassInspectorUtil.bestGuessClassName("some/path/Foo$"))
+    assertThat(ClassInspectorUtil.createClassName("some/path/Foo$"))
         .isEqualTo(ClassName("some.path", "Foo$"))
   }
 
   @Test fun bestGuess_simple_dollarNameMiddle() {
-    assertThat(ClassInspectorUtil.bestGuessClassName("some/path/Fo${'$'}o"))
+    assertThat(ClassInspectorUtil.createClassName("some/path/Fo${'$'}o"))
         .isEqualTo(ClassName("some.path", "Fo${'$'}o"))
   }
 
   @Test fun bestGuess_simple_dollarNameEnd() {
-    assertThat(ClassInspectorUtil.bestGuessClassName("some/path/Nested.${'$'}Foo"))
+    assertThat(ClassInspectorUtil.createClassName("some/path/Nested.${'$'}Foo"))
         .isEqualTo(ClassName("some.path", "Nested", "${'$'}Foo"))
   }
 
   @Test fun bestGuess_nested_dollarNameStart() {
-    assertThat(ClassInspectorUtil.bestGuessClassName("some/path/Nested.Foo$"))
+    assertThat(ClassInspectorUtil.createClassName("some/path/Nested.Foo$"))
         .isEqualTo(ClassName("some.path", "Nested", "Foo$"))
   }
 
   @Test fun bestGuess_nested_dollarNameMiddle() {
-    assertThat(ClassInspectorUtil.bestGuessClassName("some/path/Nested.Fo${'$'}o"))
+    assertThat(ClassInspectorUtil.createClassName("some/path/Nested.Fo${'$'}o"))
         .isEqualTo(ClassName("some.path", "Nested", "Fo${'$'}o"))
   }
 
   @Test fun bestGuess_nested_dollarNameEnd() {
-    assertThat(ClassInspectorUtil.bestGuessClassName("some/path/Nested.${'$'}Foo"))
+    assertThat(ClassInspectorUtil.createClassName("some/path/Nested.${'$'}Foo"))
         .isEqualTo(ClassName("some.path", "Nested", "${'$'}Foo"))
   }
 
   @Test fun bestGuess_noPackageName() {
-    assertThat(ClassInspectorUtil.bestGuessClassName("ClassWithNoPackage"))
+    assertThat(ClassInspectorUtil.createClassName("ClassWithNoPackage"))
         .isEqualTo(ClassName("", "ClassWithNoPackage"))
   }
 
   // Regression test for avoiding https://github.com/square/kotlinpoet/issues/795
   @Test fun bestGuess_noEmptyNames() {
-    val noPackage = ClassInspectorUtil.bestGuessClassName("ClassWithNoPackage")
+    val noPackage = ClassInspectorUtil.createClassName("ClassWithNoPackage")
     assertThat(noPackage.simpleNames.any { it.isEmpty() }).isFalse()
 
-    val withPackage = ClassInspectorUtil.bestGuessClassName("path/to/ClassWithNoPackage")
+    val withPackage = ClassInspectorUtil.createClassName("path/to/ClassWithNoPackage")
     assertThat(withPackage.simpleNames.any { it.isEmpty() }).isFalse()
   }
 

--- a/kotlinpoet-metadata-specs/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/ClassInspectorUtilTest.kt
+++ b/kotlinpoet-metadata-specs/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/ClassInspectorUtilTest.kt
@@ -10,53 +10,53 @@ import kotlin.test.Test
 @KotlinPoetMetadataPreview
 class ClassInspectorUtilTest {
 
-  @Test fun bestGuess_simple() {
+  @Test fun createClassName_simple() {
     assertThat(ClassInspectorUtil.createClassName("some/path/Foo"))
         .isEqualTo(ClassName("some.path", "Foo"))
   }
 
-  @Test fun bestGuess_nested() {
+  @Test fun createClassName_nested() {
     assertThat(ClassInspectorUtil.createClassName("some/path/Foo.Nested"))
         .isEqualTo(ClassName("some.path", "Foo", "Nested"))
   }
 
-  @Test fun bestGuess_simple_dollarNameStart() {
+  @Test fun createClassName_simple_dollarNameStart() {
     assertThat(ClassInspectorUtil.createClassName("some/path/Foo$"))
         .isEqualTo(ClassName("some.path", "Foo$"))
   }
 
-  @Test fun bestGuess_simple_dollarNameMiddle() {
+  @Test fun createClassName_simple_dollarNameMiddle() {
     assertThat(ClassInspectorUtil.createClassName("some/path/Fo${'$'}o"))
         .isEqualTo(ClassName("some.path", "Fo${'$'}o"))
   }
 
-  @Test fun bestGuess_simple_dollarNameEnd() {
+  @Test fun createClassName_simple_dollarNameEnd() {
     assertThat(ClassInspectorUtil.createClassName("some/path/Nested.${'$'}Foo"))
         .isEqualTo(ClassName("some.path", "Nested", "${'$'}Foo"))
   }
 
-  @Test fun bestGuess_nested_dollarNameStart() {
+  @Test fun createClassName_nested_dollarNameStart() {
     assertThat(ClassInspectorUtil.createClassName("some/path/Nested.Foo$"))
         .isEqualTo(ClassName("some.path", "Nested", "Foo$"))
   }
 
-  @Test fun bestGuess_nested_dollarNameMiddle() {
+  @Test fun createClassName_nested_dollarNameMiddle() {
     assertThat(ClassInspectorUtil.createClassName("some/path/Nested.Fo${'$'}o"))
         .isEqualTo(ClassName("some.path", "Nested", "Fo${'$'}o"))
   }
 
-  @Test fun bestGuess_nested_dollarNameEnd() {
+  @Test fun createClassName_nested_dollarNameEnd() {
     assertThat(ClassInspectorUtil.createClassName("some/path/Nested.${'$'}Foo"))
         .isEqualTo(ClassName("some.path", "Nested", "${'$'}Foo"))
   }
 
-  @Test fun bestGuess_noPackageName() {
+  @Test fun createClassName_noPackageName() {
     assertThat(ClassInspectorUtil.createClassName("ClassWithNoPackage"))
         .isEqualTo(ClassName("", "ClassWithNoPackage"))
   }
 
   // Regression test for avoiding https://github.com/square/kotlinpoet/issues/795
-  @Test fun bestGuess_noEmptyNames() {
+  @Test fun createClassName_noEmptyNames() {
     val noPackage = ClassInspectorUtil.createClassName("ClassWithNoPackage")
     assertThat(noPackage.simpleNames.any { it.isEmpty() }).isFalse()
 

--- a/kotlinpoet-metadata-specs/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/ClassInspectorUtilTest.kt
+++ b/kotlinpoet-metadata-specs/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/ClassInspectorUtilTest.kt
@@ -64,6 +64,11 @@ class ClassInspectorUtilTest {
     assertThat(withPackage.simpleNames.any { it.isEmpty() }).isFalse()
   }
 
+  @Test fun createClassName_packageWithCaps() {
+    assertThat(ClassInspectorUtil.createClassName("some/Path/Foo.Nested"))
+        .isEqualTo(ClassName("some.Path", "Foo", "Nested"))
+  }
+
   @Test fun throwsSpec_normal() {
     assertThat(ClassInspectorUtil.createThrowsSpec(listOf(Exception::class.asClassName())))
         .isEqualTo(AnnotationSpec.builder(Throws::class.asClassName())


### PR DESCRIPTION
This switches us to use `bestGuessClassName` to be used anywhere that a Km classname is looked up, and also renames it to `createClassName` since it's no longer a best guess effort.