### PR TITLE
Re-enable GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: JDK ${{ matrix.java_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java_version: [1.8, 11]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install JDK ${{ matrix.java_version }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java_version }}
+      - name: Configure Gradle
+        # Initial gradle configuration, install dependencies, etc
+        run: ./gradlew help
+      - name: Spot check
+        # Run spotless first to fail fast on spotless issues
+        run: ./gradlew spotlessCheck --stacktrace
+      - name: Build project
+        run: ./gradlew assemble --stacktrace
+      - name: Run tests
+        run: ./gradlew test --stacktrace
+      - name: Final checks
+        run: ./gradlew check --stacktrace
+        # TODO(egor): Setup snapshot publishing
+        # - name: Upload snapshot (master only)
+        #  run: ./gradlew uploadArchives -PSONATYPE_NEXUS_USERNAME=${{ secrets.SonatypeUsername }} -PSONATYPE_NEXUS_PASSWORD=${{ secrets.SonatypePassword }}
+        #  if: success() && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.java_version == '1.8'


### PR DESCRIPTION
I believe that GitHub Actions is now enabled on public repositories regardless of the company's GitHub plan. Uber is also on the legacy plan and it works fine on AutoDispose. 

This basically reverts the commit that killed Actions