### PR TITLE
Tag AnnotationSpec with the annotation mirror where available

### DIFF
--- a/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmAnnotations.kt
+++ b/kotlinpoet-metadata-specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/internal/KmAnnotations.kt
@@ -5,6 +5,7 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.joinToCode
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 import com.squareup.kotlinpoet.metadata.specs.internal.ClassInspectorUtil.createClassName
+import com.squareup.kotlinpoet.tag
 import kotlinx.metadata.KmAnnotation
 import kotlinx.metadata.KmAnnotationArgument
 import kotlinx.metadata.KmAnnotationArgument.AnnotationValue
@@ -34,6 +35,7 @@ internal fun KmAnnotation.toAnnotationSpec(): AnnotationSpec {
           addMember("%L = %L", name, arg.toCodeBlock())
         }
       }
+      .tag(this)
       .build()
 }
 

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -181,6 +181,7 @@ class AnnotationSpec private constructor(
       try {
         val javaAnnotation = annotation as java.lang.annotation.Annotation
         val builder = builder(javaAnnotation.annotationType())
+            .tag(annotation)
         val methods = annotation.annotationType().declaredMethods.sortedBy { it.name }
         for (method in methods) {
           val value = method.invoke(annotation)
@@ -218,6 +219,7 @@ class AnnotationSpec private constructor(
     @JvmStatic fun get(annotation: AnnotationMirror): AnnotationSpec {
       val element = annotation.annotationType.asElement() as TypeElement
       val builder = AnnotationSpec.builder(element.asClassName())
+          .tag(annotation)
       for (executableElement in annotation.elementValues.keys) {
         val member = CodeBlock.builder()
         val visitor = Visitor(member)


### PR DESCRIPTION
This will make it possible to read annotation arguments in an annotations processor.