### PR TITLE
Remove the Edit button from the website

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,10 @@ remote_branch: gh-pages
 
 copyright: 'Copyright &copy; 2015 Square, Inc.'
 
+# Hide the Edit button, as it doesn't work with the way MkDocs
+# is configured in this repo.
+edit_uri: ""
+
 theme:
   name: 'material'
   logo: 'images/icon-square.png'


### PR DESCRIPTION
Fixes #949 

We're running a custom script for deploying the website, which copies `README.md` into `docs/index.md` and pushes to `gh-pages`. Tapping on the Edit button on the main page leads to `https://github.com/square/kotlinpoet/edit/master/docs/index.md`, the file that does not exist on the master branch. The only property that MkDocs exposes for controlling the path to the file is `edit_uri`. This might work for redirecting the Edit action to the `gh-pages` branch, however, `README.md` is still the source of truth for `docs/index.md`, so it doesn't fix the issue. I haven't found a way to make the Edit button point to `README.md`, hence the solution is to hide the button altogether to avoid 404s.

This will require a manual deploy once the change is merged.

