### PR TITLE
Add support for Kotlin 1.4's functional interfaces

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/KModifier.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/KModifier.kt
@@ -48,6 +48,7 @@ enum class KModifier(
 
   ENUM("enum", Target.CLASS),
   ANNOTATION("annotation", Target.CLASS),
+  FUN("fun", Target.INTERFACE),
 
   COMPANION("companion", Target.CLASS),
 
@@ -72,6 +73,7 @@ enum class KModifier(
     TYPE_PARAMETER,
     FUNCTION,
     PROPERTY,
+    INTERFACE,
   }
 
   internal fun checkTarget(target: Target) {

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -750,7 +750,8 @@ class TypeSpec private constructor(
         // Note: Functional interfaces can contain any number of non-abstract functions.
         val abstractFunSpecs = funSpecs.filter { ABSTRACT in it.modifiers }
         check(abstractFunSpecs.size == 1) {
-          "Functional interfaces must have exactly one abstract function. Contained ${abstractFunSpecs.size}: ${abstractFunSpecs.map { it.name }}"
+          "Functional interfaces must have exactly one abstract function. Contained " +
+              "${abstractFunSpecs.size}: ${abstractFunSpecs.map { it.name }}"
         }
       }
 

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -872,7 +872,9 @@ class TypeSpecTest {
           .build()
       fail()
     } catch (e: IllegalStateException) {
-      assertThat(e).hasMessageThat().contains("Functional interfaces must have exactly one abstract function. Contained 0")
+      assertThat(e)
+          .hasMessageThat()
+          .contains("Functional interfaces must have exactly one abstract function. Contained 0")
     }
   }
 
@@ -888,7 +890,9 @@ class TypeSpecTest {
           .build()
       fail()
     } catch (e: IllegalStateException) {
-      assertThat(e).hasMessageThat().contains("Functional interfaces must have exactly one abstract function. Contained 2")
+      assertThat(e)
+          .hasMessageThat()
+          .contains("Functional interfaces must have exactly one abstract function. Contained 2")
     }
   }
 

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -846,6 +846,52 @@ class TypeSpecTest {
         |""".trimMargin())
   }
 
+  @Test fun funInterface() {
+    val taco = ClassName(tacosPackage, "Taco")
+    val typeSpec = TypeSpec.funInterfaceBuilder(taco)
+        .addFunction(FunSpec.builder("sam")
+            .addModifiers(ABSTRACT)
+            .build())
+        .addFunction(FunSpec.builder("notSam").build())
+        .build()
+    assertThat(toString(typeSpec)).isEqualTo("""
+        |package com.squareup.tacos
+        |
+        |fun interface Taco {
+        |  fun sam()
+        |
+        |  fun notSam() {
+        |  }
+        |}
+        |""".trimMargin())
+  }
+
+  @Test fun funInterface_empty_shouldError() {
+    try {
+      TypeSpec.funInterfaceBuilder("Taco")
+          .build()
+      fail()
+    } catch (e: IllegalStateException) {
+      assertThat(e).hasMessageThat().contains("Functional interfaces must have exactly one abstract function. Contained 0")
+    }
+  }
+
+  @Test fun funInterface_multipleAbstract_shouldError() {
+    try {
+      TypeSpec.funInterfaceBuilder("Taco")
+          .addFunction(FunSpec.builder("fun1")
+              .addModifiers(ABSTRACT)
+              .build())
+          .addFunction(FunSpec.builder("fun2")
+              .addModifiers(ABSTRACT)
+              .build())
+          .build()
+      fail()
+    } catch (e: IllegalStateException) {
+      assertThat(e).hasMessageThat().contains("Functional interfaces must have exactly one abstract function. Contained 2")
+    }
+  }
+
   @Test fun nestedClasses() {
     val taco = ClassName(tacosPackage, "Combo", "Taco")
     val topping = ClassName(tacosPackage, "Combo", "Taco", "Topping")


### PR DESCRIPTION
This adds a new `KModifier.FUN` and orders it alongside `enum` and `annotation` (figured this was the most conventional spot).