### PR TITLE
Revert "Remove kotlin-reflect dependency from the main artifact"

### DIFF
--- a/kotlinpoet-metadata-specs-tests/build.gradle.kts
+++ b/kotlinpoet-metadata-specs-tests/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
   testImplementation(project(":kotlinpoet-classinspector-elements"))
   testImplementation(project(":kotlinpoet-classinspector-reflective"))
   testImplementation(deps.kotlin.junit)
-  testImplementation(deps.kotlin.reflect)
   testImplementation(deps.test.truth)
   testImplementation(deps.test.compileTesting)
 }

--- a/kotlinpoet-metadata-specs/build.gradle.kts
+++ b/kotlinpoet-metadata-specs/build.gradle.kts
@@ -55,6 +55,5 @@ dependencies {
   api(project(":kotlinpoet-metadata"))
 
   testImplementation(deps.kotlin.junit)
-  testImplementation(deps.kotlin.reflect)
   testImplementation(deps.test.truth)
 }

--- a/kotlinpoet/build.gradle.kts
+++ b/kotlinpoet/build.gradle.kts
@@ -44,7 +44,7 @@ afterEvaluate {
 
 dependencies {
   api(deps.kotlin.stdlib)
-  testImplementation(deps.kotlin.reflect)
+  implementation(deps.kotlin.reflect)
   testImplementation(deps.kotlin.junit)
   testImplementation(deps.test.truth)
   testImplementation(deps.test.compileTesting)


### PR DESCRIPTION
This reverts commit 1490fdd88b840d3a98b65f7172e755126b7856e6.

Some functionality will not work without reflect, even though the code compiles fine, it will fail at runtime.