### PR TITLE
Avoid escaping already escaped string

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -284,8 +284,11 @@ private fun String.escapeIfHasAllowedCharacters() = if (hasAllowedCharacters && 
 private fun String.escapeIfAllCharactersAreUnderscore() = if (allCharactersAreUnderscore && !alreadyEscaped()) "`$this`" else this
 
 private fun String.escapeIfNotJavaIdentifier(): String {
-  return if (!Character.isJavaIdentifierStart(first()) ||
-    drop(1).any { !Character.isJavaIdentifierPart(it) } && !alreadyEscaped()
+  return if ((
+    !Character.isJavaIdentifierStart(first()) ||
+      drop(1).any { !Character.isJavaIdentifierPart(it) }
+    ) &&
+    !alreadyEscaped()
   ) {
     "`$this`".replace(' ', '·')
   } else {

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
@@ -141,6 +141,10 @@ class UtilTest {
     assertThat("A-\$B".escapeIfNecessary()).isEqualTo("`A-\$B`")
   }
 
+  @Test fun escapeEscaped() {
+    assertThat("`A`".escapeIfNecessary()).isEqualTo("`A`")
+  }
+
   private fun stringLiteral(string: String) = stringLiteral(string, string)
 
   private fun stringLiteral(expected: String, value: String) =


### PR DESCRIPTION
Fix by avoiding a short circuit and making sure we evaluate !alreadyEscaped

The added test would previously fail.