### PR TITLE
Validate Gradle wrapper on pushes to master

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,8 @@
 name: "Validate Gradle Wrapper"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   validation:


### PR DESCRIPTION
Aligns the behavior with SQLDelight: https://github.com/cashapp/sqldelight/blob/master/.github/workflows/gradle-wrapper-validation.yml