### PR TITLE
Propagate type implicit modifiers to constructors and nested types as well as functions.

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -269,7 +269,7 @@ class TypeSpec private constructor(
       for (funSpec in funSpecs) {
         if (!funSpec.isConstructor) continue
         if (!firstMember) codeWriter.emit("\n")
-        funSpec.emit(codeWriter, name, kind.implicitFunctionModifiers(modifiers), false)
+        funSpec.emit(codeWriter, name, kind.implicitFunctionModifiers(modifiers + implicitModifiers), false)
         firstMember = false
       }
 
@@ -286,7 +286,7 @@ class TypeSpec private constructor(
 
       for (typeSpec in typeSpecs) {
         if (!firstMember) codeWriter.emit("\n")
-        typeSpec.emit(codeWriter, null, kind.implicitTypeModifiers(modifiers), isNestedExternal = areNestedExternal)
+        typeSpec.emit(codeWriter, null, kind.implicitTypeModifiers(modifiers + implicitModifiers), isNestedExternal = areNestedExternal)
         firstMember = false
       }
 

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -1078,6 +1078,100 @@ class TypeSpecTest {
       |""".trimMargin())
   }
 
+  @Test fun deeplyNestedExpectClassWithFunction() {
+    val classA = TypeSpec.expectClassBuilder("ClassA")
+        .addType(TypeSpec.classBuilder("ClassB")
+            .addType(TypeSpec.classBuilder("ClassC")
+                .addFunction(FunSpec.builder("test")
+                    .build())
+                .build())
+            .build())
+        .build()
+
+    assertThat(classA.toString()).isEqualTo("""
+      |expect class ClassA {
+      |  class ClassB {
+      |    class ClassC {
+      |      fun test()
+      |    }
+      |  }
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun veryDeeplyNestedExpectClassWithFunction() {
+    val classA = TypeSpec.expectClassBuilder("ClassA")
+        .addType(TypeSpec.classBuilder("ClassB")
+            .addType(TypeSpec.classBuilder("ClassC")
+                .addType(TypeSpec.classBuilder("ClassD")
+                    .addFunction(FunSpec.builder("test")
+                        .build())
+                    .build())
+                .build())
+            .build())
+        .build()
+
+    assertThat(classA.toString()).isEqualTo("""
+      |expect class ClassA {
+      |  class ClassB {
+      |    class ClassC {
+      |      class ClassD {
+      |        fun test()
+      |      }
+      |    }
+      |  }
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun deeplyNestedExpectClassWithConstructor() {
+    val classA = TypeSpec.expectClassBuilder("ClassA")
+        .addType(TypeSpec.classBuilder("ClassB")
+            .addType(TypeSpec.classBuilder("ClassC")
+                .addFunction(FunSpec.constructorBuilder()
+                    .addStatement("Unit")
+                    .build())
+                .build())
+            .build())
+        .build()
+
+    assertThat(classA.toString()).isEqualTo("""
+      |expect class ClassA {
+      |  class ClassB {
+      |    class ClassC {
+      |      constructor()
+      |    }
+      |  }
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun veryDeeplyNestedExpectClassWithConstructor() {
+    val classA = TypeSpec.expectClassBuilder("ClassA")
+        .addType(TypeSpec.classBuilder("ClassB")
+            .addType(TypeSpec.classBuilder("ClassC")
+                .addType(TypeSpec.classBuilder("ClassD")
+                    .addFunction(FunSpec.constructorBuilder()
+                        .addStatement("Unit")
+                        .build())
+                    .build())
+                .build())
+            .build())
+        .build()
+
+    assertThat(classA.toString()).isEqualTo("""
+      |expect class ClassA {
+      |  class ClassB {
+      |    class ClassC {
+      |      class ClassD {
+      |        constructor()
+      |      }
+      |    }
+      |  }
+      |}
+      |""".trimMargin())
+  }
+
   @Test fun interfaceWithMethods() {
     val taco = TypeSpec.interfaceBuilder("Taco")
         .addFunction(FunSpec.builder("aMethod")


### PR DESCRIPTION
This allows deeply nested classes and constructors to respect a top-level modifier.