### PR TITLE
Do not use reflection for kotlin.Unit

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -159,7 +159,7 @@ public class FunSpec private constructor(
     if (returnType != null) {
       codeWriter.emitCode(": %T", returnType)
     } else if (emitUnitReturnType()) {
-      codeWriter.emitCode(": %T", Unit::class.asTypeName())
+      codeWriter.emitCode(": %T", UNIT)
     }
 
     if (delegateConstructor != null) {

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt
@@ -220,7 +220,7 @@ public sealed class TypeName constructor(
 
 @JvmField public val ANY: ClassName = ClassName("kotlin", "Any")
 @JvmField public val ARRAY: ClassName = ClassName("kotlin", "Array")
-@JvmField public val UNIT: ClassName = Unit::class.asClassName()
+@JvmField public val UNIT: ClassName = ClassName("kotlin", "Unit")
 @JvmField public val BOOLEAN: ClassName = ClassName("kotlin", "Boolean")
 @JvmField public val BYTE: ClassName = ClassName("kotlin", "Byte")
 @JvmField public val SHORT: ClassName = ClassName("kotlin", "Short")


### PR DESCRIPTION
Explicitely use "kotlin.Unit" instead of using reflection. Allows to use kotlinpoet with a relocated kotlin stdlib if needed. Relocating kotlin.Unit isn't super useful in itself but it can happen and the change makes the codebase more consistent regardless.