### PR TITLE
Simplify kts

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -20,7 +20,3 @@ plugins {
 repositories {
   mavenCentral()
 }
-
-kotlinDslPluginOptions {
-  experimentalWarning.set(false)
-}

--- a/interop/kotlinx-metadata/classinspectors/elements/build.gradle.kts
+++ b/interop/kotlinx-metadata/classinspectors/elements/build.gradle.kts
@@ -19,7 +19,7 @@ val VERSION_NAME: String by project
 group = GROUP
 version = VERSION_NAME
 
-tasks.named<Jar>("jar") {
+tasks.jar {
   manifest {
     attributes("Automatic-Module-Name" to "com.squareup.kotlinpoet.classinspector.elements")
   }

--- a/interop/kotlinx-metadata/classinspectors/reflect/build.gradle.kts
+++ b/interop/kotlinx-metadata/classinspectors/reflect/build.gradle.kts
@@ -19,7 +19,7 @@ val VERSION_NAME: String by project
 group = GROUP
 version = VERSION_NAME
 
-tasks.named<Jar>("jar") {
+tasks.jar {
   manifest {
     attributes("Automatic-Module-Name" to "com.squareup.kotlinpoet.classinspector.reflective")
   }

--- a/interop/kotlinx-metadata/core/build.gradle.kts
+++ b/interop/kotlinx-metadata/core/build.gradle.kts
@@ -19,7 +19,7 @@ val VERSION_NAME: String by project
 group = GROUP
 version = VERSION_NAME
 
-tasks.named<Jar>("jar") {
+tasks.jar {
   manifest {
     attributes("Automatic-Module-Name" to "com.squareup.kotlinpoet.km")
   }

--- a/interop/kotlinx-metadata/specs-tests/build.gradle.kts
+++ b/interop/kotlinx-metadata/specs-tests/build.gradle.kts
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-tasks.withType<KotlinCompile>().named("compileTestKotlin") {
+tasks.compileTestKotlin {
   kotlinOptions {
     freeCompilerArgs = listOf("-Xjvm-default=all")
   }

--- a/interop/kotlinx-metadata/specs/build.gradle.kts
+++ b/interop/kotlinx-metadata/specs/build.gradle.kts
@@ -19,7 +19,7 @@ val VERSION_NAME: String by project
 group = GROUP
 version = VERSION_NAME
 
-tasks.named<Jar>("jar") {
+tasks.jar {
   manifest {
     attributes("Automatic-Module-Name" to "com.squareup.kotlinpoet.metadata.specs")
   }

--- a/kotlinpoet/build.gradle.kts
+++ b/kotlinpoet/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val GROUP: String by project
 val VERSION_NAME: String by project
@@ -21,13 +20,13 @@ val VERSION_NAME: String by project
 group = GROUP
 version = VERSION_NAME
 
-tasks.named<Jar>("jar") {
+tasks.jar {
   manifest {
     attributes("Automatic-Module-Name" to "com.squareup.kotlinpoet")
   }
 }
 
-tasks.withType<KotlinCompile>().named("compileTestKotlin") {
+tasks.compileTestKotlin {
   kotlinOptions {
     freeCompilerArgs = listOf("-Xopt-in=com.squareup.kotlinpoet.DelicateKotlinPoetApi")
   }


### PR DESCRIPTION
- Simplify tasks with extensions in subprojects.
- Remove deprecated `kotlinDslPluginOptions`.

```kotlin
/**
 * Flag has no effect since `kotlin-dsl` no longer relies on experimental features.
 */
@Deprecated(deprecationMessage)
val experimentalWarning: Property<Boolean>
    get() {
        nagUserAboutExperimentalWarning()
        return experimentalWarningProperty
    }
```