### PR TITLE
Don't emit own annotations in LambdaTypeName

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -519,8 +519,6 @@ class LambdaTypeName private constructor(
   }
 
   override fun emit(out: CodeWriter): CodeWriter {
-    emitAnnotations(out)
-
     if (isNullable) {
       out.emit("(")
     }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -769,4 +769,40 @@ class FunSpecTest {
       |}
       |""".trimMargin())
   }
+
+  @Test fun annotatedLambdaReceiverType() {
+    val annotation = AnnotationSpec.builder(ClassName("com.squareup.tacos", "Annotation")).build()
+    val type = LambdaTypeName.get(returnType = UNIT).copy(annotations = listOf(annotation))
+    val spec = FileSpec.builder("com.squareup.tacos", "Taco")
+        .addFunction(FunSpec.builder("foo")
+            .receiver(type)
+            .build())
+        .build()
+    assertThat(spec.toString()).isEqualTo("""
+      |package com.squareup.tacos
+      |
+      |import kotlin.Unit
+      |
+      |fun (@Annotation () -> Unit).foo() {
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun annotatedLambdaReturnType() {
+    val annotation = AnnotationSpec.builder(ClassName("com.squareup.tacos", "Annotation")).build()
+    val type = LambdaTypeName.get(returnType = UNIT).copy(annotations = listOf(annotation))
+    val spec = FileSpec.builder("com.squareup.tacos", "Taco")
+        .addFunction(FunSpec.builder("foo")
+            .returns(type)
+            .build())
+        .build()
+    assertThat(spec.toString()).isEqualTo("""
+      |package com.squareup.tacos
+      |
+      |import kotlin.Unit
+      |
+      |fun foo(): @Annotation () -> Unit {
+      |}
+      |""".trimMargin())
+  }
 }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ParameterSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ParameterSpecTest.kt
@@ -103,4 +103,22 @@ class ParameterSpecTest {
       |}
       |""".trimMargin())
   }
+
+  @Test fun annotatedLambdaType() {
+    val annotation = AnnotationSpec.builder(ClassName("com.squareup.tacos", "Annotation")).build()
+    val type = LambdaTypeName.get(returnType = UNIT).copy(annotations = listOf(annotation))
+    val spec = FileSpec.builder("com.squareup.tacos", "Taco")
+        .addFunction(FunSpec.builder("foo")
+            .addParameter("bar", type)
+            .build())
+        .build()
+    assertThat(spec.toString()).isEqualTo("""
+      |package com.squareup.tacos
+      |
+      |import kotlin.Unit
+      |
+      |fun foo(bar: @Annotation () -> Unit) {
+      |}
+      |""".trimMargin())
+  }
 }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ParameterizedTypeNameTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ParameterizedTypeNameTest.kt
@@ -138,4 +138,13 @@ class ParameterizedTypeNameTest {
   private fun <Param : Closeable> withParam(): Param = throw NotImplementedError("for testing purposes")
 
   private fun <Param : Closeable> withNullableParam(): Param? = throw NotImplementedError("for testing purposes")
+
+  @Test fun annotatedLambdaTypeParameter() {
+    val annotation = AnnotationSpec.builder(ClassName("", "Annotation")).build()
+    val typeName = Map::class.asTypeName()
+        .plusParameter(String::class.asTypeName())
+        .plusParameter(LambdaTypeName.get(returnType = UNIT).copy(annotations = listOf(annotation)))
+    assertThat(typeName.toString())
+        .isEqualTo("kotlin.collections.Map<kotlin.String, @Annotation () -> kotlin.Unit>")
+  }
 }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -375,4 +375,19 @@ class PropertySpecTest {
       |const val FOO: String = "This is a long string with a newline\nin the middle."
       |""".trimMargin())
   }
+
+  @Test fun annotatedLambdaType() {
+    val annotation = AnnotationSpec.builder(ClassName("com.squareup.tacos", "Annotation")).build()
+    val type = LambdaTypeName.get(returnType = UNIT).copy(annotations = listOf(annotation))
+    val spec = FileSpec.builder("com.squareup.tacos", "Taco")
+        .addProperty(PropertySpec.builder("foo", type).build())
+        .build()
+    assertThat(spec.toString()).isEqualTo("""
+      |package com.squareup.tacos
+      |
+      |import kotlin.Unit
+      |
+      |val foo: @Annotation () -> Unit
+      |""".trimMargin())
+  }
 }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeAliasSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeAliasSpecTest.kt
@@ -198,6 +198,15 @@ class TypeAliasSpecTest {
       |typealias `fun` = kotlin.String
       |""".trimMargin())
   }
+
+  @Test fun annotatedLambdaType() {
+    val annotation = AnnotationSpec.builder(ClassName("", "Annotation")).build()
+    val type = LambdaTypeName.get(returnType = UNIT).copy(annotations = listOf(annotation))
+    val spec = TypeAliasSpec.builder("lambda", type).build()
+    assertThat(spec.toString()).isEqualTo("""
+      |typealias lambda = @Annotation () -> kotlin.Unit
+      |""".trimMargin())
+  }
 }
 
 @Retention(RUNTIME)


### PR DESCRIPTION
Fixes #908 

Based on the current design, TypeNames should not emit their own
annotations. Instead, annotations should be emitted by CodeWriter
(as part of the %T printout logic) or enclosing TypeNames (such
as ParameterizedTypeName).