### PR TITLE
Allow init blocks inside inline classes

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -558,9 +558,6 @@ public class TypeSpec private constructor(
       check(isSimpleClass || isEnum || kind == Kind.OBJECT) {
         "$kind can't have initializer blocks"
       }
-      check(!isInlineClass) {
-        "Inline classes can't have initializer blocks"
-      }
       check(EXPECT !in modifiers) {
         "expect $kind can't have initializer blocks"
       }
@@ -777,9 +774,6 @@ public class TypeSpec private constructor(
           check(!underlyingProperty.mutable) {
             "Inline classes must have a single read-only (val) property parameter."
           }
-        }
-        check(initializerBlock.isEmpty()) {
-          "Inline classes can't have initializer blocks"
         }
         check(superclass == Any::class.asTypeName()) {
           "Inline classes cannot have super classes"

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -2553,22 +2553,31 @@ class TypeSpecTest {
   }
 
   @Test fun inlineClassWithInitBlock() {
-    assertThrows<IllegalStateException> {
-      TypeSpec.classBuilder("Guacamole")
-        .primaryConstructor(
-          FunSpec.constructorBuilder()
-            .addParameter("avacado", String::class)
-            .build()
-        )
-        .addProperty(
-          PropertySpec.builder("avacado", String::class)
-            .initializer("avacado")
-            .build()
-        )
-        .addInitializerBlock(CodeBlock.EMPTY)
-        .addModifiers(INLINE)
-        .build()
-    }.hasMessageThat().isEqualTo("Inline classes can't have initializer blocks")
+    val guacamole = TypeSpec.classBuilder("Guacamole")
+      .primaryConstructor(
+        FunSpec.constructorBuilder()
+          .addParameter("avacado", String::class)
+          .build()
+      )
+      .addProperty(
+        PropertySpec.builder("avacado", String::class)
+          .initializer("avacado")
+          .build()
+      )
+      .addInitializerBlock(CodeBlock.EMPTY)
+      .addModifiers(INLINE)
+      .build()
+
+    assertThat(guacamole.toString()).isEqualTo(
+      """
+      |public inline class Guacamole(
+      |  public val avacado: kotlin.String
+      |) {
+      |  init {
+      |  }
+      |}
+      |""".trimMargin()
+    )
   }
 
   class InlineSuperClass


### PR DESCRIPTION
This feature is available since 1.4.30-M1, see
https://youtrack.jetbrains.com/issue/KT-28055.

Release notes for 1.4.30-M1:
https://github.com/JetBrains/kotlin/releases/tag/v1.4.30-M1