### PR TITLE
Improve preconditions

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -53,18 +53,6 @@ public class FunSpec private constructor(
   public val body: CodeBlock = builder.body.build()
   private val isEmptySetter = name == SETTER && parameters.isEmpty()
 
-  init {
-    require(body.isEmpty() || ABSTRACT !in builder.modifiers) {
-      "abstract function ${builder.name} cannot have code"
-    }
-    require(name != SETTER || parameters.size <= 1) {
-      "$name can have at most one parameter"
-    }
-    require(INLINE in modifiers || typeVariables.none { it.isReified }) {
-      "only type parameters of inline functions can be reified!"
-    }
-  }
-
   internal fun parameter(name: String) = parameters.firstOrNull { it.name == name }
 
   internal fun emit(
@@ -501,9 +489,15 @@ public class FunSpec private constructor(
     }
 
     public fun build(): FunSpec {
-      check(typeVariables.isEmpty() || !name.isAccessor) { "$name cannot have type variables" }
-      check(!(name == GETTER && parameters.isNotEmpty())) { "$name cannot have parameters" }
-      check(!(name == SETTER && parameters.size > 1)) { "$name can have at most one parameter" }
+      require(typeVariables.isEmpty() || !name.isAccessor) { "$name cannot have type variables" }
+      require(!(name == GETTER && parameters.isNotEmpty())) { "$name cannot have parameters" }
+      require(!(name == SETTER && parameters.size > 1)) { "$name can have at most one parameter" }
+      require(body.isEmpty() || ABSTRACT !in modifiers) {
+        "abstract function $name cannot have code"
+      }
+      require(INLINE in modifiers || typeVariables.none { it.isReified }) {
+        "only type parameters of inline functions can be reified!"
+      }
       return FunSpec(this)
     }
   }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -826,4 +826,36 @@ class FunSpecTest {
       |}
       |""".trimMargin())
   }
+
+  @Test fun typeVariablesOnAccessorNotAllowed() {
+    val typeVariable = TypeVariableName("T")
+    assertThrows<IllegalArgumentException> {
+      FunSpec.setterBuilder()
+          .addTypeVariable(typeVariable)
+          .build()
+    }.hasMessageThat().isEqualTo("set() cannot have type variables")
+
+    assertThrows<IllegalArgumentException> {
+      FunSpec.getterBuilder()
+          .addTypeVariable(typeVariable)
+          .build()
+    }.hasMessageThat().isEqualTo("get() cannot have type variables")
+  }
+
+  @Test fun multipleParametersOnSetterNotAllowed() {
+    assertThrows<IllegalArgumentException> {
+      FunSpec.setterBuilder()
+          .addParameter("value1", String::class)
+          .addParameter("value2", String::class)
+          .build()
+    }.hasMessageThat().isEqualTo("set() can have at most one parameter")
+  }
+
+  @Test fun parametersOnGetterNotAllowed() {
+    assertThrows<IllegalArgumentException> {
+      FunSpec.getterBuilder()
+          .addParameter("value1", String::class)
+          .build()
+    }.hasMessageThat().isEqualTo("get() cannot have parameters")
+  }
 }


### PR DESCRIPTION
- Checks for some specs were in inconsistent locations: in both `init` blocks of the Spec class and in the `build` function. There was even a redundant repeated check in FunSpec. I moved these checks into the build method. Since the Spec constructor is called from the build method, this shouldn't change behavior.
- Added some missing tests for FunSpec preconditions.