### PR TITLE
Use checkTarget on modifiers

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -511,6 +511,14 @@ public class FunSpec private constructor(
       check(typeVariables.isEmpty() || !name.isAccessor) { "$name cannot have type variables" }
       check(!(name == GETTER && parameters.isNotEmpty())) { "$name cannot have parameters" }
       check(!(name == SETTER && parameters.size > 1)) { "$name can have at most one parameter" }
+
+      val target = when {
+        name.isConstructor -> KModifier.Target.CONSTRUCTOR
+        name.isAccessor -> KModifier.Target.ACCESSOR
+        else -> KModifier.Target.FUNCTION
+      }
+      modifiers.checkTarget(target)
+
       return FunSpec(this)
     }
   }

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/KModifier.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/KModifier.kt
@@ -15,6 +15,17 @@
  */
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.KModifier.Target.ACCESSOR
+import com.squareup.kotlinpoet.KModifier.Target.CLASS
+import com.squareup.kotlinpoet.KModifier.Target.CLASS_TYPE_PARAMETER
+import com.squareup.kotlinpoet.KModifier.Target.FUNCTION
+import com.squareup.kotlinpoet.KModifier.Target.FUNCTION_TYPE_PARAMETER
+import com.squareup.kotlinpoet.KModifier.Target.INTERFACE
+import com.squareup.kotlinpoet.KModifier.Target.OBJECT
+import com.squareup.kotlinpoet.KModifier.Target.PARAMETER
+import com.squareup.kotlinpoet.KModifier.Target.PROPERTY
+import com.squareup.kotlinpoet.KModifier.Target.TYPE_ALIAS
+
 public enum class KModifier(
   internal val keyword: String,
   private vararg val targets: Target
@@ -23,61 +34,77 @@ public enum class KModifier(
   // https://kotlinlang.org/docs/reference/coding-conventions.html#modifiers
 
   // Access.
-  PUBLIC("public", Target.PROPERTY),
-  PROTECTED("protected", Target.PROPERTY),
-  PRIVATE("private", Target.PROPERTY),
-  INTERNAL("internal", Target.PROPERTY),
+  PUBLIC("public", *Target.declarations, TYPE_ALIAS, PARAMETER),
+  PROTECTED("protected", *Target.declarations, PARAMETER),
+  PRIVATE("private", *Target.declarations, TYPE_ALIAS, PARAMETER),
+  INTERNAL("internal", *Target.declarations, TYPE_ALIAS, PARAMETER),
 
   // Multiplatform modules.
-  EXPECT("expect", Target.CLASS, Target.FUNCTION, Target.PROPERTY),
-  ACTUAL("actual", Target.CLASS, Target.FUNCTION, Target.PROPERTY),
+  EXPECT("expect", *Target.declarations),
+  ACTUAL("actual", *Target.declarations, TYPE_ALIAS),
 
-  FINAL("final", Target.CLASS, Target.FUNCTION, Target.PROPERTY),
-  OPEN("open", Target.CLASS, Target.FUNCTION, Target.PROPERTY),
-  ABSTRACT("abstract", Target.CLASS, Target.FUNCTION, Target.PROPERTY),
-  SEALED("sealed", Target.CLASS),
-  CONST("const", Target.PROPERTY),
+  FINAL("final", CLASS, FUNCTION, PROPERTY, PARAMETER),
+  OPEN("open", CLASS, FUNCTION, PROPERTY, PARAMETER),
+  ABSTRACT("abstract", CLASS, FUNCTION, PROPERTY, PARAMETER),
+  SEALED("sealed", CLASS),
+  CONST("const", PROPERTY),
 
-  EXTERNAL("external", Target.CLASS, Target.FUNCTION, Target.PROPERTY),
-  OVERRIDE("override", Target.FUNCTION, Target.PROPERTY),
-  LATEINIT("lateinit", Target.PROPERTY),
-  TAILREC("tailrec", Target.FUNCTION),
-  VARARG("vararg", Target.PARAMETER),
-  SUSPEND("suspend", Target.FUNCTION),
-  INNER("inner", Target.CLASS),
+  EXTERNAL("external", *Target.declarations),
+  OVERRIDE("override", FUNCTION, PROPERTY, PARAMETER),
+  LATEINIT("lateinit", PROPERTY),
+  TAILREC("tailrec", FUNCTION),
+  VARARG("vararg", PARAMETER),
+  SUSPEND("suspend", FUNCTION),
+  INNER("inner", CLASS),
 
-  ENUM("enum", Target.CLASS),
-  ANNOTATION("annotation", Target.CLASS),
-  FUN("fun", Target.INTERFACE),
+  ENUM("enum", CLASS),
+  ANNOTATION("annotation", CLASS),
+  FUN("fun", INTERFACE),
 
-  COMPANION("companion", Target.CLASS),
+  COMPANION("companion", OBJECT),
 
   // Call-site compiler tips.
-  INLINE("inline", Target.FUNCTION),
-  NOINLINE("noinline", Target.PARAMETER),
-  CROSSINLINE("crossinline", Target.PARAMETER),
-  REIFIED("reified", Target.TYPE_PARAMETER),
+  INLINE("inline", FUNCTION, CLASS, PROPERTY, ACCESSOR),
+  NOINLINE("noinline", PARAMETER),
+  CROSSINLINE("crossinline", PARAMETER),
+  REIFIED("reified", FUNCTION_TYPE_PARAMETER),
 
-  INFIX("infix", Target.FUNCTION),
-  OPERATOR("operator", Target.FUNCTION),
+  INFIX("infix", FUNCTION),
+  OPERATOR("operator", FUNCTION),
 
-  DATA("data", Target.CLASS),
+  DATA("data", CLASS),
 
-  IN("in", Target.VARIANCE_ANNOTATION),
-  OUT("out", Target.VARIANCE_ANNOTATION),
+  IN("in", CLASS_TYPE_PARAMETER),
+  OUT("out", CLASS_TYPE_PARAMETER),
   ;
 
   internal enum class Target {
     CLASS,
-    VARIANCE_ANNOTATION,
-    PARAMETER,
-    TYPE_PARAMETER,
-    FUNCTION,
-    PROPERTY,
+    OBJECT,
     INTERFACE,
+    TYPE_ALIAS,
+
+    FUNCTION,
+    CONSTRUCTOR,
+    ACCESSOR,
+
+    PROPERTY,
+
+    PARAMETER,
+    FUNCTION_TYPE_PARAMETER,
+    CLASS_TYPE_PARAMETER,
+    ;
+
+    companion object {
+      val declarations = arrayOf(CLASS, OBJECT, INTERFACE, FUNCTION, CONSTRUCTOR, ACCESSOR, PROPERTY)
+    }
   }
 
   internal fun checkTarget(target: Target) {
     require(target in targets) { "unexpected modifier $this for $target" }
   }
+}
+
+internal fun Iterable<KModifier>.checkTarget(target: KModifier.Target) {
+  this.forEach { it.checkTarget(target) }
 }

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ParameterSpec.kt
@@ -143,7 +143,10 @@ public class ParameterSpec private constructor(
       this.defaultValue = codeBlock
     }
 
-    public fun build(): ParameterSpec = ParameterSpec(this)
+    public fun build(): ParameterSpec {
+      modifiers.checkTarget(KModifier.Target.PARAMETER)
+      return ParameterSpec(this)
+    }
   }
 
   public companion object {

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -262,8 +262,8 @@ public class PropertySpec private constructor(
         throw IllegalArgumentException("KotlinPoet doesn't allow setting the inline modifier on " +
             "properties. You should mark either the getter, the setter, or both inline.")
       }
-      for (it in modifiers) {
-          if (!isPrimaryConstructorParameter) it.checkTarget(PROPERTY)
+      if (!isPrimaryConstructorParameter) {
+        modifiers.checkTarget(PROPERTY)
       }
       return PropertySpec(this)
     }

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeAliasSpec.kt
@@ -124,11 +124,7 @@ public class TypeAliasSpec private constructor(
         addAnnotation(annotation.asClassName())
 
     public fun build(): TypeAliasSpec {
-      for (it in modifiers) {
-        require(it in ALLOWABLE_MODIFIERS) {
-          "unexpected typealias modifier $it"
-        }
-      }
+      modifiers.checkTarget(KModifier.Target.TYPE_ALIAS)
       return TypeAliasSpec(this)
     }
 

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -787,6 +787,12 @@ public class TypeSpec private constructor(
           throw IllegalArgumentException("Multiple companion objects are present but only one is allowed.")
         }
       }
+      val target = when (kind) {
+        Kind.CLASS -> KModifier.Target.CLASS
+        Kind.INTERFACE -> KModifier.Target.INTERFACE
+        Kind.OBJECT -> KModifier.Target.OBJECT
+      }
+      modifiers.checkTarget(target)
 
       return TypeSpec(this)
     }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -124,7 +124,6 @@ class TypeSpecTest {
     val simpleThungOfBar = simpleThung.parameterizedBy(bar)
 
     val thungParameter = ParameterSpec.builder("thung", thungOfSuperFoo)
-        .addModifiers(KModifier.FINAL)
         .build()
     val aSimpleThung = TypeSpec.anonymousClassBuilder()
         .superclass(simpleThungOfBar)
@@ -157,8 +156,8 @@ class TypeSpecTest {
         |
         |public class Taco {
         |  public val NAME: Thing.Thang<Foo, Bar> = object : Thing.Thang<Foo, Bar>() {
-        |    public override fun call(final thung: Thung<in Foo>): Thung<in Bar> = object :
-        |        SimpleThung<Bar>(thung) {
+        |    public override fun call(thung: Thung<in Foo>): Thung<in Bar> = object : SimpleThung<Bar>(thung)
+        |        {
         |      public override fun doSomething(bar: Bar): Unit {
         |        /* code snippets */
         |      }
@@ -2013,13 +2012,13 @@ class TypeSpecTest {
     val taco = TypeSpec.classBuilder("Taco")
         .addFunction(FunSpec.builder("comparePrefix")
             .returns(stringComparator)
-            .addParameter("length", Int::class, KModifier.FINAL)
+            .addParameter("length", Int::class)
             .addComment("Return a new comparator for the target length.")
             .addStatement("return %L", prefixComparator)
             .build())
         .addFunction(FunSpec.builder("sortPrefix")
             .addParameter("list", listOfString)
-            .addParameter("length", Int::class, KModifier.FINAL)
+            .addParameter("length", Int::class)
             .addStatement("%T.sort(\nlist,\n%L)", Collections::class, prefixComparator)
             .build())
         .build()
@@ -2034,7 +2033,7 @@ class TypeSpecTest {
         |import kotlin.collections.List
         |
         |public class Taco {
-        |  public fun comparePrefix(final length: Int): Comparator<String> {
+        |  public fun comparePrefix(length: Int): Comparator<String> {
         |    // Return a new comparator for the target length.
         |    return object : Comparator<String> {
         |      public override fun compare(a: String, b: String): Int {
@@ -2045,7 +2044,7 @@ class TypeSpecTest {
         |    }
         |  }
         |
-        |  public fun sortPrefix(list: List<String>, final length: Int): Unit {
+        |  public fun sortPrefix(list: List<String>, length: Int): Unit {
         |    Collections.sort(
         |        list,
         |        object : Comparator<String> {


### PR DESCRIPTION
This probably needs proofreading.

Other comments:
- Parameters can have some modifiers that properties can (that they otherwise shouldn't); this is to keep consistent behavior when parameters are turned into primary constructor properties.
  - A test case was found that doesn't produce compiling code (`final` does not apply to non-property parameter). This is fixed in a separate commit.
- In/Out (type variable) modifiers already have their own check.
- The Reified KModifier isn't used at all. See #939 