### PR TITLE
Support nested code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,8 +587,61 @@ private fun computeRange(name: String, from: Int, to: Int, op: String): FunSpec 
 }
 ```
 
-Literals are emitted directly to the output code with no escaping. Arguments for literals may be
-strings, primitives, and a few KotlinPoet types described below.
+### %B for CodeBlock
+
+Sometimes you may want to reuse or decorate your codes, in this case, you can use `%B` to import
+existed `CodeBlock`:
+
+```kotlin
+val funSpec = FunSpec.builder("cookTaco")
+    .addParameter("rawTaco", ClassName.bestGuess("com.squareup.tacos.Taco"))
+    .apply {
+      var taco = buildCodeBlock {
+        add("rawTaco")
+      }
+      taco = buildCodeBlock {
+        add("%B.fry(30,·%T.SECONDS)", taco, TimeUnit::class)
+      }
+      taco = buildCodeBlock {
+        add("%B .bake(8,·%T.MINUTES)", taco, TimeUnit::class)
+      }
+      taco = buildCodeBlock {
+        add("%B.addChicken(10)", taco)
+      }
+      taco = buildCodeBlock {
+        add("%B.addCheese(5)", taco)
+      }
+      taco = buildCodeBlock {
+        add("%B.bake(15,·%T.MINUTES)", taco, TimeUnit::class)
+      }
+      taco = buildCodeBlock {
+        add("%B .addLettuce(3)", taco)
+      }
+      taco = buildCodeBlock {
+        add("%B.addSpice(0.5)", taco)
+      }
+      addStatement("return %B", taco)
+    }
+    .build()
+val fileSpec = FileSpec.builder("com.squareup.tacos.test", "CookTaco")
+    .addFunction(funSpec)
+    .build()
+println(file)
+```
+
+The `CodeBlock` can be decorated over and over again. Finally, it can be used in many functions,
+properties, classes. The references in `CodeBlock` will auto imported.
+
+```kotlin
+package com.squareup.tacos.test
+
+import com.squareup.tacos.Taco
+import java.util.concurrent.TimeUnit
+
+fun cookTaco(rawTaco: Taco) = rawTaco.fry(30, TimeUnit.SECONDS)
+    .bake(8, TimeUnit.MINUTES).addChicken(10).addCheese(5).bake(15, TimeUnit.MINUTES)
+    .addLettuce(3).addSpice(0.5)
+```
 
 ### Code block format strings
 

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
@@ -344,6 +344,7 @@ class CodeBlock private constructor(
         'P' -> this.args += if (arg is CodeBlock) arg else argToString(arg)
         'T' -> this.args += argToType(arg)
         'M' -> this.args += arg
+        'B' -> this.args += arg
         else -> throw IllegalArgumentException(
             String.format("invalid format string: '%s'", format))
       }

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -217,7 +217,7 @@ internal class CodeWriter constructor(
     codeBlock: CodeBlock,
     isConstantContext: Boolean = false,
     ensureTrailingNewline: Boolean = false
-  ) = apply {
+  ): CodeWriter = apply {
     var a = 0
     var deferredTypeName: ClassName? = null // used by "import static" logic
     val partIterator = codeBlock.formatParts.listIterator()
@@ -288,6 +288,11 @@ internal class CodeWriter constructor(
         "%M" -> {
           val memberName = codeBlock.args[a++] as MemberName
           memberName.emit(this)
+        }
+
+        "%B" -> {
+          val block = codeBlock.args[a++] as CodeBlock
+          emitCode(block)
         }
 
         "%%" -> emit("%")


### PR DESCRIPTION
# Compose poetry with nested `CodeBlock`
This PR adds `%B` to support the nested code block.

## Checklist
- [x] Implementation
- [x] Test
- [x] Documents
- [x] CI build pass
- [ ] Review

## Description
Sometimes you may want to reuse or decorate your codes, in this case, you can use `%B` to import
existed `CodeBlock`:

```kotlin
val funSpec = FunSpec.builder("cookTaco")
    .addParameter("rawTaco", ClassName.bestGuess("com.squareup.tacos.Taco"))
    .apply {
      var taco = buildCodeBlock {
        add("rawTaco")
      }
      taco = buildCodeBlock {
        add("%B.fry(30,·%T.SECONDS)", taco, TimeUnit::class)
      }
      taco = buildCodeBlock {
        add("%B .bake(8,·%T.MINUTES)", taco, TimeUnit::class)
      }
      taco = buildCodeBlock {
        add("%B.addChicken(10)", taco)
      }
      taco = buildCodeBlock {
        add("%B.addCheese(5)", taco)
      }
      taco = buildCodeBlock {
        add("%B.bake(15,·%T.MINUTES)", taco, TimeUnit::class)
      }
      taco = buildCodeBlock {
        add("%B .addLettuce(3)", taco)
      }
      taco = buildCodeBlock {
        add("%B.addSpice(0.5)", taco)
      }
      addStatement("return %B", taco)
    }
    .build()
val fileSpec = FileSpec.builder("com.squareup.tacos.test", "CookTaco")
    .addFunction(funSpec)
    .build()
println(file)
```

The `CodeBlock` can be decorated over and over again. Finally, it can be used in many functions,
properties, classes. The references in `CodeBlock` will auto imported.

```kotlin
package com.squareup.tacos.test

import com.squareup.tacos.Taco
import java.util.concurrent.TimeUnit

fun cookTaco(rawTaco: Taco) = rawTaco.fry(30, TimeUnit.SECONDS)
    .bake(8, TimeUnit.MINUTES).addChicken(10).addCheese(5).bake(15, TimeUnit.MINUTES)
    .addLettuce(3).addSpice(0.5)
```