### PR TITLE
Update kotlinx-metadata to 0.2.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -28,7 +28,7 @@ object deps {
   object kotlin {
     const val reflect = "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}"
     const val junit = "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}"
-    const val metadata = "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0"
+    const val metadata = "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.2.0"
   }
   object test {
     const val truth = "com.google.truth:truth:1.0"

--- a/interop/kotlinx-metadata/core/src/main/kotlin/com/squareup/kotlinpoet/metadata/Flags.kt
+++ b/interop/kotlinx-metadata/core/src/main/kotlin/com/squareup/kotlinpoet/metadata/Flags.kt
@@ -105,6 +105,8 @@ public val Flags.isObjectClass: Boolean get() = Flag.Class.IS_OBJECT(this)
 @KotlinPoetMetadataPreview
 public val Flags.isInterface: Boolean get() = Flag.Class.IS_INTERFACE(this)
 @KotlinPoetMetadataPreview
+public val Flags.isFun: Boolean get() = Flag.Class.IS_FUN(this)
+@KotlinPoetMetadataPreview
 public val KmClass.isAnnotation: Boolean get() = flags.isAnnotationClass
 @KotlinPoetMetadataPreview
 public val KmClass.isClass: Boolean get() = flags.isClass
@@ -156,6 +158,8 @@ public val ImmutableKmClass.isInner: Boolean get() = flags.isInnerClass
 public val ImmutableKmClass.isObject: Boolean get() = flags.isObjectClass
 @KotlinPoetMetadataPreview
 public val ImmutableKmClass.isInterface: Boolean get() = flags.isInterface
+@KotlinPoetMetadataPreview
+public val ImmutableKmClass.isFun: Boolean get() = flags.isFun
 @KotlinPoetMetadataPreview
 public val ImmutableKmType.isSuspend: Boolean get() = flags.isSuspendType
 @KotlinPoetMetadataPreview

--- a/interop/kotlinx-metadata/core/src/main/kotlin/com/squareup/kotlinpoet/metadata/Flags.kt
+++ b/interop/kotlinx-metadata/core/src/main/kotlin/com/squareup/kotlinpoet/metadata/Flags.kt
@@ -163,7 +163,7 @@ public val ImmutableKmType.isNullable: Boolean get() = flags.isNullableType
 
 // Constructor flags.
 @KotlinPoetMetadataPreview
-public val Flags.isPrimaryConstructor: Boolean get() = Flag.Constructor.IS_PRIMARY(this)
+public val Flags.isPrimaryConstructor: Boolean get() = !Flag.Constructor.IS_SECONDARY(this)
 @KotlinPoetMetadataPreview
 public val KmConstructor.isPrimary: Boolean get() = flags.isPrimaryConstructor
 @KotlinPoetMetadataPreview

--- a/interop/kotlinx-metadata/specs-tests/build.gradle.kts
+++ b/interop/kotlinx-metadata/specs-tests/build.gradle.kts
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val compileTestKotlin: KotlinCompile by tasks
 compileTestKotlin.kotlinOptions {
-  freeCompilerArgs = listOf("-XXLanguage:+InlineClasses", "-Xjvm-default=enable")
+  freeCompilerArgs = listOf("-Xinline-classes", "-Xjvm-default=enable")
   jvmTarget = "1.8"
 }
 

--- a/interop/kotlinx-metadata/specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/interop/kotlinx-metadata/specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -2141,8 +2141,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     assertThat(funInterface.trimmedToString()).isEqualTo(
       """
       public fun interface FunInterface {
-        public fun example(): kotlin.Unit {
-        }
+        public abstract fun example(): kotlin.Unit
       }
       """.trimIndent()
     )

--- a/interop/kotlinx-metadata/specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/interop/kotlinx-metadata/specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -2132,6 +2132,25 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     override fun openFun() {
     }
   }
+
+  @Test
+  fun funClass() {
+    val funInterface = FunInterface::class.toTypeSpecWithTestHandler()
+
+    //language=kotlin
+    assertThat(funInterface.trimmedToString()).isEqualTo(
+      """
+      public fun interface FunInterface {
+        public fun example(): kotlin.Unit {
+        }
+      }
+      """.trimIndent()
+    )
+  }
+
+  fun interface FunInterface {
+    fun example()
+  }
 }
 
 class ClassNesting {

--- a/interop/kotlinx-metadata/specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/interop/kotlinx-metadata/specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -273,22 +273,22 @@ private fun ImmutableKmClass.toTypeSpec(
     isEnum -> TypeSpec.enumBuilder(simpleName)
     isExpect -> TypeSpec.expectClassBuilder(simpleName)
     isObject -> TypeSpec.objectBuilder(simpleName)
-    isInterface -> TypeSpec.interfaceBuilder(simpleName)
+    isInterface -> {
+      if (classData?.declarationContainer?.isFun == true) {
+        TypeSpec.funInterfaceBuilder(simpleName)
+      } else {
+        TypeSpec.interfaceBuilder(simpleName)
+      }
+    }
     isEnumEntry -> TypeSpec.anonymousClassBuilder()
     else -> TypeSpec.classBuilder(simpleName)
   }
 
-  classData?.run {
-    annotations
-      .filterNot {
-        it.typeName == METADATA || it.typeName in JAVA_ANNOTATION_ANNOTATIONS
-      }
-      .let(builder::addAnnotations)
-
-    if (declarationContainer.isFun) {
-      builder.addModifiers(KModifier.FUN)
+  classData?.annotations
+    ?.filterNot {
+      it.typeName == METADATA || it.typeName in JAVA_ANNOTATION_ANNOTATIONS
     }
-  }
+    ?.let(builder::addAnnotations)
 
   if (isEnum) {
     enumEntries.forEach { entryName ->

--- a/interop/kotlinx-metadata/specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/interop/kotlinx-metadata/specs/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -88,6 +88,7 @@ import com.squareup.kotlinpoet.metadata.isEnumEntry
 import com.squareup.kotlinpoet.metadata.isExpect
 import com.squareup.kotlinpoet.metadata.isExternal
 import com.squareup.kotlinpoet.metadata.isFinal
+import com.squareup.kotlinpoet.metadata.isFun
 import com.squareup.kotlinpoet.metadata.isInfix
 import com.squareup.kotlinpoet.metadata.isInline
 import com.squareup.kotlinpoet.metadata.isInner
@@ -277,11 +278,17 @@ private fun ImmutableKmClass.toTypeSpec(
     else -> TypeSpec.classBuilder(simpleName)
   }
 
-  classData?.annotations
-    ?.filterNot {
-      it.typeName == METADATA || it.typeName in JAVA_ANNOTATION_ANNOTATIONS
+  classData?.run {
+    annotations
+      .filterNot {
+        it.typeName == METADATA || it.typeName in JAVA_ANNOTATION_ANNOTATIONS
+      }
+      .let(builder::addAnnotations)
+
+    if (declarationContainer.isFun) {
+      builder.addModifiers(KModifier.FUN)
     }
-    ?.let(builder::addAnnotations)
+  }
 
   if (isEnum) {
     enumEntries.forEach { entryName ->


### PR DESCRIPTION
Notable improvements:
* Support `fun interface`
* Fix primary constructor detection