### PR TITLE
Emit Unit as return type

### DIFF
--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/FileFacadeTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/FileFacadeTest.kt
@@ -33,6 +33,7 @@ class FacadeFileTest : MultiClassInspectorTest() {
       import kotlin.Int
       import kotlin.Long
       import kotlin.String
+      import kotlin.Unit
       import kotlin.collections.List
       import kotlin.jvm.JvmField
       import kotlin.jvm.JvmName
@@ -40,21 +41,21 @@ class FacadeFileTest : MultiClassInspectorTest() {
       import kotlin.jvm.Synchronized
 
       @JvmName(name = "jvmStaticFunction")
-      fun jvmNameFunction() {
+      fun jvmNameFunction(): Unit {
       }
 
       fun jvmOverloads(
         param1: String,
         optionalParam2: String = throw NotImplementedError("Stub!"),
         nullableParam3: String? = throw NotImplementedError("Stub!")
-      ) {
+      ): Unit {
       }
 
-      fun regularFun() {
+      fun regularFun(): Unit {
       }
 
       @Synchronized
-      fun synchronizedFun() {
+      fun synchronizedFun(): Unit {
       }
 
       val BINARY_PROP: Int = 11
@@ -165,6 +166,7 @@ class FacadeFileTest : MultiClassInspectorTest() {
       import kotlin.Int
       import kotlin.Long
       import kotlin.String
+      import kotlin.Unit
       import kotlin.collections.List
       import kotlin.jvm.JvmName
       import kotlin.jvm.JvmOverloads
@@ -172,7 +174,7 @@ class FacadeFileTest : MultiClassInspectorTest() {
       import kotlin.jvm.Synchronized
 
       @JvmName(name = "jvmStaticFunction")
-      fun jvmNameFunction() {
+      fun jvmNameFunction(): Unit {
       }
 
       @JvmOverloads
@@ -180,14 +182,14 @@ class FacadeFileTest : MultiClassInspectorTest() {
         param1: String,
         optionalParam2: String = throw NotImplementedError("Stub!"),
         nullableParam3: String? = throw NotImplementedError("Stub!")
-      ) {
+      ): Unit {
       }
 
-      fun regularFun() {
+      fun regularFun(): Unit {
       }
 
       @Synchronized
-      fun synchronizedFun() {
+      fun synchronizedFun(): Unit {
       }
 
       val BINARY_PROP: Int = 11

--- a/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/kotlinpoet-metadata-specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -233,13 +233,13 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
       class SuspendTypes {
         val testProp: suspend (kotlin.Int, kotlin.Long) -> kotlin.String = throw NotImplementedError("Stub!")
 
-        suspend fun testComplexSuspendFun(body: suspend (kotlin.Int, suspend (kotlin.Long) -> kotlin.String) -> kotlin.String) {
+        suspend fun testComplexSuspendFun(body: suspend (kotlin.Int, suspend (kotlin.Long) -> kotlin.String) -> kotlin.String): kotlin.Unit {
         }
 
-        fun testFun(body: suspend (kotlin.Int, kotlin.Long) -> kotlin.String) {
+        fun testFun(body: suspend (kotlin.Int, kotlin.Long) -> kotlin.String): kotlin.Unit {
         }
 
-        suspend fun testSuspendFun(param1: kotlin.String) {
+        suspend fun testSuspendFun(param1: kotlin.String): kotlin.Unit {
         }
       }
     """.trimIndent())
@@ -264,10 +264,10 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Parameters {
-        inline fun hasDefault(param1: kotlin.String = throw NotImplementedError("Stub!")) {
+        inline fun hasDefault(param1: kotlin.String = throw NotImplementedError("Stub!")): kotlin.Unit {
         }
 
-        inline fun inline(crossinline param1: () -> kotlin.String) {
+        inline fun inline(crossinline param1: () -> kotlin.String): kotlin.Unit {
         }
 
         inline fun noinline(noinline param1: () -> kotlin.String): kotlin.String {
@@ -295,13 +295,13 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class LambdaReceiver {
-        fun lambdaReceiver(block: kotlin.String.() -> kotlin.Unit) {
+        fun lambdaReceiver(block: kotlin.String.() -> kotlin.Unit): kotlin.Unit {
         }
 
-        fun lambdaReceiver2(block: kotlin.String.(kotlin.Int) -> kotlin.Unit) {
+        fun lambdaReceiver2(block: kotlin.String.(kotlin.Int) -> kotlin.Unit): kotlin.Unit {
         }
 
-        fun lambdaReceiver3(block: kotlin.String.(kotlin.Int, kotlin.String) -> kotlin.Unit) {
+        fun lambdaReceiver3(block: kotlin.String.(kotlin.Int, kotlin.String) -> kotlin.Unit): kotlin.Unit {
         }
       }
     """.trimIndent())
@@ -351,7 +351,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class FunctionsReferencingTypeParameters<T> {
-        fun test(param: T) {
+        fun test(param: T): kotlin.Unit {
         }
       }
     """.trimIndent())
@@ -373,10 +373,10 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
 
         override var openPropInterface: kotlin.String = throw NotImplementedError("Stub!")
 
-        override fun openFunction() {
+        override fun openFunction(): kotlin.Unit {
         }
 
-        override fun openFunctionInterface() {
+        override fun openFunctionInterface(): kotlin.Unit {
         }
       }
     """.trimIndent())
@@ -608,7 +608,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
           throw NotImplementedError("Stub!")
         }
 
-        fun hasDefault() {
+        fun hasDefault(): kotlin.Unit {
         }
 
         fun hasDefaultMultiParam(input: kotlin.String, input2: kotlin.String): kotlin.String {
@@ -620,14 +620,14 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         }
 
         @kotlin.jvm.JvmDefault
-        fun hasJvmDefault() {
+        fun hasJvmDefault(): kotlin.Unit {
         }
 
-        fun noDefault()
+        fun noDefault(): kotlin.Unit
 
-        fun noDefaultWithInput(input: kotlin.String)
+        fun noDefaultWithInput(input: kotlin.String): kotlin.Unit
 
-        fun noDefaultWithInputDefault(input: kotlin.String = throw NotImplementedError("Stub!"))
+        fun noDefaultWithInputDefault(input: kotlin.String = throw NotImplementedError("Stub!")): kotlin.Unit
       }
     """.trimIndent())
 
@@ -636,14 +636,14 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     //language=kotlin
     assertThat(subInterfaceSpec.trimmedToString()).isEqualTo("""
       interface SubInterface : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TestInterface {
-        override fun hasDefault() {
+        override fun hasDefault(): kotlin.Unit {
         }
 
         @kotlin.jvm.JvmDefault
-        override fun hasJvmDefault() {
+        override fun hasJvmDefault(): kotlin.Unit {
         }
 
-        fun subInterfaceFunction() {
+        fun subInterfaceFunction(): kotlin.Unit {
         }
       }
     """.trimIndent())
@@ -653,13 +653,13 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     //language=kotlin
     assertThat(implSpec.trimmedToString()).isEqualTo("""
       class TestSubInterfaceImpl : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.SubInterface {
-        override fun noDefault() {
+        override fun noDefault(): kotlin.Unit {
         }
 
-        override fun noDefaultWithInput(input: kotlin.String) {
+        override fun noDefaultWithInput(input: kotlin.String): kotlin.Unit {
         }
 
-        override fun noDefaultWithInputDefault(input: kotlin.String) {
+        override fun noDefaultWithInputDefault(input: kotlin.String): kotlin.Unit {
         }
       }
     """.trimIndent())
@@ -779,19 +779,19 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class GenericClass<T> {
-        fun <T> functionAlsoWithT(param: T) {
+        fun <T> functionAlsoWithT(param: T): kotlin.Unit {
         }
 
-        fun <R> functionWithADifferentType(param: R) {
+        fun <R> functionWithADifferentType(param: R): kotlin.Unit {
         }
 
-        fun functionWithT(param: T) {
+        fun functionWithT(param: T): kotlin.Unit {
         }
 
         /**
          * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
          */
-        inline fun <reified T> reified(param: T) {
+        inline fun <reified T> reified(param: T): kotlin.Unit {
         }
       }
     """.trimIndent())
@@ -861,7 +861,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         constructor(value: kotlin.String)
 
         @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.FunctionAnnotation
-        fun function() {
+        fun function(): kotlin.Unit {
         }
       }
     """.trimIndent())
@@ -1142,7 +1142,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         var volatileProp: kotlin.String? = null
 
         @kotlin.jvm.Synchronized
-        fun synchronizedFun() {
+        fun synchronizedFun(): kotlin.Unit {
         }
       }
     """.trimIndent())
@@ -1153,10 +1153,10 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     assertThat(interfaceSpec.trimmedToString()).isEqualTo("""
       interface JvmAnnotationsInterface {
         @kotlin.jvm.JvmDefault
-        fun defaultMethod() {
+        fun defaultMethod(): kotlin.Unit {
         }
 
-        fun notDefaultMethod()
+        fun notDefaultMethod(): kotlin.Unit
       }
     """.trimIndent())
   }
@@ -1219,7 +1219,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         var propertySet: kotlin.String? = null
 
         @kotlin.jvm.JvmName(name = "jvmFunction")
-        fun function() {
+        fun function(): kotlin.Unit {
         }
 
         interface InterfaceWithJvmName {
@@ -1230,7 +1230,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
 
             @kotlin.jvm.JvmName(name = "jvmStaticFunction")
             @kotlin.jvm.JvmStatic
-            fun staticFunction() {
+            fun staticFunction(): kotlin.Unit {
             }
           }
         }
@@ -1292,7 +1292,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
           param1: kotlin.String,
           optionalParam2: kotlin.String = throw NotImplementedError("Stub!"),
           nullableParam3: kotlin.String? = throw NotImplementedError("Stub!")
-        ) {
+        ): kotlin.Unit {
         }
       }
     """.trimIndent())
@@ -1419,7 +1419,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
          * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
          */
         @kotlin.jvm.JvmSynthetic
-        fun function() {
+        fun function(): kotlin.Unit {
         }
 
         interface InterfaceWithJvmName {
@@ -1427,7 +1427,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
            * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
            */
           @kotlin.jvm.JvmSynthetic
-          fun interfaceFunction()
+          fun interfaceFunction(): kotlin.Unit
 
           companion object {
             @get:kotlin.jvm.JvmSynthetic
@@ -1439,7 +1439,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
              */
             @kotlin.jvm.JvmStatic
             @kotlin.jvm.JvmSynthetic
-            fun staticFunction() {
+            fun staticFunction(): kotlin.Unit {
             }
           }
         }
@@ -1482,7 +1482,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
          * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
          */
         @kotlin.jvm.JvmSynthetic
-        fun function() {
+        fun function(): kotlin.Unit {
         }
 
         interface InterfaceWithJvmName {
@@ -1490,7 +1490,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
            * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
            */
           @kotlin.jvm.JvmSynthetic
-          fun interfaceFunction()
+          fun interfaceFunction(): kotlin.Unit
 
           companion object {
             @get:kotlin.jvm.JvmSynthetic
@@ -1501,7 +1501,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
              * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
              */
             @kotlin.jvm.JvmSynthetic
-            fun staticFunction() {
+            fun staticFunction(): kotlin.Unit {
             }
           }
         }
@@ -1570,7 +1570,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         var setterThrows: kotlin.String? = null
 
         @kotlin.jvm.Throws(exceptionClasses = [java.lang.IllegalStateException::class])
-        fun testFunction() {
+        fun testFunction(): kotlin.Unit {
         }
       }
       """.trimIndent())
@@ -1714,7 +1714,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "2")
         param2: kotlin.String
       ) {
-        fun function(@com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "woo") param1: kotlin.String) {
+        fun function(@com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "woo") param1: kotlin.String): kotlin.Unit {
         }
       }
       """.trimIndent())
@@ -1736,7 +1736,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "2")
         param2: kotlin.String
       ) {
-        fun function(@com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "woo") param1: kotlin.String) {
+        fun function(@com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "woo") param1: kotlin.String): kotlin.Unit {
         }
       }
       """.trimIndent())
@@ -1803,7 +1803,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
       class TypeAnnotations {
         val foo: kotlin.collections.List<@com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.String> = throw NotImplementedError("Stub!")
 
-        fun <T> bar(input: @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.String, input2: @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation (@com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.Int) -> @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.String) {
+        fun <T> bar(input: @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.String, input2: @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation (@com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.Int) -> @com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.String): kotlin.Unit {
         }
       }
       """.trimIndent()
@@ -1833,7 +1833,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     //language=kotlin
     assertThat(typeSpec.trimmedToString()).isEqualTo("""
       class Asset<A : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.Asset<A>> {
-        fun <D : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.Asset<D>, C : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.Asset<A>> function() {
+        fun <D : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.Asset<D>, C : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.Asset<A>> function(): kotlin.Unit {
         }
 
         class AssetIn<in C : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.Asset.AssetIn<C>>
@@ -1864,11 +1864,11 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
 
         abstract val foo: kotlin.String
 
-        abstract fun bar()
+        abstract fun bar(): kotlin.Unit
 
         abstract fun barWithReturn(): kotlin.String
 
-        fun fuz() {
+        fun fuz(): kotlin.Unit {
         }
 
         fun fuzWithReturn(): kotlin.String {
@@ -1923,13 +1923,13 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
 
         open val openProp: kotlin.String? = null
 
-        fun implicitFinalFun() {
+        fun implicitFinalFun(): kotlin.Unit {
         }
 
-        override fun interfaceFun() {
+        override fun interfaceFun(): kotlin.Unit {
         }
 
-        open fun openFun() {
+        open fun openFun(): kotlin.Unit {
         }
       }
     """.trimIndent())
@@ -1941,7 +1941,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
       abstract class FinalAbstractModalities : com.squareup.kotlinpoet.metadata.specs.test.KotlinPoetMetadataSpecsTest.ModalitiesInterface {
         final override val interfaceProp: kotlin.String? = null
 
-        final override fun interfaceFun() {
+        final override fun interfaceFun(): kotlin.Unit {
         }
       }
     """.trimIndent())
@@ -1955,10 +1955,10 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
 
         override val openProp: kotlin.String? = null
 
-        override fun interfaceFun() {
+        override fun interfaceFun(): kotlin.Unit {
         }
 
-        override fun openFun() {
+        override fun openFun(): kotlin.Unit {
         }
       }
     """.trimIndent())

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
@@ -285,8 +285,9 @@ class AnnotationSpecTest {
       |package test
       |
       |import kotlin.Suppress
+      |import kotlin.Unit
       |
-      |fun test() {
+      |fun test(): Unit {
       |  @Suppress("Things")
       |  val annotatedString = "AnnotatedString"
       |}
@@ -303,7 +304,7 @@ class AnnotationSpecTest {
         .build()
 
     assertThat(funSpec.toString().trim()).isEqualTo("""
-      |fun operation() {
+      |fun operation(): kotlin.Unit {
       |  @Suppress("UNCHECKED_CAST")
       |}
       """.trimMargin())
@@ -480,6 +481,7 @@ class AnnotationSpecTest {
       package com.squareup.parceler
 
       import kotlin.Int
+      import kotlin.Unit
 
       class ExternalClass(
         val value: Int
@@ -488,7 +490,7 @@ class AnnotationSpecTest {
       object ExternalClassParceler : Parceler<ExternalClass> {
         override fun create(parcel: Parcel) = ExternalClass(parcel.readInt())
 
-        override fun ExternalClass.write(parcel: Parcel, flags: Int) {
+        override fun ExternalClass.write(parcel: Parcel, flags: Int): Unit {
           parcel.writeInt(value)
         }
       }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
@@ -179,8 +179,9 @@ class ClassNameTest {
       |package com.squareup.tacos
       |
       |import com.squareup.`taco factory`.`Taco Factory`
+      |import kotlin.Unit
       |
-      |fun main() {
+      |fun main(): Unit {
       |  println(`Taco Factory`.produceTacos())
       |}
       |""".trimMargin())

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/CodeBlockTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/CodeBlockTest.kt
@@ -448,7 +448,9 @@ class CodeBlockTest {
     assertThat(file.toString()).isEqualTo("""
       |package com.squareup.tacos
       |
-      |fun test() {
+      |import kotlin.Unit
+      |
+      |fun test(): Unit {
       |  if ("Very long string that would wrap the line " ==
       |      "Very long string that would wrap the line ") {
       |  } else if ("Long string that would wrap the line 2 " ==

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/CrossplatformTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/CrossplatformTest.kt
@@ -62,6 +62,7 @@ class CrossplatformTest {
     assertThat(fileSpec.toString()).isEqualTo("""
       |import java.util.concurrent.atomic.AtomicReference
       |import kotlin.Boolean
+      |import kotlin.Unit
       |
       |internal expect class AtomicRef<V>(
       |  value: V
@@ -70,7 +71,7 @@ class CrossplatformTest {
       |
       |  fun get(): V
       |
-      |  fun set(value: V)
+      |  fun set(value: V): Unit
       |
       |  fun getAndSet(value: V): V
       |

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -345,8 +345,9 @@ class FileSpecTest {
       |package com.example
       |
       |import com.squareup.`taco factory`.TacoFactory
+      |import kotlin.Unit
       |
-      |fun main() {
+      |fun main(): Unit {
       |  println(TacoFactory.produceTacos())
       |}
       |""".trimMargin())
@@ -363,9 +364,10 @@ class FileSpecTest {
     assertThat(file.toString()).isEqualTo("""
       |package com.example
       |
+      |import kotlin.Unit
       |import com.squareup.`taco factory`.TacoFactory as `La Taqueria`
       |
-      |fun main() {
+      |fun main(): Unit {
       |  println(`La Taqueria`.produceTacos())
       |}
       |""".trimMargin())
@@ -405,9 +407,10 @@ class FileSpecTest {
     assertThat(source.toString()).isEqualTo("""
       |package com.squareup.tacos
       |
+      |import kotlin.Unit
       |import java.util.concurrent.TimeUnit.MINUTES as MINS
       |
-      |fun sleepForFiveMins() {
+      |fun sleepForFiveMins(): Unit {
       |  MINS.sleep(5)
       |}
       |""".trimMargin())
@@ -576,9 +579,10 @@ class FileSpecTest {
         |import java.lang.System
         |import kotlin.Array
         |import kotlin.String
+        |import kotlin.Unit
         |
         |class HelloWorld {
-        |  fun main(args: Array<String>) {
+        |  fun main(args: Array<String>): Unit {
         |    System.out.println("Hello World!");
         |  }
         |}
@@ -837,7 +841,9 @@ class FileSpecTest {
     assertThat(spec.toString()).isEqualTo("""
       |package com.squareup.taco.enchilada.quesadillas.tamales.burritos.`super`.burritos.trying.to.get.a.really.large.packagename
       |
-      |fun foo() {
+      |import kotlin.Unit
+      |
+      |fun foo(): Unit {
       |}
       |""".trimMargin())
   }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileWritingTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileWritingTest.kt
@@ -255,11 +255,12 @@ class FileWritingTest {
         |import java.lang.System
         |import java.util.Date
         |import kotlin.Array
+        |import kotlin.Unit
         |
         |class Test {
         |${"\t"}val madeFreshDate: Date
         |
-        |${"\t"}fun main(args: Array<String>) {
+        |${"\t"}fun main(args: Array<String>): Unit {
         |${"\t\t"}System.out.println("Hello World!");
         |${"\t"}}
         |}

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -146,7 +146,7 @@ class FunSpecTest {
             .build())
         .build()
     assertThat(funSpec.toString()).isEqualTo("""
-      |fun foo(string: kotlin.String?) {
+      |fun foo(string: kotlin.String?): kotlin.Unit {
       |}
       |""".trimMargin())
   }
@@ -167,7 +167,7 @@ class FunSpecTest {
         .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
-      |fun foo() {
+      |fun foo(): kotlin.Unit {
       |}
       |""".trimMargin())
   }
@@ -206,7 +206,7 @@ class FunSpecTest {
       |  string: kotlin.String,
       |  number: kotlin.Int,
       |  nodoc: kotlin.Boolean
-      |) {
+      |): kotlin.Unit {
       |}
       |""".trimMargin())
   }
@@ -224,7 +224,7 @@ class FunSpecTest {
       |/**
       | * @param string A string parameter. This is non null
       | */
-      |fun foo(string: kotlin.String) {
+      |fun foo(string: kotlin.String): kotlin.Unit {
       |}
       |""".trimMargin())
   }
@@ -293,7 +293,7 @@ class FunSpecTest {
         .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
-      |fun foo() {
+      |fun foo(): kotlin.Unit {
       |  throwOrDoSomethingElse()
       |}
       |""".trimMargin())
@@ -521,7 +521,7 @@ class FunSpecTest {
         .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
-      |fun `if`() {
+      |fun `if`(): kotlin.Unit {
       |}
       |""".trimMargin())
   }
@@ -531,7 +531,7 @@ class FunSpecTest {
         .build()
 
     assertThat(funSpec.toString()).isEqualTo("""
-      |fun `with-hyphen`() {
+      |fun `with-hyphen`(): kotlin.Unit {
       |}
       |""".trimMargin())
   }
@@ -690,7 +690,7 @@ class FunSpecTest {
 
     assertThat(builder.build().toString()).isEqualTo("""
       |@kotlin.jvm.JvmStatic
-      |internal fun staticMethod() {
+      |internal fun staticMethod(): kotlin.Unit {
       |}
       |""".trimMargin())
   }
@@ -700,7 +700,7 @@ class FunSpecTest {
     builder.jvmModifiers(listOf(Modifier.FINAL))
 
     assertThat(builder.build().toString()).isEqualTo("""
-      |internal final fun finalMethod() {
+      |internal final fun finalMethod(): kotlin.Unit {
       |}
       |""".trimMargin())
   }
@@ -711,7 +711,7 @@ class FunSpecTest {
 
     assertThat(builder.build().toString()).isEqualTo("""
       |@kotlin.jvm.Synchronized
-      |internal fun synchronizedMethod() {
+      |internal fun synchronizedMethod(): kotlin.Unit {
       |}
       |""".trimMargin())
   }
@@ -722,7 +722,7 @@ class FunSpecTest {
         .build()
 
     assertThat(methodSpec.toString()).isEqualTo("""
-      |fun function() {
+      |fun function(): kotlin.Unit {
       |  codeWithNoNewline()
       |}
       |""".trimMargin())
@@ -735,7 +735,7 @@ class FunSpecTest {
         .build()
 
     assertThat(methodSpec.toString()).isEqualTo("""
-      |fun function() {
+      |fun function(): kotlin.Unit {
       |  codeWithNoNewline()
       |}
       |""".trimMargin())
@@ -750,7 +750,7 @@ class FunSpecTest {
       |/**
       | * This is a comment with no initial newline
       | */
-      |fun function() {
+      |fun function(): kotlin.Unit {
       |}
       |""".trimMargin())
   }
@@ -765,7 +765,7 @@ class FunSpecTest {
       |/**
       | * This is a comment with an initial newline
       | */
-      |fun function() {
+      |fun function(): kotlin.Unit {
       |}
       |""".trimMargin())
   }
@@ -783,7 +783,7 @@ class FunSpecTest {
       |
       |import kotlin.Unit
       |
-      |fun (@Annotation () -> Unit).foo() {
+      |fun (@Annotation () -> Unit).foo(): Unit {
       |}
       |""".trimMargin())
   }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -42,15 +42,16 @@ class KotlinPoetTest {
         |package com.squareup.tacos
         |
         |import kotlin.String
+        |import kotlin.Unit
         |
-        |fun a() {
+        |fun a(): Unit {
         |}
         |
         |class B
         |
         |val c: String = "C"
         |
-        |fun d() {
+        |fun d(): Unit {
         |}
         |
         |class E
@@ -178,17 +179,19 @@ class KotlinPoetTest {
     assertThat(source.toString()).isEqualTo("""
         |package com.squareup.tacos
         |
+        |import kotlin.Unit
+        |
         |class Taco {
-        |  fun a() {
+        |  fun a(): Unit {
         |  }
         |
-        |  protected fun b() {
+        |  protected fun b(): Unit {
         |  }
         |
-        |  internal fun c() {
+        |  internal fun c(): Unit {
         |  }
         |
-        |  private fun d() {
+        |  private fun d(): Unit {
         |  }
         |}
         |""".trimMargin())
@@ -204,8 +207,10 @@ class KotlinPoetTest {
     assertThat(source.toString()).isEqualTo("" +
         "package com.squareup.tacos\n" +
         "\n" +
+        "import kotlin.Unit\n" +
+        "\n" +
         "class Taco {\n" +
-        "  fun strings() {\n" +
+        "  fun strings(): Unit {\n" +
         "    val a = \"basic string\"\n" +
         "    val b = \"string with a \${\'\$\'} dollar sign\"\n" +
         "  }\n" +
@@ -234,8 +239,10 @@ class KotlinPoetTest {
     assertThat(source.toString()).isEqualTo("" +
         "package com.squareup.tacos\n" +
         "\n" +
+        "import kotlin.Unit\n" +
+        "\n" +
         "class Taco {\n" +
-        "  fun strings() {\n" +
+        "  fun strings(): Unit {\n" +
         "    val a = \"\"\"\n" +
         "        |\"\n" +
         "        |\"\"\".trimMargin()\n" +
@@ -271,8 +278,10 @@ class KotlinPoetTest {
     assertThat(source.toString()).isEqualTo("" +
         "package com.squareup.tacos\n" +
         "\n" +
+        "import kotlin.Unit\n" +
+        "\n" +
         "class Taco {\n" +
-        "  fun strings() {\n" +
+        "  fun strings(): Unit {\n" +
         "    val a = \"\"\"\n" +
         "        |\n" +
         "        |\"\"\".trimMargin()\n" +
@@ -296,9 +305,10 @@ class KotlinPoetTest {
         |package com.squareup.tacos
         |
         |import kotlin.String
+        |import kotlin.Unit
         |
         |class Taco {
-        |  fun addCheese(kind: String = "monterey jack") {
+        |  fun addCheese(kind: String = "monterey jack"): Unit {
         |  }
         |}
         |""".trimMargin())
@@ -595,11 +605,13 @@ class KotlinPoetTest {
     assertThat(source.toString()).isEqualTo("""
       |package com.squareup.tacos
       |
+      |import kotlin.Unit
+      |
       |var bar: suspend (Foo) -> Bar = { Bar() }
       |
       |var nullBar: (suspend (Foo) -> Bar)? = null
       |
-      |fun foo(bar: suspend (Foo) -> Bar) {
+      |fun foo(bar: suspend (Foo) -> Bar): Unit {
       |}
       |""".trimMargin())
   }
@@ -619,8 +631,9 @@ class KotlinPoetTest {
       |
       |import java.util.concurrent.TimeUnit
       |import kotlin.Long
+      |import kotlin.Unit
       |
-      |fun timeout(duration: Long, timeUnit: TimeUnit = TimeUnit.MILLISECONDS) {
+      |fun timeout(duration: Long, timeUnit: TimeUnit = TimeUnit.MILLISECONDS): Unit {
       |  this.timeout = timeUnit.toMillis(duration)
       |}
       |""".trimMargin())
@@ -642,7 +655,9 @@ class KotlinPoetTest {
     assertThat(source.toString()).isEqualTo("""
       |package com.squareup.tacos
       |
-      |fun dynamicTest() {
+      |import kotlin.Unit
+      |
+      |fun dynamicTest(): Unit {
       |  val d1: dynamic = "Taco"
       |  val d2: dynamic = 1f
       |  // dynamics are dangerous!
@@ -688,10 +703,11 @@ class KotlinPoetTest {
       |package com.squareup.tacos
       |
       |import kotlin.Int
+      |import kotlin.Unit
       |import kotlin.collections.List
       |import kotlin.jvm.JvmSuppressWildcards
       |
-      |fun foo(a: List<@JvmSuppressWildcards Int>) {
+      |fun foo(a: List<@JvmSuppressWildcards Int>): Unit {
       |}
       |""".trimMargin())
   }
@@ -766,8 +782,10 @@ class KotlinPoetTest {
       |package com.squareup.tacos
       |
       |import kotlin.String
+      |import kotlin.Unit
       |
-      |fun functionWithAPrettyLongNameThatWouldCauseWrapping(parameterWithALongNameThatWouldAlsoCauseWrapping: String) {
+      |fun functionWithAPrettyLongNameThatWouldCauseWrapping(parameterWithALongNameThatWouldAlsoCauseWrapping: String):
+      |    Unit {
       |}
       |""".trimMargin())
   }
@@ -857,8 +875,9 @@ class KotlinPoetTest {
       |package com.squareup.example
       |
       |import com.squareup.tacos.Taco
+      |import kotlin.Unit
       |
-      |fun main() {
+      |fun main(): Unit {
       |  println(${'"'}""Here's a taco: ${'$'}{Taco()}""${'"'})
       |}
       |""".trimMargin())
@@ -876,9 +895,10 @@ class KotlinPoetTest {
     assertThat(file.toString()).isEqualTo("""
       |package com.squareup.example
       |
+      |import kotlin.Unit
       |import kotlin.collections.contentToString
       |
-      |fun main() {
+      |fun main(): Unit {
       |  val ints = arrayOf(1, 2, 3)
       |  println(${'"'}""${'$'}{ints.contentToString()}""${'"'})
       |}
@@ -910,7 +930,7 @@ class KotlinPoetTest {
       | * @param a Progress in %
       | * @param b Some other parameter with %
       | */
-      |fun test(a: kotlin.Int, b: kotlin.Int) {
+      |fun test(a: kotlin.Int, b: kotlin.Int): kotlin.Unit {
       |}
       |""".trimMargin())
   }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/LineWrappingTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/LineWrappingTest.kt
@@ -88,7 +88,9 @@ class LineWrappingTest {
     assertThat(toString(wrapMe)).isEqualTo("""
         |package com.squareup.tacos
         |
-        |fun wrapMe() {
+        |import kotlin.Unit
+        |
+        |fun wrapMe(): Unit {
         |  val a =    8
         |  val b =   64
         |  val c =  512
@@ -107,7 +109,9 @@ class LineWrappingTest {
     assertThat(toString(wrapMe)).isEqualTo("""
         |package com.squareup.tacos
         |
-        |fun wrapMe() {
+        |import kotlin.Unit
+        |
+        |fun wrapMe(): Unit {
         |  val aaaaaa = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" +1
         |  val bbbbbb =
         |      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" +1
@@ -135,6 +139,7 @@ class LineWrappingTest {
         |package com.squareup.tacos
         |
         |import kotlin.String
+        |import kotlin.Unit
         |
         |class Taco {
         |  fun call(
@@ -170,7 +175,7 @@ class LineWrappingTest {
         |    s29: String,
         |    s30: String,
         |    s31: String
-        |  ) {
+        |  ): Unit {
         |    call("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16",
         |        "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31")
         |  }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/MemberNameTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/MemberNameTest.kt
@@ -37,8 +37,9 @@ class MemberNameTest {
       |
       |import com.squareup.tacos.bestTacoEver
       |import com.squareup.tacos.randomTaco
+      |import kotlin.Unit
       |
-      |fun makeTastyTacos() {
+      |fun makeTastyTacos(): Unit {
       |  val randomTaco = randomTaco()
       |  val bestTaco = bestTacoEver
       |}
@@ -57,8 +58,9 @@ class MemberNameTest {
       |package com.example
       |
       |import com.squareup.tacos.Taco.Companion.createTaco
+      |import kotlin.Unit
       |
-      |fun makeTastyTacos() {
+      |fun makeTastyTacos(): Unit {
       |  createTaco()
       |}
       |""".trimMargin())
@@ -74,7 +76,9 @@ class MemberNameTest {
     assertThat(file.toString()).isEqualTo("""
       |package com.squareup.tacos
       |
-      |fun makeTastyTacos() {
+      |import kotlin.Unit
+      |
+      |fun makeTastyTacos(): Unit {
       |  createTaco()
       |}
       |""".trimMargin())
@@ -94,8 +98,9 @@ class MemberNameTest {
       |package com.squareup.tacos
       |
       |import com.squareup.tacos.Town.createTaco
+      |import kotlin.Unit
       |
-      |fun makeTastyTacos() {
+      |fun makeTastyTacos(): Unit {
       |  createTaco()
       |}
       |""".trimMargin())
@@ -114,8 +119,9 @@ class MemberNameTest {
       |package com.example
       |
       |import com.squareup.tacos.createTaco
+      |import kotlin.Unit
       |
-      |fun makeTastyTacos() {
+      |fun makeTastyTacos(): Unit {
       |  createTaco()
       |  com.twitter.tacos.createTaco()
       |}
@@ -138,8 +144,9 @@ class MemberNameTest {
       |
       |import com.squareup.tacos.SquareTacos.Companion.createTaco
       |import com.twitter.tacos.TwitterTacos
+      |import kotlin.Unit
       |
-      |fun makeTastyTacos() {
+      |fun makeTastyTacos(): Unit {
       |  createTaco()
       |  TwitterTacos.Companion.createTaco()
       |}
@@ -159,8 +166,9 @@ class MemberNameTest {
       |package com.example
       |
       |import com.squareup.tacos.SquareTacos
+      |import kotlin.Unit
       |
-      |fun makeTastyTacos() {
+      |fun makeTastyTacos(): Unit {
       |  val tacos = SquareTacos()
       |  com.squareup.tacos.math.SquareTacos(tacos)
       |}
@@ -181,10 +189,11 @@ class MemberNameTest {
     assertThat(file.toString()).isEqualTo("""
       |package com.example
       |
+      |import kotlin.Unit
       |import com.squareup.tacos.createTaco as createSquareTaco
       |import com.twitter.tacos.createTaco as createTwitterTaco
       |
-      |fun makeTastyTacos() {
+      |fun makeTastyTacos(): Unit {
       |  createSquareTaco()
       |  createTwitterTaco()
       |}
@@ -204,12 +213,13 @@ class MemberNameTest {
     assertThat(file.toString()).isEqualTo("""
       |package com.squareup.tacos
       |
+      |import kotlin.Unit
       |import org.junit.Before
       |import org.mockito.`when`
       |
       |class TacoTest {
       |  @Before
-      |  fun setUp() {
+      |  fun setUp(): Unit {
       |    `when`(tacoService.createTaco()).thenReturn(tastyTaco())
       |  }
       |}
@@ -232,8 +242,9 @@ class MemberNameTest {
       |
       |import com.squareup.tacos.SquareTacos.Companion.`when`
       |import com.twitter.tacos.TwitterTacos
+      |import kotlin.Unit
       |
-      |fun whenTastyTacos() {
+      |fun whenTastyTacos(): Unit {
       |  `when`()
       |  TwitterTacos.Companion.`when`()
       |}
@@ -256,8 +267,9 @@ class MemberNameTest {
       |
       |import com.squareup.tacos.TacoTruck
       |import com.squareup.tacos.randomTaco
+      |import kotlin.Unit
       |
-      |fun makeTastyTacos() {
+      |fun makeTastyTacos(): Unit {
       |  val randomTacoFactory = ::randomTaco
       |  val bestTacoFactory = TacoTruck::bestTacoEver
       |}
@@ -275,8 +287,9 @@ class MemberNameTest {
       |package com.squareup.tacos
       |
       |import com.squareup.`taco factory`.`produce tacos`
+      |import kotlin.Unit
       |
-      |fun main() {
+      |fun main(): Unit {
       |  println(`produce tacos`())
       |}
       |""".trimMargin())
@@ -313,9 +326,10 @@ class MemberNameTest {
       |
       |import com.squareup.tacos.Taco
       |import com.squareup.tacos.TacoPackager
+      |import kotlin.Unit
       |import kotlin.collections.List
       |
-      |fun packageTacos(tacos: List<Taco>, packager: TacoPackager) {
+      |fun packageTacos(tacos: List<Taco>, packager: TacoPackager): Unit {
       |  packager.`package`(tacos)
       |}
       |""".trimMargin())
@@ -342,8 +356,9 @@ class MemberNameTest {
       |import com.squareup.tacos.ingredient.Meat
       |import com.squareup.tacos.internal.iterator
       |import com.squareup.tacos.internal.minusAssign
+      |import kotlin.Unit
       |
-      |fun makeTacoHealthy(taco: Taco) {
+      |fun makeTacoHealthy(taco: Taco): Unit {
       |  for (ingredient in taco) {
       |    if (ingredient is Meat) taco -= ingredient
       |  }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ParameterSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ParameterSpecTest.kt
@@ -117,7 +117,7 @@ class ParameterSpecTest {
       |
       |import kotlin.Unit
       |
-      |fun foo(bar: @Annotation () -> Unit) {
+      |fun foo(bar: @Annotation () -> Unit): Unit {
       |}
       |""".trimMargin())
   }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -153,11 +153,13 @@ class TypeSpecTest {
     assertThat(toString(taco)).isEqualTo("""
         |package com.squareup.tacos
         |
+        |import kotlin.Unit
+        |
         |class Taco {
         |  val NAME: Thing.Thang<Foo, Bar> = object : Thing.Thang<Foo, Bar>() {
         |    override fun call(final thung: Thung<in Foo>): Thung<in Bar> = object : SimpleThung<Bar>(thung)
         |        {
-        |      override fun doSomething(bar: Bar) {
+        |      override fun doSomething(bar: Bar): Unit {
         |        /* code snippets */
         |      }
         |    }
@@ -213,10 +215,11 @@ class TypeSpecTest {
         |
         |import com.squareup.wire.Message
         |import java.lang.Runnable
+        |import kotlin.Unit
         |
         |class Taco {
         |  val NAME: Runnable = object : Message(), Runnable {
-        |    override fun run() {
+        |    override fun run(): Unit {
         |      /* code snippets */
         |    }
         |  }
@@ -502,13 +505,15 @@ class TypeSpecTest {
     assertThat(toString(roshambo)).isEqualTo("""
         |package com.squareup.tacos
         |
+        |import kotlin.Unit
+        |
         |enum class Tortilla {
         |  CORN {
-        |    override fun fold() {
+        |    override fun fold(): Unit {
         |    }
         |  };
         |
-        |  abstract fun fold()
+        |  abstract fun fold(): Unit
         |}
         |""".trimMargin())
   }
@@ -523,11 +528,12 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import kotlin.String
+        |import kotlin.Unit
         |
         |sealed class Sealed {
         |  abstract val name: String
         |
-        |  abstract fun fold()
+        |  abstract fun fold(): Unit
         |}
         |""".trimMargin())
   }
@@ -644,25 +650,26 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import java.io.IOException
+        |import kotlin.Unit
         |import kotlin.jvm.Throws
         |
         |abstract class Taco {
         |  @Throws(IOException::class)
-        |  fun throwOne() {
+        |  fun throwOne(): Unit {
         |  }
         |
         |  @Throws(
         |    IOException::class,
         |    SourCreamException::class
         |  )
-        |  fun throwTwo() {
+        |  fun throwTwo(): Unit {
         |  }
         |
         |  @Throws(IOException::class)
-        |  abstract fun abstractThrow()
+        |  abstract fun abstractThrow(): Unit
         |
         |  @Throws(IOException::class)
-        |  external fun nativeThrow()
+        |  external fun nativeThrow(): Unit
         |}
         |""".trimMargin())
   }
@@ -858,10 +865,12 @@ class TypeSpecTest {
     assertThat(toString(typeSpec)).isEqualTo("""
         |package com.squareup.tacos
         |
-        |fun interface Taco {
-        |  fun sam()
+        |import kotlin.Unit
         |
-        |  fun notSam() {
+        |fun interface Taco {
+        |  fun sam(): Unit
+        |
+        |  fun notSam(): Unit {
         |  }
         |}
         |""".trimMargin())
@@ -1082,7 +1091,7 @@ class TypeSpecTest {
 
     assertThat(classA.toString()).isEqualTo("""
       |expect class ClassA {
-      |  fun test()
+      |  fun test(): kotlin.Unit
       |}
       |""".trimMargin())
   }
@@ -1098,7 +1107,7 @@ class TypeSpecTest {
     assertThat(classA.toString()).isEqualTo("""
       |expect class ClassA {
       |  companion object {
-      |    fun test()
+      |    fun test(): kotlin.Unit
       |  }
       |}
       |""".trimMargin())
@@ -1115,7 +1124,7 @@ class TypeSpecTest {
     assertThat(classA.toString()).isEqualTo("""
       |expect class ClassA {
       |  class ClassB {
-      |    fun test()
+      |    fun test(): kotlin.Unit
       |  }
       |}
       |""".trimMargin())
@@ -1135,7 +1144,7 @@ class TypeSpecTest {
       |expect class ClassA {
       |  class ClassB {
       |    class ClassC {
-      |      fun test()
+      |      fun test(): kotlin.Unit
       |    }
       |  }
       |}
@@ -1159,7 +1168,7 @@ class TypeSpecTest {
       |  class ClassB {
       |    class ClassC {
       |      class ClassD {
-      |        fun test()
+      |        fun test(): kotlin.Unit
       |      }
       |    }
       |  }
@@ -1229,13 +1238,15 @@ class TypeSpecTest {
     assertThat(toString(taco)).isEqualTo("""
         |package com.squareup.tacos
         |
-        |interface Taco {
-        |  fun aMethod()
+        |import kotlin.Unit
         |
-        |  fun aDefaultMethod() {
+        |interface Taco {
+        |  fun aMethod(): Unit
+        |
+        |  fun aDefaultMethod(): Unit {
         |  }
         |
-        |  private fun aPrivateMethod() {
+        |  private fun aPrivateMethod(): Unit {
         |  }
         |}
         |""".trimMargin())
@@ -1383,6 +1394,7 @@ class TypeSpecTest {
         |
         |import java.util.Locale
         |import kotlin.Boolean
+        |import kotlin.Unit
         |
         |/**
         | * A hard or soft tortilla, loosely folded and filled with whatever
@@ -1400,7 +1412,7 @@ class TypeSpecTest {
         |   *
         |   * For [Locale#KOREAN], the front may also be folded.
         |   */
-        |  fun refold(locale: Locale) {
+        |  fun refold(locale: Locale): Unit {
         |  }
         |}
         |""".trimMargin())
@@ -1513,9 +1525,10 @@ class TypeSpecTest {
         |
         |import java.lang.Runnable
         |import kotlin.Int
+        |import kotlin.Unit
         |
         |class Taqueria {
-        |  fun prepare(workers: Int, vararg jobs: Runnable) {
+        |  fun prepare(workers: Int, vararg jobs: Runnable): Unit {
         |  }
         |}
         |""".trimMargin())
@@ -1535,13 +1548,14 @@ class TypeSpecTest {
         |import java.lang.Runnable
         |import kotlin.Boolean
         |import kotlin.Int
+        |import kotlin.Unit
         |
         |class Taqueria {
         |  fun prepare(
         |    workers: Int,
         |    vararg jobs: Runnable,
         |    start: Boolean
-        |  ) {
+        |  ): Unit {
         |  }
         |}
         |""".trimMargin())
@@ -1631,9 +1645,10 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import java.lang.System
+        |import kotlin.Unit
         |
         |class Taco {
-        |  fun choices() {
+        |  fun choices(): Unit {
         |    if (taco != null || taco == otherTaco) {
         |      System.out.println("only one taco? NOO!")
         |    } else if (taco.isSupreme() && otherTaco.isSupreme()) {
@@ -1658,9 +1673,10 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import java.lang.System
+        |import kotlin.Unit
         |
         |class Taco {
-        |  fun choices() {
+        |  fun choices(): Unit {
         |    if (5 < 4)  {
         |      System.out.println("wat")
         |    } else if (5 < 6) {
@@ -1681,9 +1697,10 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import java.lang.System
+        |import kotlin.Unit
         |
         |class Taco {
-        |  fun inlineIndent() {
+        |  fun inlineIndent(): Unit {
         |    if (3 < 4) {
         |      System.out.println("hello");
         |    }
@@ -1742,6 +1759,7 @@ class TypeSpecTest {
         |import kotlin.Int
         |import kotlin.Long
         |import kotlin.String
+        |import kotlin.Unit
         |
         |class Members {
         |  val W: String
@@ -1752,16 +1770,16 @@ class TypeSpecTest {
         |
         |  constructor(o: Long)
         |
-        |  fun T() {
+        |  fun T(): Unit {
         |  }
         |
-        |  fun S() {
+        |  fun S(): Unit {
         |  }
         |
-        |  fun R() {
+        |  fun R(): Unit {
         |  }
         |
-        |  fun Q() {
+        |  fun Q(): Unit {
         |  }
         |
         |  class Z
@@ -1875,7 +1893,7 @@ class TypeSpecTest {
         .build()
     assertThat(type.toString()).isEqualTo("""
         |object : java.lang.Runnable {
-        |  override fun run() {
+        |  override fun run(): kotlin.Unit {
         |  }
         |}""".trimMargin())
   }
@@ -1962,6 +1980,7 @@ class TypeSpecTest {
         |import java.util.Comparator
         |import kotlin.Int
         |import kotlin.String
+        |import kotlin.Unit
         |import kotlin.collections.List
         |
         |class Taco {
@@ -1976,7 +1995,7 @@ class TypeSpecTest {
         |    }
         |  }
         |
-        |  fun sortPrefix(list: List<String>, final length: Int) {
+        |  fun sortPrefix(list: List<String>, final length: Int): Unit {
         |    Collections.sort(
         |        list,
         |        object : Comparator<String> {
@@ -2313,8 +2332,10 @@ class TypeSpecTest {
     assertThat(toString(taco)).isEqualTo("""
         |package com.squareup.tacos
         |
+        |import kotlin.Unit
+        |
         |class Taco {
-        |  fun addTopping(topping: Topping) {
+        |  fun addTopping(topping: Topping): Unit {
         |    try {
         |      /* do something tricky with the topping */
         |    } catch (e: IllegalToppingException) {
@@ -2798,6 +2819,7 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import kotlin.Int
+        |import kotlin.Unit
         |
         |object MyObject {
         |  val tacos: Int
@@ -2805,7 +2827,7 @@ class TypeSpecTest {
         |  init {
         |  }
         |
-        |  fun test() {
+        |  fun test(): Unit {
         |  }
         |}
         |""".trimMargin())
@@ -2826,12 +2848,13 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import com.squareup.wire.Message
+        |import kotlin.Unit
         |
         |object MyObject : Message() {
         |  init {
         |  }
         |
-        |  fun test() {
+        |  fun test(): Unit {
         |  }
         |}
         |""".trimMargin())
@@ -2856,12 +2879,13 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import kotlin.Int
+        |import kotlin.Unit
         |
         |class MyClass {
         |  companion object {
         |    val tacos: Int = 42
         |
-        |    fun test() {
+        |    fun test(): Unit {
         |    }
         |  }
         |}
@@ -2913,9 +2937,11 @@ class TypeSpecTest {
     assertThat(toString(type)).isEqualTo("""
         |package com.squareup.tacos
         |
+        |import kotlin.Unit
+        |
         |class MyClass {
         |  companion object Factory {
-        |    fun tacos() {
+        |    fun tacos(): Unit {
         |    }
         |  }
         |}
@@ -2937,9 +2963,11 @@ class TypeSpecTest {
     assertThat(toString(type)).isEqualTo("""
         |package com.squareup.tacos
         |
+        |import kotlin.Unit
+        |
         |interface MyInterface {
         |  companion object {
-        |    fun test() {
+        |    fun test(): Unit {
         |    }
         |  }
         |}
@@ -2963,13 +2991,15 @@ class TypeSpecTest {
     assertThat(toString(enumBuilder)).isEqualTo("""
         |package com.squareup.tacos
         |
+        |import kotlin.Unit
+        |
         |enum class MyEnum {
         |  FOO,
         |
         |  BAR;
         |
         |  companion object {
-        |    fun test() {
+        |    fun test(): Unit {
         |    }
         |  }
         |}
@@ -3010,10 +3040,11 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import com.squareup.wire.Message
+        |import kotlin.Unit
         |
         |class MyClass {
         |  companion object : Message() {
-        |    fun test() {
+        |    fun test(): Unit {
         |    }
         |  }
         |}
@@ -3452,9 +3483,10 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import kotlin.String
+        |import kotlin.Unit
         |
         |class Taco {
-        |  fun shell() {
+        |  fun shell(): Unit {
         |    val taco1: String = "Taco!"
         |    val taco2: String? = null
         |    lateinit var taco3: String
@@ -3617,8 +3649,10 @@ class TypeSpecTest {
     assertThat(toString(typeSpec)).isEqualTo("""
       |package com.squareup.tacos
       |
+      |import kotlin.Unit
+      |
       |external class Foo {
-      |  fun bar()
+      |  fun bar(): Unit
       |}
       |""".trimMargin())
   }
@@ -3634,11 +3668,12 @@ class TypeSpecTest {
       |package com.squareup.tacos
       |
       |import kotlin.String
+      |import kotlin.Unit
       |
       |external interface Foo {
       |  val baz: String
       |
-      |  fun bar()
+      |  fun bar(): Unit
       |}
       |""".trimMargin())
   }
@@ -3654,11 +3689,12 @@ class TypeSpecTest {
       |package com.squareup.tacos
       |
       |import kotlin.String
+      |import kotlin.Unit
       |
       |external object Foo {
       |  val baz: String
       |
-      |  fun bar()
+      |  fun bar(): Unit
       |}
       |""".trimMargin())
   }
@@ -3683,17 +3719,19 @@ class TypeSpecTest {
     assertThat(toString(typeSpec)).isEqualTo("""
       |package com.squareup.tacos
       |
+      |import kotlin.Unit
+      |
       |external class Foo {
       |  class Nested1 {
-      |    fun baz()
+      |    fun baz(): Unit
       |
       |    object Nested2 {
-      |      fun bar()
+      |      fun bar(): Unit
       |    }
       |  }
       |
       |  companion object {
-      |    fun qux()
+      |    fun qux(): Unit
       |  }
       |}
       |""".trimMargin())
@@ -4178,7 +4216,7 @@ class TypeSpecTest {
         .addStatement("print(taco)")
         .build()
     assertThat(funSpec.toString()).isEqualTo("""
-      |fun printTaco(taco: com.squareup.tacos.Taco.`object`) {
+      |fun printTaco(taco: com.squareup.tacos.Taco.`object`): kotlin.Unit {
       |  print(taco)
       |}
       |""".trimMargin())

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeVariableNameTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeVariableNameTest.kt
@@ -147,7 +147,7 @@ class TypeVariableNameTest {
         .addStatement("println(T::class.members)")
         .build()
     assertThat(funSpec.toString()).isEqualTo("""
-      |inline fun <reified T> printMembers() {
+      |inline fun <reified T> printMembers(): kotlin.Unit {
       |  println(T::class.members)
       |}
       |""".trimMargin())

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/jvm/JvmAnnotationsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/jvm/JvmAnnotationsTest.kt
@@ -211,13 +211,14 @@ class JvmAnnotationsTest {
       |
       |import java.io.IOException
       |import java.lang.IllegalArgumentException
+      |import kotlin.Unit
       |import kotlin.jvm.Throws
       |
       |@Throws(
       |  IOException::class,
       |  IllegalArgumentException::class
       |)
-      |fun foo() {
+      |fun foo(): Unit {
       |}
       |""".trimMargin())
   }
@@ -231,10 +232,11 @@ class JvmAnnotationsTest {
     assertThat(file.toString()).isEqualTo("""
       |package com.squareup.tacos
       |
+      |import kotlin.Unit
       |import kotlin.jvm.Throws
       |
       |@Throws(IllegalTacoException::class)
-      |fun foo() {
+      |fun foo(): Unit {
       |}
       |""".trimMargin())
   }
@@ -323,10 +325,11 @@ class JvmAnnotationsTest {
       |
       |import kotlin.Int
       |import kotlin.String
+      |import kotlin.Unit
       |import kotlin.jvm.JvmOverloads
       |
       |@JvmOverloads
-      |fun foo(bar: Int, baz: String = "baz") {
+      |fun foo(bar: Int, baz: String = "baz"): Unit {
       |}
       |""".trimMargin())
   }
@@ -399,10 +402,11 @@ class JvmAnnotationsTest {
     assertThat(file.toString()).isEqualTo("""
       |package com.squareup.tacos
       |
+      |import kotlin.Unit
       |import kotlin.jvm.JvmName
       |
       |@JvmName("getFoo")
-      |fun foo() {
+      |fun foo(): Unit {
       |}
       |""".trimMargin())
   }
@@ -503,10 +507,11 @@ class JvmAnnotationsTest {
     assertThat(file.toString()).isEqualTo("""
       |package com.squareup.tacos
       |
+      |import kotlin.Unit
       |import kotlin.jvm.JvmSuppressWildcards
       |
       |@JvmSuppressWildcards(suppress = false)
-      |fun foo() {
+      |fun foo(): Unit {
       |}
       |""".trimMargin())
   }
@@ -561,10 +566,11 @@ class JvmAnnotationsTest {
       |package com.squareup.tacos
       |
       |import kotlin.Int
+      |import kotlin.Unit
       |import kotlin.collections.List
       |import kotlin.jvm.JvmSuppressWildcards
       |
-      |fun foo(a: List<@JvmSuppressWildcards Int>) {
+      |fun foo(a: List<@JvmSuppressWildcards Int>): Unit {
       |}
       |""".trimMargin())
   }
@@ -580,10 +586,11 @@ class JvmAnnotationsTest {
       |package com.squareup.tacos
       |
       |import kotlin.Int
+      |import kotlin.Unit
       |import kotlin.collections.List
       |import kotlin.jvm.JvmWildcard
       |
-      |fun foo(a: List<@JvmWildcard Int>) {
+      |fun foo(a: List<@JvmWildcard Int>): Unit {
       |}
       |""".trimMargin())
   }
@@ -760,10 +767,11 @@ class JvmAnnotationsTest {
     assertThat(file.toString()).isEqualTo("""
       |package com.squareup.tacos
       |
+      |import kotlin.Unit
       |import kotlin.jvm.Strictfp
       |
       |@Strictfp
-      |fun foo() {
+      |fun foo(): Unit {
       |}
       |""".trimMargin())
   }


### PR DESCRIPTION
Ref #927 #926 

This emits return types for FunSpec unless:
- It's a constructor
- Getter/Setter on a property 
- Expression body