### PR TITLE
fix overeager auto-import leading to uncompilable code due to clash with class function name

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -448,12 +448,25 @@ internal class CodeWriter constructor(
       return memberName.simpleName
     }
 
-    // We'll have to use the fully-qualified name. Mark the member as importable for a future pass.
-    if (!kdoc) {
+    // We'll have to use the fully-qualified name.
+    // Mark the member as importable for a future pass unless the name clashes with
+    // a method in the current context
+    if (!kdoc && !isMethodNameUsedInCurrentContext(memberName.simpleName)) {
       importableMember(memberName)
     }
 
     return memberName.canonicalName
+  }
+
+  // TODO(luqasn): also honor superclass members when resolving names.
+  private fun isMethodNameUsedInCurrentContext(simpleName: String): Boolean {
+    for (it in typeSpecStack.reversed()) {
+      if (it.funSpecs.any { it.name == simpleName })
+        return true
+      if (!it.modifiers.contains(KModifier.INNER))
+        break
+    }
+    return false
   }
 
   private fun importableType(className: ClassName) {

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/MemberNameTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/MemberNameTest.kt
@@ -201,6 +201,42 @@ class MemberNameTest {
     )
   }
 
+  @Test fun importedMemberAndClassFunctionNameClash() {
+    val kotlinErrorMember = MemberName("kotlin", "error")
+    val file = FileSpec.builder("com.squareup.tacos", "TacoTest")
+      .addType(
+        TypeSpec.classBuilder("TacoTest")
+          .addFunction(
+            FunSpec.builder("test")
+              .addStatement("%M(%S)", kotlinErrorMember, "errorText")
+              .build()
+          )
+          .addFunction(
+            FunSpec
+              .builder("error")
+              .build()
+          )
+          .build()
+      )
+      .build()
+    assertThat(file.toString()).isEqualTo(
+      """
+      |package com.squareup.tacos
+      |
+      |import kotlin.Unit
+      |
+      |public class TacoTest {
+      |  public fun test(): Unit {
+      |    kotlin.error("errorText")
+      |  }
+      |
+      |  public fun error(): Unit {
+      |  }
+      |}
+      |""".trimMargin()
+    )
+  }
+
   @Test fun memberNameAliases() {
     val createSquareTaco = MemberName("com.squareup.tacos", "createTaco")
     val createTwitterTaco = MemberName("com.twitter.tacos", "createTaco")


### PR DESCRIPTION
If I try to reference `kotlin.error` inside a class function to throw an exception, but my class also has a method called `error`, the auto-importing of `kotlin.error` and subsequent shortening of the emitted MemberName to `error` leads to a clash with the class function `error` (with the class member winning over the imported member).

See test for a clearer picture.

I fixed it by introducing tracking of emitted `FunSpec` names for `CodeBlock`s and subsequently in the `CodeWriter`.
This is not an ideal solution because in order to really fix it properly, the CodeWriter would need to have knowledge of scopes, which it does not have currently.
The way I fixed it would mean that a local function (not sure they are even supported?) would lead to blocking a auto import even though there might not be a clash.
But I was not able to come up with a better solution without changing how everything works right now.

Looking forward to your feedback!