### PR TITLE
Fixes #194 : FuncSpec.overriding now supports overriding suspend function

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -17,6 +17,7 @@ package com.squareup.kotlinpoet
 
 import com.squareup.kotlinpoet.CodeBlock.Companion.isPlaceholder
 import java.util.Collections
+import kotlin.reflect.KClass
 
 internal object NullAppendable : Appendable {
   override fun append(charSequence: CharSequence) = this
@@ -236,3 +237,9 @@ private fun String.escapeIfNotJavaIdentifier(): String {
 internal fun String.escapeSegmentsIfNecessary(delimiter: Char = '.') = split(delimiter)
     .filter { it.isNotEmpty() }
     .joinToString(delimiter.toString()) { it.escapeIfNecessary() }
+
+fun TypeName.belongsToType(expectedType: TypeName): Boolean {
+  return if (this is ParameterizedTypeName) rawType == expectedType else this == expectedType
+}
+
+fun TypeName.belongsToType(expectedClass: KClass<*>) = belongsToType(expectedClass.asTypeName())


### PR DESCRIPTION
I haven't been able to support suspend vararg functions for now. But I've tested with regular suspend functions... maybe we could also have tests for overriding suspend functions?

Sorry, but I couldn't find any suitable alternative for the extension function I created, `TypeName.belongsToType`. If there already exists a better alternative, I'll switch over to it.