### PR TITLE
Preserve tags with basic copy()

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -86,7 +86,7 @@ sealed class TypeName constructor(
     nullable: Boolean = this.isNullable,
     annotations: List<AnnotationSpec> = this.annotations.toList()
   ): TypeName {
-    return copy(nullable, annotations, emptyMap())
+    return copy(nullable, annotations, this.tags)
   }
 
   abstract fun copy(

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeNameKotlinTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeNameKotlinTest.kt
@@ -68,4 +68,11 @@ class TypeNameKotlinTest {
     val type = typeNameOf<String>().copy(tags = mapOf(String::class to "Test"))
     assertThat(type.tag<String>()).isEqualTo("Test")
   }
+
+  @Test
+  fun existingTagsShouldBePreserved() {
+    val type = typeNameOf<String>().copy(tags = mapOf(String::class to "Test"))
+    val copied = type.copy(nullable = true)
+    assertThat(copied.tag<String>()).isEqualTo("Test")
+  }
 }


### PR DESCRIPTION
This was always clearing tags on copies before