### PR TITLE
gradle-maven-publish-plugin 0.13.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -17,7 +17,7 @@ object versions {
   const val kotlin = "1.4.10"
   const val spotless = "3.27.0"
   const val ktlint = "0.36.0"
-  const val mavenPublish = "0.13.0-SNAPSHOT"
+  const val mavenPublish = "0.13.0"
   const val shadowPlugin = "6.0.0"
   const val dokka = "1.4.0"
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,7 +17,6 @@ pluginManagement {
   repositories {
     mavenCentral()
     gradlePluginPortal()
-    maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
   }
 }
 


### PR DESCRIPTION
Release notes: https://github.com/vanniktech/gradle-maven-publish-plugin/releases/tag/0.13.0