### PR TITLE
Fix Version 1.8.0 release date in changelog

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,7 @@ Change Log
 
 ## Version 1.8.0
 
-_2021-03-22_
+_2021-03-29_
 
  
  * New: Kotlin 1.4.31.


### PR DESCRIPTION
Setting to the actual release date