### PR TITLE
Rearrange kdoc of MemberName

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/MemberName.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/MemberName.kt
@@ -20,13 +20,6 @@ import kotlin.reflect.KClass
 /**
  * Represents the name of a member (such as a function or a property).
  *
- * @param packageName e.g. `kotlin.collections`
- * @param enclosingClassName e.g. `Map.Entry.Companion`, if the member is declared inside the
- * companion object of the Map.Entry class
- * @param simpleName e.g. `isBlank`, `size`
- * @param isExtension whether the member is an extension property or an extension function. Default
- * is false.
- *
  * If there is a member with the same name as this member in a local scope, the generated code will
  * include this member's fully-qualified name to avoid ambiguity, e.g.:
  *
@@ -66,6 +59,13 @@ import kotlin.reflect.KClass
  *   }
  * }
  * ```
+ *
+ * @param packageName e.g. `kotlin.collections`
+ * @param enclosingClassName e.g. `Map.Entry.Companion`, if the member is declared inside the
+ * companion object of the Map.Entry class
+ * @param simpleName e.g. `isBlank`, `size`
+ * @param isExtension whether the member is an extension property or an extension function. Default
+ * is false.
  */
 public data class MemberName internal constructor(
   public val packageName: String,


### PR DESCRIPTION
Looks like the comments of `MemberName` are not showing completely in [doc website](https://square.github.io/kotlinpoet/1.x/kotlinpoet/kotlinpoet/com.squareup.kotlinpoet/-member-name/index.html) as params were placed in middle place instead of the last lines. They should be moved to the last lines, right ?
Filed an issue [here](https://github.com/Kotlin/dokka/issues/2135).

![image](https://user-images.githubusercontent.com/10363352/132998103-4d80cea4-21f3-4888-b14e-04826115a570.png)
