### PR TITLE
Add support for escaping $ in names

### DIFF
--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -1687,7 +1687,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     val typeSpec = `Fuzzy$ClassNesting`::class.toTypeSpecWithTestHandler()
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
-      class Fuzzy${'$'}ClassNesting {
+      class `Fuzzy${'$'}ClassNesting` {
         class `-Nested` {
           class SuperNestedClass {
             inner class `-${'$'}Fuzzy${'$'}Super${'$'}Weird-Nested${'$'}Name`

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -383,7 +383,7 @@ class ClassName internal constructor(
     }
     // concat top level class name and nested names
     return buildString {
-      append(topLevelClassName())
+      append(topLevelClassName().canonicalName)
       for (name in simpleNames.subList(1, simpleNames.size)) {
         append('$').append(name)
       }

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -199,7 +199,7 @@ private const val ALLOWED_CHARACTER = '$'
 
 internal val String.isKeyword get() = this in KEYWORDS
 
-internal val String.isAllowedCharacter get() = this.any { it == ALLOWED_CHARACTER }
+internal val String.hasAllowedCharacters get() = this.any { it == ALLOWED_CHARACTER }
 
 // https://github.com/JetBrains/kotlin/blob/master/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JvmSimpleNameBacktickChecker.kt
 private val ILLEGAL_CHARACTERS_TO_ESCAPE = setOf('.', ';', '[', ']', '/', '<', '>', ':', '\\')
@@ -211,7 +211,7 @@ private fun String.failIfEscapeInvalid() {
 }
 
 internal fun String.escapeIfNecessary(validate: Boolean = true): String {
-  val escapedString = escapeIfNotJavaIdentifier().escapeIfKeyword().escapeIfAllowedCharacter()
+  val escapedString = escapeIfNotJavaIdentifier().escapeIfKeyword().escapeIfHasAllowedCharacters()
   if (validate) {
     escapedString.failIfEscapeInvalid()
   }
@@ -222,7 +222,7 @@ private fun String.alreadyEscaped() = startsWith("`") && endsWith("`")
 
 private fun String.escapeIfKeyword() = if (isKeyword && !alreadyEscaped()) "`$this`" else this
 
-private fun String.escapeIfAllowedCharacter() = if (isAllowedCharacter && !alreadyEscaped()) "`$this`" else this
+private fun String.escapeIfHasAllowedCharacters() = if (hasAllowedCharacters && !alreadyEscaped()) "`$this`" else this
 
 private fun String.escapeIfNotJavaIdentifier(): String {
   return if (!Character.isJavaIdentifierStart(first()) ||

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -195,13 +195,11 @@ private val KEYWORDS = setOf(
     "typeof"
 )
 
-private val ALLOWED_CHARACTERS = setOf(
-    '$'
-)
+private const val ALLOWED_CHARACTER = '$'
 
 internal val String.isKeyword get() = this in KEYWORDS
 
-internal val String.isAllowedCharacter get() = this.any { it in ALLOWED_CHARACTERS }
+internal val String.isAllowedCharacter get() = this.any { it == ALLOWED_CHARACTER }
 
 // https://github.com/JetBrains/kotlin/blob/master/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JvmSimpleNameBacktickChecker.kt
 private val ILLEGAL_CHARACTERS_TO_ESCAPE = setOf('.', ';', '[', ']', '/', '<', '>', ':', '\\')
@@ -220,13 +218,15 @@ internal fun String.escapeIfNecessary(validate: Boolean = true): String {
   return escapedString
 }
 
-private fun String.escapeIfKeyword() = if (isKeyword) "`$this`" else this
+private fun String.alreadyEscaped() = startsWith("`") && endsWith("`")
 
-private fun String.escapeIfAllowedCharacter() = if (isAllowedCharacter) "`$this`" else this
+private fun String.escapeIfKeyword() = if (isKeyword && !alreadyEscaped()) "`$this`" else this
+
+private fun String.escapeIfAllowedCharacter() = if (isAllowedCharacter && !alreadyEscaped()) "`$this`" else this
 
 private fun String.escapeIfNotJavaIdentifier(): String {
   return if (!Character.isJavaIdentifierStart(first()) ||
-      drop(1).any { !Character.isJavaIdentifierPart(it) }) {
+      drop(1).any { !Character.isJavaIdentifierPart(it) } && !alreadyEscaped()) {
     "`$this`"
   } else {
     this

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -195,7 +195,13 @@ private val KEYWORDS = setOf(
     "typeof"
 )
 
+private val ALLOWED_CHARACTERS = setOf(
+    '$'
+)
+
 internal val String.isKeyword get() = this in KEYWORDS
+
+internal val String.isAllowedCharacter get() = this.any { it in ALLOWED_CHARACTERS }
 
 // https://github.com/JetBrains/kotlin/blob/master/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JvmSimpleNameBacktickChecker.kt
 private val ILLEGAL_CHARACTERS_TO_ESCAPE = setOf('.', ';', '[', ']', '/', '<', '>', ':', '\\')
@@ -207,7 +213,7 @@ private fun String.failIfEscapeInvalid() {
 }
 
 internal fun String.escapeIfNecessary(validate: Boolean = true): String {
-  val escapedString = escapeIfNotJavaIdentifier().escapeIfKeyword()
+  val escapedString = escapeIfNotJavaIdentifier().escapeIfKeyword().escapeIfAllowedCharacter()
   if (validate) {
     escapedString.failIfEscapeInvalid()
   }
@@ -215,6 +221,8 @@ internal fun String.escapeIfNecessary(validate: Boolean = true): String {
 }
 
 private fun String.escapeIfKeyword() = if (isKeyword) "`$this`" else this
+
+private fun String.escapeIfAllowedCharacter() = if (isAllowedCharacter) "`$this`" else this
 
 private fun String.escapeIfNotJavaIdentifier(): String {
   return if (!Character.isJavaIdentifierStart(first()) ||

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -4141,6 +4141,12 @@ class TypeSpecTest {
       |""".trimMargin())
   }
 
+  @Test fun escapeAllowedCharacters() {
+    var typeSpec = TypeSpec.classBuilder("A\$B")
+        .build()
+    assertThat(typeSpec.toString()).isEqualTo("class `A\$B`\n")
+  }
+
   companion object {
     private val donutsPackage = "com.squareup.donuts"
   }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
@@ -96,6 +96,10 @@ class UtilTest {
     assertThat("with_unicode_punctuation\u2026".escapeIfNecessary()).isEqualTo("`with_unicode_punctuation\u2026`")
   }
 
+  @Test fun escapeMultipleTimes() {
+    assertThat("A-\$B".escapeIfNecessary()).isEqualTo("`A-\$B`")
+  }
+
   private fun stringLiteral(string: String) = stringLiteral(string, string)
 
   private fun stringLiteral(expected: String, value: String) =


### PR DESCRIPTION
Resolves #841 

Technically `$` is allowed in names till it's escaped. 

```kotlin
class `A$B`
```

Most other special characters are covered by the Java identifiers. 