### PR TITLE
Update error message when metadata cannot be read

### DIFF
--- a/interop/kotlinx-metadata/core/src/main/kotlin/com/squareup/kotlinpoet/metadata/KotlinPoetMetadata.kt
+++ b/interop/kotlinx-metadata/core/src/main/kotlin/com/squareup/kotlinpoet/metadata/KotlinPoetMetadata.kt
@@ -87,7 +87,7 @@ public inline fun <reified T : KotlinClassMetadata> Metadata.toKotlinClassMetada
 public fun Metadata.readKotlinClassMetadata(): KotlinClassMetadata {
   val metadata = KotlinClassMetadata.read(asClassHeader())
   checkNotNull(metadata) {
-    "Could not parse metadata! This should only happen if you're using Kotlin <1.1."
+    "Could not parse metadata! Try bumping kotlinpoet and/or kotlinx-metadata version."
   }
   return metadata
 }


### PR DESCRIPTION
Kotlin 1.1 is long gone and updating the version is more actionable.

See https://github.com/square/kotlinpoet/issues/1078