### PR TITLE
Allow copying a ParameterizedTypeName with new type arguments

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ParameterizedTypeName.kt
@@ -50,6 +50,15 @@ public class ParameterizedTypeName internal constructor(
     return ParameterizedTypeName(enclosingType, rawType, typeArguments, nullable, annotations, tags)
   }
 
+  public fun copy(
+    nullable: Boolean = this.isNullable,
+    annotations: List<AnnotationSpec> = this.annotations,
+    tags: Map<KClass<*>, Any> = this.tags,
+    typeArguments: List<TypeName> = this.typeArguments
+  ): ParameterizedTypeName {
+    return ParameterizedTypeName(enclosingType, rawType, typeArguments, nullable, annotations, tags)
+  }
+
   public fun plusParameter(typeArgument: TypeName): ParameterizedTypeName =
     ParameterizedTypeName(
       enclosingType, rawType, typeArguments + typeArgument, isNullable,

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ParameterizedTypeNameTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ParameterizedTypeNameTest.kt
@@ -112,6 +112,21 @@ class ParameterizedTypeNameTest {
     assertThat(typeName.toString()).isEqualTo("java.util.Map<java.lang.String, java.lang.Integer>")
   }
 
+  @Test fun copyingTypeArguments() {
+    val typeName = java.util.Map::class.java
+      .plusParameter(java.lang.String::class.java)
+      .plusParameter(java.lang.Integer::class.java)
+      .nestedClass(
+        "Entry",
+        listOf(
+          java.lang.String::class.java.asClassName(),
+          java.lang.Integer::class.java.asClassName()
+        )
+      )
+      .copy(typeArguments = listOf(STAR, STAR))
+    assertThat(typeName.toString()).isEqualTo("java.util.Map<java.lang.String, java.lang.Integer>.Entry<*, *>")
+  }
+
   interface Projections {
     val outVariance: KClass<out Annotation>
     val inVariance: KClass<in Test>


### PR DESCRIPTION
This fixes #1139 