### PR TITLE
Update dependencies

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -15,7 +15,7 @@
  */
 object versions {
   const val kotlin = "1.5.10"
-  const val spotless = "5.12.5"
+  const val spotless = "5.13.0"
   const val ktlint = "0.41.0"
   const val mavenPublish = "0.15.1"
   const val dokka = "1.4.32"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -17,12 +17,12 @@ object versions {
   const val kotlin = "1.5.10"
   const val spotless = "5.12.5"
   const val ktlint = "0.41.0"
-  const val mavenPublish = "0.13.0"
+  const val mavenPublish = "0.15.1"
   const val dokka = "1.4.32"
 }
 
 object deps {
-  const val autoCommon = "com.google.auto:auto-common:1.0"
+  const val autoCommon = "com.google.auto:auto-common:1.0.1"
   const val guava = "com.google.guava:guava:30.1.1-jre"
   object kotlin {
     const val reflect = "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}"
@@ -34,6 +34,6 @@ object deps {
     const val compileTesting = "com.google.testing.compile:compile-testing:0.19"
     const val jimfs = "com.google.jimfs:jimfs:1.2"
     const val ecj = "org.eclipse.jdt.core.compiler:ecj:4.6.1"
-    const val kotlinCompileTesting = "com.github.tschuchortdev:kotlin-compile-testing:1.4.1"
+    const val kotlinCompileTesting = "com.github.tschuchortdev:kotlin-compile-testing:1.4.2"
   }
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -17,7 +17,7 @@ object versions {
   const val kotlin = "1.5.10"
   const val spotless = "5.13.0"
   const val ktlint = "0.41.0"
-  const val mavenPublish = "0.15.1"
+  const val mavenPublish = "0.13.0"
   const val dokka = "1.4.32"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- [kotlin-compile-testing 1.4.2](https://github.com/tschuchortdev/kotlin-compile-testing/releases/tag/1.4.2) Updated kotlin-compiler-embeddable and KSP to 1.5.10
- [AutoCommon 1.0.1](https://github.com/google/auto/releases/tag/auto-common-1.0.1) Added some methods to allow annotation processors to use Streams functionality that is present in mainline Guava but not Android Guava. This can be useful if Android Guava might be on the processor path.