### PR TITLE
Update dependency declaration in Download section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1369,7 +1369,7 @@ Download [the latest .jar][dl] or depend via Maven:
 or Gradle:
 
 ```groovy
-compile 'com.squareup:kotlinpoet:1.6.0'
+implementation("com.squareup:kotlinpoet:1.6.0")
 ```
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].


### PR DESCRIPTION
Replaces deprecated "compile"  configuration with "implementation", and make snippet Kotlin DSL compatible.