### PR TITLE
Omit redundant abstract modifiers on members where possible

### DIFF
--- a/interop/kotlinx-metadata/specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
+++ b/interop/kotlinx-metadata/specs-tests/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/test/KotlinPoetMetadataSpecsTest.kt
@@ -645,11 +645,11 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         public fun hasJvmDefault(): kotlin.Unit {
         }
 
-        public abstract fun noDefault(): kotlin.Unit
+        public fun noDefault(): kotlin.Unit
 
-        public abstract fun noDefaultWithInput(input: kotlin.String): kotlin.Unit
+        public fun noDefaultWithInput(input: kotlin.String): kotlin.Unit
 
-        public abstract fun noDefaultWithInputDefault(input: kotlin.String = throw NotImplementedError("Stub!")): kotlin.Unit
+        public fun noDefaultWithInputDefault(input: kotlin.String = throw NotImplementedError("Stub!")): kotlin.Unit
       }
       """.trimIndent()
     )
@@ -1200,7 +1200,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         public fun defaultMethod(): kotlin.Unit {
         }
 
-        public abstract fun notDefaultMethod(): kotlin.Unit
+        public fun notDefaultMethod(): kotlin.Unit
       }
       """.trimIndent()
     )
@@ -1535,7 +1535,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
            * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
            */
           @kotlin.jvm.JvmSynthetic
-          public abstract fun interfaceFunction(): kotlin.Unit
+          public fun interfaceFunction(): kotlin.Unit
 
           public companion object {
             @get:kotlin.jvm.JvmSynthetic
@@ -1600,7 +1600,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
            * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
            */
           @kotlin.jvm.JvmSynthetic
-          public abstract fun interfaceFunction(): kotlin.Unit
+          public fun interfaceFunction(): kotlin.Unit
 
           public companion object {
             @get:kotlin.jvm.JvmSynthetic
@@ -2141,7 +2141,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     assertThat(funInterface.trimmedToString()).isEqualTo(
       """
       public fun interface FunInterface {
-        public abstract fun example(): kotlin.Unit
+        public fun example(): kotlin.Unit
       }
       """.trimIndent()
     )

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -129,8 +129,8 @@ public class FunSpec private constructor(
     ABSTRACT in modifiers || EXPECT in modifiers + implicitModifiers
 
   private fun canBodyBeOmitted(implicitModifiers: Set<KModifier>) = isConstructor ||
-      EXTERNAL in (modifiers + implicitModifiers) ||
-      ABSTRACT in modifiers
+    EXTERNAL in (modifiers + implicitModifiers) ||
+    ABSTRACT in modifiers
 
   private fun emitSignature(codeWriter: CodeWriter, enclosingName: String?) {
     if (isConstructor) {

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -128,8 +128,9 @@ public class FunSpec private constructor(
   private fun canNotHaveBody(implicitModifiers: Set<KModifier>) =
     ABSTRACT in modifiers || EXPECT in modifiers + implicitModifiers
 
-  private fun canBodyBeOmitted(implicitModifiers: Set<KModifier>) =
-    isConstructor || (modifiers + implicitModifiers).containsAnyOf(ABSTRACT, EXTERNAL)
+  private fun canBodyBeOmitted(implicitModifiers: Set<KModifier>) = isConstructor ||
+      EXTERNAL in (modifiers + implicitModifiers) ||
+      ABSTRACT in modifiers
 
   private fun emitSignature(codeWriter: CodeWriter, enclosingName: String?) {
     if (isConstructor) {

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -420,7 +420,7 @@ public class TypeSpec private constructor(
   ) {
     CLASS("class", setOf(PUBLIC), setOf(PUBLIC), setOf()),
     OBJECT("object", setOf(PUBLIC), setOf(PUBLIC), setOf()),
-    INTERFACE("interface", setOf(PUBLIC), setOf(PUBLIC), setOf());
+    INTERFACE("interface", setOf(PUBLIC, ABSTRACT), setOf(PUBLIC, ABSTRACT), setOf());
 
     internal fun implicitPropertyModifiers(modifiers: Set<KModifier>): Set<KModifier> {
       return defaultImplicitPropertyModifiers + when {

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -423,7 +423,7 @@ class TypeSpecTest {
         |    "User-Agent: foobar"
         |  )
         |  @POST("/foo/bar")
-        |  public abstract fun fooBar(
+        |  public fun fooBar(
         |    @Body things: Things<Thing>,
         |    @QueryMap(encodeValues = false) query: Map<String, String>,
         |    @Header("Authorization") authorization: String
@@ -1127,7 +1127,7 @@ class TypeSpecTest {
         |import kotlin.Unit
         |
         |public fun interface Taco {
-        |  public abstract fun sam(): Unit
+        |  public fun sam(): Unit
         |
         |  public fun notSam(): Unit {
         |  }
@@ -1600,7 +1600,7 @@ class TypeSpecTest {
         |import kotlin.Unit
         |
         |public interface Taco {
-        |  public abstract fun aMethod(): Unit
+        |  public fun aMethod(): Unit
         |
         |  public fun aDefaultMethod(): Unit {
         |  }
@@ -4949,10 +4949,17 @@ class TypeSpecTest {
       .addType(
         TypeSpec.interfaceBuilder("Taco")
           .addProperty("foo", String::class, ABSTRACT)
+          .addProperty(PropertySpec.builder("fooWithDefault", String::class)
+            .initializer("%S", "defaultValue")
+            .build())
           .addFunction(
             FunSpec.builder("bar")
               .addModifiers(ABSTRACT)
               .returns(String::class)
+              .build()
+          )
+          .addFunction(
+            FunSpec.builder("barWithDefault")
               .build()
           )
           .build()
@@ -4964,11 +4971,17 @@ class TypeSpecTest {
       package com.squareup.tacos
 
       import kotlin.String
+      import kotlin.Unit
 
       public interface Taco {
-        public abstract val foo: String
-
-        public abstract fun bar(): String
+        public val foo: String
+      
+        public val fooWithDefault: String = "defaultValue"
+      
+        public fun bar(): String
+      
+        public fun barWithDefault(): Unit {
+        }
       }
 
       """.trimIndent()
@@ -4976,6 +4989,6 @@ class TypeSpecTest {
   }
 
   companion object {
-    private val donutsPackage = "com.squareup.donuts"
+    private const val donutsPackage = "com.squareup.donuts"
   }
 }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -4949,9 +4949,11 @@ class TypeSpecTest {
       .addType(
         TypeSpec.interfaceBuilder("Taco")
           .addProperty("foo", String::class, ABSTRACT)
-          .addProperty(PropertySpec.builder("fooWithDefault", String::class)
-            .initializer("%S", "defaultValue")
-            .build())
+          .addProperty(
+            PropertySpec.builder("fooWithDefault", String::class)
+              .initializer("%S", "defaultValue")
+              .build()
+          )
           .addFunction(
             FunSpec.builder("bar")
               .addModifiers(ABSTRACT)
@@ -4975,11 +4977,11 @@ class TypeSpecTest {
 
       public interface Taco {
         public val foo: String
-      
+
         public val fooWithDefault: String = "defaultValue"
-      
+
         public fun bar(): String
-      
+
         public fun barWithDefault(): Unit {
         }
       }


### PR DESCRIPTION
Partially revert #1013 in favor of moving the other direction