### PR TITLE
Fun interface followups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,7 +1001,7 @@ val helloWorld = TypeSpec.interfaceBuilder("HelloWorld")
     .build()
 ```
 
-But these modifiers are omitted when the code is generated. These are the defaults so we don't need
+But these modifiers are omitted when the code is generated. These are the default so we don't need
 to include them for `kotlinc`'s benefit!
 
 ```kotlin
@@ -1009,6 +1009,22 @@ interface HelloWorld {
     val buzz: String
 
     fun beep()
+}
+```
+
+Kotlin 1.4 adds support for functional interfaces via `fun interface` syntax. To create this in 
+KotlinPoet, use `TypeSpec.funInterfaceBuilder()`.
+
+```kotlin
+val helloWorld = TypeSpec.funInterfaceBuilder("HelloWorld")
+    .addFunction(FunSpec.builder("beep")
+        .addModifiers(KModifier.ABSTRACT)
+        .build())
+    .build()
+
+// Generates...
+fun interface HelloWorld {
+  fun beep()
 }
 ```
 

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -53,7 +53,7 @@ class TypeSpec private constructor(
   val isAnnotation = builder.isAnnotation
   val isCompanion = builder.isCompanion
   val isAnonymousClass = builder.isAnonymousClass
-  val isFunInterface = builder.isFunInterface
+  val isFunctionalInterface = builder.isFunInterface
 
   /**
    * Map of superinterfaces - entries with a null value represent a regular superinterface (with

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -854,6 +854,7 @@ class TypeSpecTest {
             .build())
         .addFunction(FunSpec.builder("notSam").build())
         .build()
+    assertThat(typeSpec.isFunctionalInterface).isTrue()
     assertThat(toString(typeSpec)).isEqualTo("""
         |package com.squareup.tacos
         |

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -868,19 +868,15 @@ class TypeSpecTest {
   }
 
   @Test fun funInterface_empty_shouldError() {
-    try {
+    assertThrows<IllegalStateException> {
       TypeSpec.funInterfaceBuilder("Taco")
           .build()
-      fail()
-    } catch (e: IllegalStateException) {
-      assertThat(e)
-          .hasMessageThat()
-          .contains("Functional interfaces must have exactly one abstract function. Contained 0")
-    }
+    }.hasMessageThat()
+        .contains("Functional interfaces must have exactly one abstract function. Contained 0")
   }
 
   @Test fun funInterface_multipleAbstract_shouldError() {
-    try {
+    assertThrows<IllegalStateException> {
       TypeSpec.funInterfaceBuilder("Taco")
           .addFunction(FunSpec.builder("fun1")
               .addModifiers(ABSTRACT)
@@ -889,12 +885,8 @@ class TypeSpecTest {
               .addModifiers(ABSTRACT)
               .build())
           .build()
-      fail()
-    } catch (e: IllegalStateException) {
-      assertThat(e)
-          .hasMessageThat()
-          .contains("Functional interfaces must have exactly one abstract function. Contained 2")
-    }
+    }.hasMessageThat()
+        .contains("Functional interfaces must have exactly one abstract function. Contained 2")
   }
 
   @Test fun nestedClasses() {


### PR DESCRIPTION
Followups from #910

One thing I'm wondering is if we should make the function names match `isFunctionalInterface` or vice versa. Right now we have `funInterfaceBuilder()` (like the syntax) and `isFunctionalInterface()` (like the construct)