### PR TITLE
Implement basic KSP interop

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,11 +14,13 @@
 
 [versions]
 kotlin = "1.5.30"
+ksp = "1.5.30-1.0.0"
 ktlint = "0.41.0"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version = "1.5.0" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 spotless = { id = "com.diffplug.spotless", version = "5.14.3" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.17.0" }
 
@@ -29,6 +31,9 @@ guava = { module = "com.google.guava:guava", version = "30.1.1-jre" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlin-metadata = { module = "org.jetbrains.kotlinx:kotlinx-metadata-jvm", version = "0.3.0" }
+
+ksp = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
+ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 
 truth = { module = "com.google.truth:truth", version = "1.1.3" }
 compileTesting = { module = "com.google.testing.compile:compile-testing", version = "0.19" }

--- a/interop/ksp/build.gradle.kts
+++ b/interop/ksp/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Square, Inc.
+ * Copyright (C) 2021 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/interop/ksp/build.gradle.kts
+++ b/interop/ksp/build.gradle.kts
@@ -13,21 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-pluginManagement {
-  repositories {
-    mavenCentral()
-    gradlePluginPortal()
+
+tasks.jar {
+  manifest {
+    attributes("Automatic-Module-Name" to "com.squareup.kotlinpoet.ksp")
   }
 }
 
-include(
-    ":kotlinpoet",
-    ":interop:kotlinx-metadata:classinspectors:elements",
-    ":interop:kotlinx-metadata:classinspectors:reflect",
-    ":interop:kotlinx-metadata:core",
-    ":interop:kotlinx-metadata:specs",
-    ":interop:kotlinx-metadata:specs-tests",
-    ":interop:ksp"
-)
-
-enableFeaturePreview("VERSION_CATALOGS")
+dependencies {
+  api(project(":kotlinpoet"))
+  api(libs.ksp.api)
+  testImplementation(libs.kotlin.junit)
+  testImplementation(libs.truth)
+}

--- a/interop/ksp/build.gradle.kts
+++ b/interop/ksp/build.gradle.kts
@@ -22,7 +22,7 @@ tasks.jar {
 
 dependencies {
   api(project(":kotlinpoet"))
-  api(libs.ksp.api)
+  compileOnly(libs.ksp.api)
   testImplementation(libs.kotlin.junit)
   testImplementation(libs.truth)
 }

--- a/interop/ksp/gradle.properties
+++ b/interop/ksp/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=kotlinpoet-ksp
+POM_NAME=KotlinPoet (KSP Interop)
+POM_DESCRIPTION=Extensions for interop with KSP (Kotlin Symbol Processing).
+POM_PACKAGING=jar

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KotlinPoetKspPreview.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KotlinPoetKspPreview.kt
@@ -1,0 +1,14 @@
+package com.squareup.kotlinpoet.ksp
+
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY
+
+/**
+ * Indicates that a given API is part of the experimental KotlinPoet KSP support. This exists
+ * because KotlinPoet support of KSP is in preview and subject to change.
+ */
+@RequiresOptIn
+@Retention(AnnotationRetention.BINARY)
+@Target(CLASS, FUNCTION, PROPERTY)
+public annotation class KotlinPoetKspPreview

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KotlinPoetKspPreview.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KotlinPoetKspPreview.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.kotlinpoet.ksp
 
 import kotlin.annotation.AnnotationTarget.CLASS

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/TypeParameterResolver.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/TypeParameterResolver.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.kotlinpoet.ksp
 
 import com.google.devtools.ksp.symbol.KSType

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/TypeParameterResolver.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/TypeParameterResolver.kt
@@ -26,12 +26,9 @@ public interface TypeParameterResolver {
      * are known to not have arguments, such as top-level classes.
      */
     public val EMPTY: TypeParameterResolver = object : TypeParameterResolver {
-      override val parametersMap: Map<String, TypeVariableName>
-        get() = emptyMap()
+      override val parametersMap: Map<String, TypeVariableName> = emptyMap()
 
-      override fun get(index: String): TypeVariableName {
-        error("No TypeParameter found for index $index")
-      }
+      override fun get(index: String): TypeVariableName = throw NoSuchElementException("No TypeParameter found for index $index")
     }
   }
 }

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/TypeParameterResolver.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/TypeParameterResolver.kt
@@ -1,0 +1,85 @@
+package com.squareup.kotlinpoet.ksp
+
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.squareup.kotlinpoet.TypeVariableName
+
+/**
+ * A resolver for enclosing declarations' type parameters. Parent declarations can be anything with
+ * generics that child nodes declare as defined by [KSType.arguments].
+ *
+ * This is important for resolving inherited generics on child declarations, as KSP interop
+ * otherwise can't resolve them.
+ *
+ * In general, you want to retrieve an instance of this via [toTypeParameterResolver].
+ *
+ * @see toTypeParameterResolver
+ */
+@KotlinPoetKspPreview
+public interface TypeParameterResolver {
+  public val parametersMap: Map<String, TypeVariableName>
+  public operator fun get(index: String): TypeVariableName
+
+  public companion object {
+    /**
+     * An empty instance of [TypeParameterResolver], only should be used if enclosing declarations
+     * are known to not have arguments, such as top-level classes.
+     */
+    public val EMPTY: TypeParameterResolver = object : TypeParameterResolver {
+      override val parametersMap: Map<String, TypeVariableName>
+        get() = emptyMap()
+
+      override fun get(index: String): TypeVariableName {
+        error("No TypeParameter found for index $index")
+      }
+    }
+  }
+}
+
+/**
+ * Returns a [TypeParameterResolver] for this list of [KSTypeParameters][KSTypeParameter] for use
+ * with enclosed declarations.
+ *
+ * @param parent the optional parent resolver, if any. An example of this is cases where you might
+ *               create a resolver for a [KSFunction] and supply a parent resolved from the
+ *               enclosing [KSClassDeclaration].
+ * @param sourceTypeHint an optional hint for error messages. Unresolvable parameter IDs will
+ *                       include this hint in the thrown error's message.
+ */
+@KotlinPoetKspPreview
+public fun List<KSTypeParameter>.toTypeParameterResolver(
+  parent: TypeParameterResolver? = null,
+  sourceTypeHint: String = "<unknown>",
+): TypeParameterResolver {
+  val parametersMap = LinkedHashMap<String, TypeVariableName>()
+  val typeParamResolver = { id: String ->
+    parametersMap[id]
+      ?: parent?.get(id)
+      ?: throw IllegalStateException(
+        "No type argument found for $id! Analyzed $sourceTypeHint with known parameters " +
+          "${parametersMap.keys}"
+      )
+  }
+
+  val resolver = object : TypeParameterResolver {
+    override val parametersMap: Map<String, TypeVariableName> = parametersMap
+
+    override operator fun get(index: String): TypeVariableName = typeParamResolver(index)
+  }
+
+  // Fill the parametersMap. Need to do sequentially and allow for referencing previously defined params
+  for (typeVar in this) {
+    // Put the simple typevar in first, then it can be referenced in the full toTypeVariable()
+    // replacement later that may add bounds referencing this.
+    val id = typeVar.name.getShortName()
+    parametersMap[id] = TypeVariableName(id)
+  }
+
+  for (typeVar in this) {
+    val id = typeVar.name.getShortName()
+    // Now replace it with the full version.
+    parametersMap[id] = typeVar.toTypeVariableName(resolver)
+  }
+
+  return resolver
+}

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksClassDeclarations.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksClassDeclarations.kt
@@ -1,0 +1,19 @@
+package com.squareup.kotlinpoet.ksp
+
+import com.google.devtools.ksp.isLocal
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.ClassName
+
+/** Returns the [ClassName] representation of this [KSClassDeclaration]. */
+@KotlinPoetKspPreview
+public fun KSClassDeclaration.toClassName(): ClassName {
+  require(!isLocal()) {
+    "Local/anonymous classes are not supported!"
+  }
+  val pkgName = packageName.asString()
+  val typesString = checkNotNull(qualifiedName).asString().removePrefix("$pkgName.")
+
+  val simpleNames = typesString
+    .split(".")
+  return ClassName(pkgName, simpleNames)
+}

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksClassDeclarations.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksClassDeclarations.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.kotlinpoet.ksp
 
 import com.google.devtools.ksp.isLocal

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.kotlinpoet.ksp
 
 import com.google.devtools.ksp.symbol.KSClassDeclaration

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt
@@ -1,0 +1,121 @@
+package com.squareup.kotlinpoet.ksp
+
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeAlias
+import com.google.devtools.ksp.symbol.KSTypeArgument
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.Variance
+import com.google.devtools.ksp.symbol.Variance.CONTRAVARIANT
+import com.google.devtools.ksp.symbol.Variance.COVARIANT
+import com.google.devtools.ksp.symbol.Variance.INVARIANT
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.STAR
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeVariableName
+import com.squareup.kotlinpoet.WildcardTypeName
+
+/** Returns the [ClassName] representation of this [KSType] IFF it's a [KSClassDeclaration]. */
+@KotlinPoetKspPreview
+public fun KSType.toClassName(): ClassName {
+  val decl = declaration
+  check(decl is KSClassDeclaration) {
+    "Declaration was not a KSClassDeclaration: $this"
+  }
+  return decl.toClassName()
+}
+
+/**
+ * Returns the [TypeName] representation of this [KSType].
+ *
+ * @see toTypeParameterResolver
+ * @param typeParamResolver an optional resolver for enclosing declarations' type parameters. Parent
+ *                          declarations can be anything with generics that child nodes declare as
+ *                          defined by [KSType.arguments].
+ */
+@KotlinPoetKspPreview
+public fun KSType.toTypeName(
+  typeParamResolver: TypeParameterResolver = TypeParameterResolver.EMPTY
+): TypeName {
+  val type = when (val decl = declaration) {
+    is KSClassDeclaration -> decl.toClassName().parameterizedBy(arguments.map { it.toTypeName(typeParamResolver) })
+    is KSTypeParameter -> typeParamResolver[decl.name.getShortName()]
+    is KSTypeAlias -> {
+      val extraResolver = if (decl.typeParameters.isEmpty()) {
+        typeParamResolver
+      } else {
+        decl.typeParameters.toTypeParameterResolver(typeParamResolver)
+      }
+      val args = arguments.map { it.toTypeName(typeParamResolver) }
+      val firstPass = decl.type.resolve().toTypeName(extraResolver).copy(nullable = isMarkedNullable)
+      if (args.isNotEmpty()) {
+        firstPass.rawType().parameterizedBy(args)
+      } else {
+        firstPass
+      }
+    }
+    else -> error("Unsupported type: $declaration")
+  }
+
+  return type.copy(nullable = isMarkedNullable)
+}
+
+/**
+ * Returns a [TypeVariableName] representation of this [KSTypeParameter].
+ *
+ * @see toTypeParameterResolver
+ * @param typeParamResolver an optional resolver for enclosing declarations' type parameters. Parent
+ *                          declarations can be anything with generics that child nodes declare as
+ *                          defined by [KSType.arguments].
+ */
+@KotlinPoetKspPreview
+public fun KSTypeParameter.toTypeVariableName(
+  typeParamResolver: TypeParameterResolver = TypeParameterResolver.EMPTY,
+): TypeVariableName {
+  val typeVarName = name.getShortName()
+  val typeVarBounds = bounds.map { it.toTypeName(typeParamResolver) }.toList()
+  val typeVarVariance = when (variance) {
+    COVARIANT -> KModifier.OUT
+    CONTRAVARIANT -> KModifier.IN
+    else -> null
+  }
+  return TypeVariableName(typeVarName, bounds = typeVarBounds, variance = typeVarVariance)
+}
+
+/**
+ * Returns a [TypeName] representation of this [KSTypeArgument].
+ *
+ * @see toTypeParameterResolver
+ * @param typeParamResolver an optional resolver for enclosing declarations' type parameters. Parent
+ *                          declarations can be anything with generics that child nodes declare as
+ *                          defined by [KSType.arguments].
+ */
+@KotlinPoetKspPreview
+public fun KSTypeArgument.toTypeName(typeParamResolver: TypeParameterResolver): TypeName {
+  val typeName = type?.resolve()?.toTypeName(typeParamResolver) ?: return STAR
+  return when (variance) {
+    COVARIANT -> WildcardTypeName.producerOf(typeName)
+    CONTRAVARIANT -> WildcardTypeName.consumerOf(typeName)
+    Variance.STAR -> STAR
+    INVARIANT -> typeName
+  }
+}
+
+/**
+ * Returns a [TypeName] representation of this [KSTypeReference].
+ *
+ * @see toTypeParameterResolver
+ * @param typeParamResolver an optional resolver for enclosing declarations' type parameters. Parent
+ *                          declarations can be anything with generics that child nodes declare as
+ *                          defined by [KSType.arguments].
+ */
+@KotlinPoetKspPreview
+public fun KSTypeReference.toTypeName(
+  typeParamResolver: TypeParameterResolver = TypeParameterResolver.EMPTY
+): TypeName {
+  val type = resolve()
+  return type.toTypeName(typeParamResolver)
+}

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/originatingKSFiles.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/originatingKSFiles.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.ksp
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.symbol.KSFile
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.Taggable
+import com.squareup.kotlinpoet.TypeAliasSpec
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.tag
+import java.io.OutputStreamWriter
+import java.nio.charset.StandardCharsets
+
+/**
+ * A simple holder class for containing originating [KSFiles][KSFile], which are used by KSP to
+ * inform its incremental processing.
+ *
+ * See [the docs](https://github.com/google/ksp/blob/main/docs/incremental.md) for more information.
+ */
+@KotlinPoetKspPreview
+public interface OriginatingKSFiles {
+  public val files: List<KSFile>
+}
+
+/** Returns this spec's originating [KSFiles][KSFile] for use with incremental processing. */
+@KotlinPoetKspPreview
+public fun TypeSpec.originatingKSFiles(): List<KSFile> = getKSFilesTag()
+
+/** Returns this spec's originating [KSFiles][KSFile] for use with incremental processing. */
+@KotlinPoetKspPreview
+public fun FunSpec.originatingKSFiles(): List<KSFile> = getKSFilesTag()
+
+/** Returns this spec's originating [KSFiles][KSFile] for use with incremental processing. */
+@KotlinPoetKspPreview
+public fun PropertySpec.originatingKSFiles(): List<KSFile> = getKSFilesTag()
+
+/** Returns this spec's originating [KSFiles][KSFile] for use with incremental processing. */
+@KotlinPoetKspPreview
+public fun TypeAliasSpec.originatingKSFiles(): List<KSFile> = getKSFilesTag()
+
+/**
+ * Returns the list of all files added to the contained
+ * [TypeSpecs][TypeSpec], [PropertySpecs][PropertySpec], [FunSpecs][FunSpec], or
+ * [TypeAliasSpecs][TypeAliasSpec] contained in this spec.
+ */
+@KotlinPoetKspPreview
+public fun FileSpec.originatingKSFiles(): List<KSFile> {
+  return members
+    .flatMap {
+      when (it) {
+        is FunSpec -> it.originatingKSFiles()
+        is PropertySpec -> it.originatingKSFiles()
+        is TypeSpec -> it.originatingKSFiles()
+        is TypeAliasSpec -> it.originatingKSFiles()
+        else -> emptyList()
+      }
+    }
+    .distinct()
+}
+
+/** Adds the given [ksFile] to this builder's tags for use with [originatingKSFiles]. */
+@KotlinPoetKspPreview
+public fun TypeAliasSpec.Builder.addOriginatingKSFile(ksFile: KSFile): TypeAliasSpec.Builder = apply {
+  getOrCreateKSFilesTag().add(ksFile)
+}
+
+/** Adds the given [ksFile] to this builder's tags for use with [originatingKSFiles]. */
+@KotlinPoetKspPreview
+public fun PropertySpec.Builder.addOriginatingKSFile(ksFile: KSFile): PropertySpec.Builder = apply {
+  getOrCreateKSFilesTag().add(ksFile)
+}
+
+/** Adds the given [ksFile] to this builder's tags for use with [originatingKSFiles]. */
+@KotlinPoetKspPreview
+public fun FunSpec.Builder.addOriginatingKSFile(ksFile: KSFile): FunSpec.Builder = apply {
+  getOrCreateKSFilesTag().add(ksFile)
+}
+
+/** Adds the given [ksFile] to this builder's tags for use with [originatingKSFiles]. */
+@KotlinPoetKspPreview
+public fun TypeSpec.Builder.addOriginatingKSFile(ksFile: KSFile): TypeSpec.Builder = apply {
+  getOrCreateKSFilesTag().add(ksFile)
+}
+
+/**
+ * Writes this [FileSpec] to a given [codeGenerator] with the given [originatingKSFiles].
+ *
+ * Note that if none are specified, the [originatingKSFiles] argument defaults to using
+ * [FileSpec.originatingKSFiles], which will automatically resolve any files added to the
+ * contained declarations.
+ *
+ * See [the docs](https://github.com/google/ksp/blob/main/docs/incremental.md) for more information.
+ *
+ * @see FileSpec.originatingKSFiles
+ * @param codeGenerator the [CodeGenerator] to write to
+ * @param aggregating flag indicating if this is an aggregating
+ */
+@KotlinPoetKspPreview
+public fun FileSpec.writeTo(
+  codeGenerator: CodeGenerator,
+  aggregating: Boolean,
+  originatingKSFiles: Iterable<KSFile> = originatingKSFiles()
+) {
+  val dependencies = kspDependencies(aggregating, originatingKSFiles)
+  val file = codeGenerator.createNewFile(dependencies, packageName, name)
+  // Don't use writeTo(file) because that tries to handle directories under the hood
+  OutputStreamWriter(file, StandardCharsets.UTF_8)
+    .use(::writeTo)
+}
+
+/**
+ * Returns a KSP [Dependencies] component of this [FileSpec] with the given [originatingKSFiles],
+ * intended to be used in tandem with [writeTo].
+ *
+ * Note that if no [originatingKSFiles] are specified, the [originatingKSFiles] argument defaults
+ * to using [FileSpec.originatingKSFiles], which will automatically resolve any files added to the
+ * contained declarations.
+ *
+ * See [the docs](https://github.com/google/ksp/blob/main/docs/incremental.md) for more information.
+ *
+ * @see FileSpec.originatingKSFiles
+ * @see FileSpec.writeTo
+ * @param aggregating flag indicating if this is an aggregating
+ */
+@KotlinPoetKspPreview
+public fun FileSpec.kspDependencies(
+  aggregating: Boolean,
+  originatingKSFiles: Iterable<KSFile> = originatingKSFiles()
+): Dependencies = Dependencies(aggregating, *originatingKSFiles.toList().toTypedArray())
+
+/**
+ * A mutable [OriginatingKSFiles] instance for use with KotlinPoet Builders via [Taggable.Builder].
+ */
+@OptIn(KotlinPoetKspPreview::class)
+private interface MutableOriginatingKSFiles : OriginatingKSFiles {
+  override val files: MutableList<KSFile>
+}
+
+private data class MutableOriginatingKSFilesImpl(override val files: MutableList<KSFile> = mutableListOf()) : MutableOriginatingKSFiles
+
+@OptIn(KotlinPoetKspPreview::class)
+private fun Taggable.getKSFilesTag(): List<KSFile> {
+  return tag<OriginatingKSFiles>()?.files.orEmpty()
+}
+
+@OptIn(KotlinPoetKspPreview::class)
+private fun Taggable.Builder<*>.getOrCreateKSFilesTag(): MutableList<KSFile> {
+  val holder = tags.getOrPut(
+    OriginatingKSFiles::class, ::MutableOriginatingKSFilesImpl
+  ) as MutableOriginatingKSFiles
+  return holder.files
+}

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/originatingKSFiles.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/originatingKSFiles.kt
@@ -109,8 +109,8 @@ public fun TypeSpec.Builder.addOriginatingKSFile(ksFile: KSFile): TypeSpec.Build
  * See [the docs](https://github.com/google/ksp/blob/main/docs/incremental.md) for more information.
  *
  * @see FileSpec.originatingKSFiles
- * @param codeGenerator the [CodeGenerator] to write to
- * @param aggregating flag indicating if this is an aggregating
+ * @param codeGenerator the [CodeGenerator] to write to.
+ * @param aggregating flag indicating if this is an aggregating symbol processor.
  */
 @KotlinPoetKspPreview
 public fun FileSpec.writeTo(
@@ -137,7 +137,7 @@ public fun FileSpec.writeTo(
  *
  * @see FileSpec.originatingKSFiles
  * @see FileSpec.writeTo
- * @param aggregating flag indicating if this is an aggregating
+ * @param aggregating flag indicating if this is an aggregating symbol processor.
  */
 @KotlinPoetKspPreview
 public fun FileSpec.kspDependencies(

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/utils.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/utils.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.kotlinpoet.ksp
 
 import com.squareup.kotlinpoet.ClassName

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/utils.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/utils.kt
@@ -1,0 +1,30 @@
+package com.squareup.kotlinpoet.ksp
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.ParameterizedTypeName
+import com.squareup.kotlinpoet.TypeName
+
+internal fun TypeName.rawType(): ClassName {
+  return findRawType() ?: throw IllegalArgumentException("Cannot get raw type from $this")
+}
+
+internal fun TypeName.findRawType(): ClassName? {
+  return when (this) {
+    is ClassName -> this
+    is ParameterizedTypeName -> rawType
+    is LambdaTypeName -> {
+      var count = parameters.size
+      if (receiver != null) {
+        count++
+      }
+      val functionSimpleName = if (count >= 23) {
+        "FunctionN"
+      } else {
+        "Function$count"
+      }
+      ClassName("kotlin.jvm.functions", functionSimpleName)
+    }
+    else -> null
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,7 +27,7 @@ include(
     ":interop:kotlinx-metadata:core",
     ":interop:kotlinx-metadata:specs",
     ":interop:kotlinx-metadata:specs-tests",
-    ":interop:ksp"
+    ":interop:ksp",
 )
 
 enableFeaturePreview("VERSION_CATALOGS")


### PR DESCRIPTION
This starts a basic KSP interop project, with extensions covering common use cases like...
- Basic KS type -> KotlinPoet `TypeName` type conversion
- Support for originating KSFiles to support KSP's incremental processing
- Support for writing `FileSpec` to `CodeGenerator`s
- Annotated with a new `@KotlinPoetKspPreview` annotation while we fine-tune the API.

This is largely upstreamed and cleaned up from the Moshi KSP implementation currently being upstreamed over [here](https://github.com/square/moshi/pull/1393).

What this does _not_ attempt to do: the full "give me a class and I'll give you a TypeSpec of the API" like kotlinx-metadata interop does. I'm open to considering it if we think it's worthwhile, but unlike with metadata we don't need to run everything from a class's `@Metadata` annotation for this to work, so I'm currently erring on the side of keeping the interop lightweight. There could be a good use-case for some existing helpers like `overriding`, `AnnotationSpec.get()`, `ParameterSpec.get()`, etc, but we can see if the community asks for that later.

TODO:
- [ ] Tests. Moshi used integration tests as cover for this. We'll need to figure out a good way to test these here. Open to saving this for a followup PR.