### PR TITLE
Lift the requirement for file names to not be keywords

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -223,10 +223,6 @@ class FileSpec private constructor(
 
     val annotations = mutableListOf<AnnotationSpec>()
 
-    init {
-      require(name.isName) { "not a valid file name: $name" }
-    }
-
     /**
      * Add an annotation to the file.
      *

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileWritingTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileWritingTest.kt
@@ -285,4 +285,12 @@ class FileWritingTest {
         |class Taco
         |""".trimMargin())
   }
+
+  @Test fun fileWithKeywordName() {
+    val type = TypeSpec.classBuilder("fun").build()
+    FileSpec.get("", type).writeTo(filer)
+
+    val testPath = fsRoot.resolve("fun.kt")
+    assertThat(Files.exists(testPath)).isTrue()
+  }
 }


### PR DESCRIPTION
Not an issue with the compiler.