### PR TITLE
Refactor logic to determine if function body should be omitted

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -117,16 +117,19 @@ public class FunSpec private constructor(
     }
   }
 
-  private fun shouldOmitBody(
-    implicitModifiers: Set<KModifier>
-  ): Boolean {
-    val isEmptyConstructor = isConstructor && body.isEmpty()
-    val isExternal = EXTERNAL in modifiers || EXTERNAL in implicitModifiers
-    return modifiers.containsAnyOf(ABSTRACT, EXPECT) ||
-            EXPECT in implicitModifiers ||
-            isEmptyConstructor ||
-            (isExternal && body.isEmpty())
+  private fun shouldOmitBody(implicitModifiers: Set<KModifier>): Boolean {
+    if (canNotHaveBody(implicitModifiers)) {
+      check(body.isEmpty()) { "function $name cannot have code" }
+      return true
+    }
+    return canBodyBeOmitted(implicitModifiers) && body.isEmpty()
   }
+
+  private fun canNotHaveBody(implicitModifiers: Set<KModifier>) =
+    ABSTRACT in modifiers || EXPECT in modifiers + implicitModifiers
+
+  private fun canBodyBeOmitted(implicitModifiers: Set<KModifier>) =
+    isConstructor || (modifiers + implicitModifiers).containsAnyOf(ABSTRACT, EXTERNAL)
 
   private fun emitSignature(codeWriter: CodeWriter, enclosingName: String?) {
     if (isConstructor) {

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -97,11 +97,7 @@ public class FunSpec private constructor(
     emitSignature(codeWriter, enclosingName)
     codeWriter.emitWhereBlock(typeVariables)
 
-    val isEmptyConstructor = isConstructor && body.isEmpty()
-    val isExternal = EXTERNAL in modifiers || EXTERNAL in implicitModifiers
-    if (modifiers.containsAnyOf(ABSTRACT, EXPECT) || EXPECT in implicitModifiers ||
-      isEmptyConstructor || (isExternal && body.isEmpty())
-    ) {
+    if (shouldOmitBody(implicitModifiers)) {
       codeWriter.emit("\n")
       return
     }
@@ -119,6 +115,17 @@ public class FunSpec private constructor(
     } else {
       codeWriter.emit("\n")
     }
+  }
+
+  private fun shouldOmitBody(
+    implicitModifiers: Set<KModifier>
+  ): Boolean {
+    val isEmptyConstructor = isConstructor && body.isEmpty()
+    val isExternal = EXTERNAL in modifiers || EXTERNAL in implicitModifiers
+    return modifiers.containsAnyOf(ABSTRACT, EXPECT) ||
+            EXPECT in implicitModifiers ||
+            isEmptyConstructor ||
+            (isExternal && body.isEmpty())
   }
 
   private fun emitSignature(codeWriter: CodeWriter, enclosingName: String?) {

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -54,8 +54,8 @@ public class FunSpec private constructor(
   private val isEmptySetter = name == SETTER && parameters.isEmpty()
 
   init {
-    require(body.isEmpty() || ABSTRACT !in builder.modifiers) {
-      "abstract function ${builder.name} cannot have code"
+    require(body.isEmpty() || !builder.modifiers.containsAnyOf(ABSTRACT, EXPECT)) {
+      "abstract or expect function ${builder.name} cannot have code"
     }
     if (name == SETTER) {
       require(parameters.size <= 1) {

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -1524,7 +1524,6 @@ class TypeSpecTest {
             TypeSpec.classBuilder("ClassC")
               .addFunction(
                 FunSpec.constructorBuilder()
-                  .addStatement("Unit")
                   .build()
               )
               .build()
@@ -1556,7 +1555,6 @@ class TypeSpecTest {
                 TypeSpec.classBuilder("ClassD")
                   .addFunction(
                     FunSpec.constructorBuilder()
-                      .addStatement("Unit")
                       .build()
                   )
                   .build()


### PR DESCRIPTION
while looking at some related code, I had a hard time understanding the current logic and extracted stuff into (hopefully) self-describing methods.

This also fixes what I think is a bug: `expect` functions would omit their body even if it was not empty. This logic 'flaw' was also present for `abstract` functions, but this code path was never hit due to validation in the constructor of `FunSpec`

Included is also another drive-by: implicitly abstract functions can have their empty body omitted as well now (this is currently not used, but I plan on doing a follow-up PR).