### PR TITLE
Disable publish action in forked repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
@@ -39,7 +39,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.repository == 'square/kotlinpoet' && github.ref == 'refs/heads/master'
     needs:
       - jvm
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [ push, pull_request ]
+on: [push, pull_request]
 
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"


### PR DESCRIPTION
I enabled the github actions in my forked repo for build and test, but triggered publish action after jvm job, it's unnecessary to publish, so I think we can disable it in forked repo.


![image](https://user-images.githubusercontent.com/10363352/129059367-63455ae6-3b32-4dba-aa3b-97d12b337183.png)
