### PR TITLE
Delete unnecessary sed call from deploy_website.sh

### DIFF
--- a/.buildscript/deploy_website.sh
+++ b/.buildscript/deploy_website.sh
@@ -27,12 +27,6 @@ if ! [ $local ]; then
   ./gradlew dokka
 fi
 
-# Fix *.md links to point to where the docs live under Mkdocs.
-# Linux
-# sed -i 's/kotlinpoet-metadata-specs\/README.md/\/kotlinpoet_metadata_specs/' docs/changelog.md
-# OSX
-sed -i "" 's/kotlinpoet-metadata-specs\/README.md/\/kotlinpoet_metadata_specs/' docs/changelog.md
-
 # Build the site and push the new files up to GitHub
 if ! [ $local ]; then
   mkdocs gh-deploy


### PR DESCRIPTION
Since there's no file copying happening anymore, there's no need to fixup any links.