### PR TITLE
Allow non-public primary constructors inside inline classes

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -759,9 +759,6 @@ public class TypeSpec private constructor(
           check(it.parameters.size == 1) {
             "Inline classes must have 1 parameter in constructor"
           }
-          check(PRIVATE !in it.modifiers && INTERNAL !in it.modifiers) {
-            "Inline classes must have a public primary constructor"
-          }
         }
 
         check(propertySpecs.size > 0) {

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -2666,22 +2666,28 @@ class TypeSpecTest {
   }
 
   @Test fun inlineClassWithPrivateConstructor() {
-    assertThrows<IllegalStateException> {
-      TypeSpec.classBuilder("Guacamole")
-        .primaryConstructor(
-          FunSpec.constructorBuilder()
-            .addParameter("avocado", String::class)
-            .addModifiers(PRIVATE)
-            .build()
-        )
-        .addProperty(
-          PropertySpec.builder("avocado", String::class)
-            .initializer("avocado")
-            .build()
-        )
-        .addModifiers(INLINE)
-        .build()
-    }.hasMessageThat().isEqualTo("Inline classes must have a public primary constructor")
+    val guacamole = TypeSpec.classBuilder("Guacamole")
+      .primaryConstructor(
+        FunSpec.constructorBuilder()
+          .addParameter("avocado", String::class)
+          .addModifiers(PRIVATE)
+          .build()
+      )
+      .addProperty(
+        PropertySpec.builder("avocado", String::class)
+          .initializer("avocado")
+          .build()
+      )
+      .addModifiers(INLINE)
+      .build()
+
+    assertThat(guacamole.toString()).isEqualTo(
+      """
+      |public inline class Guacamole private constructor(
+      |  public val avocado: kotlin.String
+      |)
+      |""".trimMargin()
+    )
   }
 
   @Test fun inlineEnumClass() {


### PR DESCRIPTION
This feature is available since 1.4.30-M1, see
https://youtrack.jetbrains.com/issue/KT-28056.

Release notes for 1.4.30-M1:
https://github.com/JetBrains/kotlin/releases/tag/v1.4.30-M1