### PR TITLE
Escape members that contains only underscores

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -168,7 +168,6 @@ internal val String.isIdentifier get() = IDENTIFIER_REGEX.matches(this)
 // https://kotlinlang.org/docs/reference/keyword-reference.html
 private val KEYWORDS = setOf(
   // Hard keywords
-  "_",
   "as",
   "break",
   "class",

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -270,10 +270,10 @@ private fun String.failIfEscapeInvalid() {
 }
 
 internal fun String.escapeIfNecessary(validate: Boolean = true): String = escapeIfNotJavaIdentifier()
-    .escapeIfKeyword()
-    .escapeIfHasAllowedCharacters()
-    .escapeIfAllCharactersAreUnderscore()
-    .apply { if (!validate) failIfEscapeInvalid() }
+  .escapeIfKeyword()
+  .escapeIfHasAllowedCharacters()
+  .escapeIfAllCharactersAreUnderscore()
+  .apply { if (validate) failIfEscapeInvalid() }
 
 private fun String.alreadyEscaped() = startsWith("`") && endsWith("`")
 

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -1223,4 +1223,41 @@ class KotlinPoetTest {
       |""".trimMargin()
     )
   }
+
+  @Test fun allStringsAreEscaped() {
+    val file = FileSpec.builder("com.squareup.tacos", "SourceWithEscapedStrings")
+      .addType(
+        TypeSpec.classBuilder("SourceWithEscapedStrings")
+          .primaryConstructor(
+            FunSpec.constructorBuilder()
+              .addParameter("_", Float::class)
+              .addParameter("____", Float::class)
+              .build()
+          )
+          .addProperty(
+            PropertySpec.builder("_", Float::class)
+              .initializer("_")
+              .build()
+          )
+          .addProperty(
+            PropertySpec.builder("____", Float::class)
+              .initializer("____")
+              .build()
+          )
+          .build()
+      )
+      .build()
+    assertThat(file.toString()).isEqualTo(
+      """
+      |package com.squareup.tacos
+      |
+      |import kotlin.Float
+      |
+      |public class SourceWithEscapedStrings(
+      |  public val `_`: Float,
+      |  public val `____`: Float
+      |)
+      |""".trimMargin()
+    )
+  }
 }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -1224,10 +1224,10 @@ class KotlinPoetTest {
     )
   }
 
-  @Test fun allStringsAreEscaped() {
-    val file = FileSpec.builder("com.squareup.tacos", "SourceWithEscapedStrings")
+  @Test fun allStringsAreUnderscore() {
+    val file = FileSpec.builder("com.squareup.tacos", "SourceWithUnderscores")
       .addType(
-        TypeSpec.classBuilder("SourceWithEscapedStrings")
+        TypeSpec.classBuilder("SourceWithUnderscores")
           .primaryConstructor(
             FunSpec.constructorBuilder()
               .addParameter("_", Float::class)
@@ -1253,7 +1253,7 @@ class KotlinPoetTest {
       |
       |import kotlin.Float
       |
-      |public class SourceWithEscapedStrings(
+      |public class SourceWithUnderscores(
       |  public val `_`: Float,
       |  public val `____`: Float
       |)


### PR DESCRIPTION
Currently, instructions like `_` and `__` after generation not escaped.  This PR add escaping for such identifiers.

Example:  `data class(val `____`: String)`