### PR TITLE
Open up FileSpec.Builder for more mutation

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -218,9 +218,10 @@ class FileSpec private constructor(
     internal val comment = CodeBlock.builder()
     internal val memberImports = sortedSetOf<Import>()
     internal var indent = DEFAULT_INDENT
-    internal val members = mutableListOf<Any>()
     override val tags = mutableMapOf<KClass<*>, Any>()
 
+    val imports: List<Import> get() = memberImports.toList()
+    val members = mutableListOf<Any>()
     val annotations = mutableListOf<AnnotationSpec>()
 
     /**
@@ -247,6 +248,10 @@ class FileSpec private constructor(
 
     fun addComment(format: String, vararg args: Any) = apply {
       comment.add(format.replace(' ', '·'), *args)
+    }
+
+    fun clearComment() = apply {
+      comment.clear()
     }
 
     fun addType(typeSpec: TypeSpec) = apply {
@@ -313,6 +318,14 @@ class FileSpec private constructor(
           Import(name)
         }
       }
+    }
+
+    fun addImport(import: Import) = apply {
+      memberImports += import
+    }
+
+    fun clearImports() = apply {
+      memberImports.clear()
     }
 
     fun addAliasedImport(`class`: Class<*>, `as`: String) =

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Import.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Import.kt
@@ -16,9 +16,9 @@
 
 package com.squareup.kotlinpoet
 
-internal data class Import(
-  internal val qualifiedName: String,
-  internal val alias: String? = null
+data class Import internal constructor(
+  val qualifiedName: String,
+  val alias: String? = null
 ) : Comparable<Import> {
 
   private val importString = buildString {

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -770,11 +770,11 @@ class FileSpecTest {
 
     assertThat(builder.build().toString()).isEqualTo("""
       package com.taco
-      
+
       import com.foo.Foo
       import com.foo.Foo2
-      
-      
+
+
     """.trimIndent())
   }
 

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -754,6 +754,52 @@ class FileSpecTest {
     assertThat(builder.build().annotations).containsExactly(javaWord)
   }
 
+  @Test fun modifyImports() {
+    val builder = FileSpec.builder("com.taco", "Taco")
+        .addImport("com.foo", "Foo")
+
+    val currentImports = builder.imports
+    builder.clearImports()
+    builder.addImport("com.foo", "Foo2")
+        .apply {
+          for (current in currentImports) {
+            addImport(current)
+          }
+        }
+        .indent("")
+
+    assertThat(builder.build().toString()).isEqualTo("""
+      package com.taco
+      
+      import com.foo.Foo
+      import com.foo.Foo2
+      
+      
+    """.trimIndent())
+  }
+
+  @Test fun modifyMembers() {
+    val builder = FileSpec.builder("com.taco", "Taco")
+        .addFunction(FunSpec.builder("aFunction").build())
+        .addFunction(FunSpec.builder("aSecondFunction").build())
+        .addType(TypeSpec.classBuilder("AClass").build())
+
+    builder.members.removeAll { it !is TypeSpec }
+
+    check(builder.build().members.all { it is TypeSpec })
+  }
+
+  @Test fun clearIndent() {
+    val builder = FileSpec.builder("com.taco", "Taco")
+        .addFunction(FunSpec.builder("aFunction").build())
+        .addComment("Hello!")
+
+    builder.clearComment()
+        .addComment("Goodbye!")
+
+    assertThat(builder.build().comment.toString()).isEqualTo("Goodbye!")
+  }
+
   // https://github.com/square/kotlinpoet/issues/480
   @Test fun defaultPackageMemberImport() {
     val bigInteger = ClassName.bestGuess("bigInt.BigInteger")

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -789,7 +789,7 @@ class FileSpecTest {
     check(builder.build().members.all { it is TypeSpec })
   }
 
-  @Test fun clearIndent() {
+  @Test fun clearComment() {
     val builder = FileSpec.builder("com.taco", "Taco")
         .addFunction(FunSpec.builder("aFunction").build())
         .addComment("Hello!")

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -781,7 +781,8 @@ class FileSpecTest {
   @Test fun modifyMembers() {
     val builder = FileSpec.builder("com.taco", "Taco")
         .addFunction(FunSpec.builder("aFunction").build())
-        .addFunction(FunSpec.builder("aSecondFunction").build())
+        .addProperty(PropertySpec.builder("aProperty", INT).initializer("1").build())
+        .addTypeAlias(TypeAliasSpec.builder("ATypeAlias", INT).build())
         .addType(TypeSpec.classBuilder("AClass").build())
 
     builder.members.removeAll { it !is TypeSpec }


### PR DESCRIPTION
Similar towhat we do in other spec builders, this allows mutation of builder bits directly (so it's no longer just additive).

This covers:
- `comment`
- `members`
- `memberImports`. Specifically - this makes `Import` public but keeps its constructor `internal` and adds an adder. This allows reading Imports and re-adding them later if they're cleared in between, and seemed strictly better than just making the `memberImports` property itself public since we want folks to use the `addImport` functions.