### PR TITLE
Detect expression bodies on 'return·' or 'throw·' prefix

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -215,11 +215,13 @@ public class FunSpec private constructor(
 
   private fun CodeBlock.asExpressionBody(): CodeBlock? {
     val codeBlock = this.trim()
-    val asReturnExpressionBody = codeBlock.withoutPrefix(RETURN_EXPRESSION_BODY_PREFIX)
+    val asReturnExpressionBody = codeBlock.withoutPrefix(RETURN_EXPRESSION_BODY_PREFIX_SPACE)
+      ?: codeBlock.withoutPrefix(RETURN_EXPRESSION_BODY_PREFIX_NBSP)
     if (asReturnExpressionBody != null) {
       return asReturnExpressionBody
     }
-    if (codeBlock.withoutPrefix(THROW_EXPRESSION_BODY_PREFIX) != null) {
+    if (codeBlock.withoutPrefix(THROW_EXPRESSION_BODY_PREFIX_SPACE) != null ||
+      codeBlock.withoutPrefix(THROW_EXPRESSION_BODY_PREFIX_NBSP) != null) {
       return codeBlock
     }
     return null
@@ -527,8 +529,10 @@ public class FunSpec private constructor(
     internal val String.isConstructor get() = this == CONSTRUCTOR
     internal val String.isAccessor get() = this.isOneOf(GETTER, SETTER)
 
-    private val RETURN_EXPRESSION_BODY_PREFIX = CodeBlock.of("return ")
-    private val THROW_EXPRESSION_BODY_PREFIX = CodeBlock.of("throw ")
+    private val RETURN_EXPRESSION_BODY_PREFIX_SPACE = CodeBlock.of("return ")
+    private val RETURN_EXPRESSION_BODY_PREFIX_NBSP = CodeBlock.of("return·")
+    private val THROW_EXPRESSION_BODY_PREFIX_SPACE = CodeBlock.of("throw ")
+    private val THROW_EXPRESSION_BODY_PREFIX_NBSP = CodeBlock.of("throw ·")
 
     @JvmStatic public fun builder(name: String): Builder = Builder(name)
 

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -532,7 +532,7 @@ public class FunSpec private constructor(
     private val RETURN_EXPRESSION_BODY_PREFIX_SPACE = CodeBlock.of("return ")
     private val RETURN_EXPRESSION_BODY_PREFIX_NBSP = CodeBlock.of("return·")
     private val THROW_EXPRESSION_BODY_PREFIX_SPACE = CodeBlock.of("throw ")
-    private val THROW_EXPRESSION_BODY_PREFIX_NBSP = CodeBlock.of("throw ·")
+    private val THROW_EXPRESSION_BODY_PREFIX_NBSP = CodeBlock.of("throw·")
 
     @JvmStatic public fun builder(name: String): Builder = Builder(name)
 

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -337,7 +337,7 @@ class FunSpecTest {
     )
   }
 
-  @Test fun expressionBodyIsDetectedWithNonBreakingSpace() {
+  @Test fun expressionBodyIsDetectedReturnWithNonBreakingSpace() {
     val funSpec = FunSpec.builder("foo")
       .addStatement("return·1")
       .build()
@@ -345,6 +345,19 @@ class FunSpecTest {
     assertThat(funSpec.toString()).isEqualTo(
       """
       |public fun foo() = 1
+      |""".trimMargin()
+    )
+  }
+
+  @Test fun expressionBodyIsDetectedThrowWithNonBreakingSpace() {
+    val funSpec = FunSpec.builder("foo")
+      .addStatement("throw·%T()", AssertionError::class)
+      .returns(NOTHING)
+      .build()
+
+    assertThat(funSpec.toString()).isEqualTo(
+      """
+      |public fun foo(): kotlin.Nothing = throw java.lang.AssertionError()
       |""".trimMargin()
     )
   }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -337,6 +337,18 @@ class FunSpecTest {
     )
   }
 
+  @Test fun expressionBodyIsDetectedWithNonBreakingSpace() {
+    val funSpec = FunSpec.builder("foo")
+      .addStatement("return·1")
+      .build()
+
+    assertThat(funSpec.toString()).isEqualTo(
+      """
+      |public fun foo() = 1
+      |""".trimMargin()
+    )
+  }
+
   @Test fun functionWithReturnKDocAndMainKdoc() {
     val funSpec = FunSpec.builder("foo")
       .addParameter("nodoc", Boolean::class)


### PR DESCRIPTION
Expression bodies were not recognized when the code starts with "return·"
I was surprised, because naturally, I used the "·" character after "return" keyword instead of space, because the line cannot be broken in this location. Before my changes, only space should be used.