### PR TITLE
Implement basic JavaPoet interop module

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.17.0" }
 [libraries]
 autoCommon = { module = "com.google.auto:auto-common", version = "1.1.2" }
 guava = { module = "com.google.guava:guava", version = "30.1.1-jre" }
+javapoet = "com.squareup:javapoet:1.13.0"
 
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }

--- a/interop/javapoet/build.gradle.kts
+++ b/interop/javapoet/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Square, Inc.
+ * Copyright (C) 2021 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-pluginManagement {
-  repositories {
-    mavenCentral()
-    gradlePluginPortal()
+
+tasks.jar {
+  manifest {
+    attributes("Automatic-Module-Name" to "com.squareup.kotlinpoet.javapoet")
   }
 }
 
-include(
-    ":kotlinpoet",
-    ":interop:javapoet",
-    ":interop:kotlinx-metadata:classinspectors:elements",
-    ":interop:kotlinx-metadata:classinspectors:reflect",
-    ":interop:kotlinx-metadata:core",
-    ":interop:kotlinx-metadata:specs",
-    ":interop:kotlinx-metadata:specs-tests"
-)
-
-enableFeaturePreview("VERSION_CATALOGS")
+dependencies {
+  api(project(":kotlinpoet"))
+  api(libs.javapoet)
+  testImplementation(libs.kotlin.junit)
+  testImplementation(libs.truth)
+}

--- a/interop/javapoet/gradle.properties
+++ b/interop/javapoet/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=kotlinpoet-ksp
+POM_NAME=KotlinPoet (KSP Interop)
+POM_DESCRIPTION=Extensions for interop with KSP (Kotlin Symbol Processing).
+POM_PACKAGING=jar

--- a/interop/javapoet/gradle.properties
+++ b/interop/javapoet/gradle.properties
@@ -1,4 +1,4 @@
-POM_ARTIFACT_ID=kotlinpoet-ksp
-POM_NAME=KotlinPoet (KSP Interop)
-POM_DESCRIPTION=Extensions for interop with KSP (Kotlin Symbol Processing).
+POM_ARTIFACT_ID=kotlinpoet-javapoet
+POM_NAME=KotlinPoet (JavaPoet Interop)
+POM_DESCRIPTION=Extensions for interop with JavaPoet.
 POM_PACKAGING=jar

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/KotlinPoetJavaPoetPreview.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/KotlinPoetJavaPoetPreview.kt
@@ -15,11 +15,16 @@
  */
 package com.squareup.kotlinpoet.javapoet
 
-/** Various JavaPoet and KotlinPoet representations of some common types. */
-@OptIn(KotlinPoetJavaPoetPreview::class)
-internal object PoetInterop {
-  internal val CN_JAVA_STRING = JClassName.get("java.lang", "String")
-  internal val CN_JAVA_LIST = JClassName.get("java.util", "List")
-  internal val CN_JAVA_SET = JClassName.get("java.util", "Set")
-  internal val CN_JAVA_MAP = JClassName.get("java.util", "Map")
-}
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY
+import kotlin.annotation.AnnotationTarget.TYPEALIAS
+
+/**
+ * Indicates that a given API is part of the experimental KotlinPoet JavaPoet support and is
+ * subject to API changes.
+ */
+@RequiresOptIn
+@Retention(AnnotationRetention.BINARY)
+@Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
+public annotation class KotlinPoetJavaPoetPreview

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/PoetInterop.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/PoetInterop.kt
@@ -22,4 +22,5 @@ internal object PoetInterop {
   internal val CN_JAVA_LIST = JClassName.get("java.util", "List")
   internal val CN_JAVA_SET = JClassName.get("java.util", "Set")
   internal val CN_JAVA_MAP = JClassName.get("java.util", "Map")
+  internal val CN_JAVA_ENUM = JClassName.get("java.lang", "Enum")
 }

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/PoetInterop.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/PoetInterop.kt
@@ -17,10 +17,6 @@ package com.squareup.kotlinpoet.javapoet
 
 /** Various JavaPoet and KotlinPoet representations of some common types. */
 internal object PoetInterop {
-  internal val CN_KOTLIN_STRING = KClassName("kotlin", "String")
-  internal val CN_KOTLIN_LIST = KClassName("kotlin", "List")
-  internal val CN_KOTLIN_SET = KClassName("kotlin", "Set")
-  internal val CN_KOTLIN_MAP = KClassName("kotlin", "Map")
   internal val CN_JAVA_STRING = JClassName.get("java.lang", "String")
   internal val CN_JAVA_LIST = JClassName.get("java.util", "List")
   internal val CN_JAVA_SET = JClassName.get("java.util", "Set")

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/PoetInterop.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/PoetInterop.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.javapoet
+
+/** Various JavaPoet and KotlinPoet representations of some common types. */
+internal object PoetInterop {
+  internal val CN_KOTLIN_STRING = KClassName("kotlin", "String")
+  internal val CN_KOTLIN_LIST = KClassName("kotlin", "List")
+  internal val CN_KOTLIN_SET = KClassName("kotlin", "Set")
+  internal val CN_KOTLIN_MAP = KClassName("kotlin", "Map")
+  internal val CN_JAVA_STRING = JClassName.get("java.lang", "String")
+  internal val CN_JAVA_LIST = JClassName.get("java.util", "List")
+  internal val CN_JAVA_SET = JClassName.get("java.util", "Set")
+  internal val CN_JAVA_MAP = JClassName.get("java.util", "Map")
+}

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/j2kInterop.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/j2kInterop.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.javapoet
+
+import com.squareup.javapoet.ArrayTypeName
+import com.squareup.kotlinpoet.ANY
+import com.squareup.kotlinpoet.ARRAY
+import com.squareup.kotlinpoet.BOOLEAN
+import com.squareup.kotlinpoet.BYTE
+import com.squareup.kotlinpoet.CHAR
+import com.squareup.kotlinpoet.DOUBLE
+import com.squareup.kotlinpoet.FLOAT
+import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.LIST
+import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.MAP
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.SET
+import com.squareup.kotlinpoet.SHORT
+import com.squareup.kotlinpoet.STRING
+
+public fun JClassName.toKClassName(): KClassName {
+  return if (simpleNames().size == 1) {
+    KClassName(packageName(), simpleName())
+  } else {
+    KClassName(packageName(), simpleNames().first(), *simpleNames().drop(1).toTypedArray())
+  }
+}
+
+public fun JParameterizedTypeName.toKParameterizedTypeName(): KParameterizedTypeName {
+  return rawType.toKClassName().parameterizedBy(*typeArguments.map { it.toKTypeName() }.toTypedArray())
+}
+
+public fun JTypeVariableName.toKTypeVariableName(): KTypeVariableName {
+  return if (bounds.isEmpty()) {
+    KTypeVariableName(name)
+  } else {
+    KTypeVariableName(name, *bounds.map { it.toKTypeName() }.toTypedArray())
+  }
+}
+
+public fun JTypeName.toKTypeName(): KTypeName {
+  return when (this) {
+    is JClassName -> when (this) {
+      JTypeName.BOOLEAN.box() -> BOOLEAN
+      JTypeName.BYTE.box() -> BYTE
+      JTypeName.CHAR.box() -> CHAR
+      JTypeName.SHORT.box() -> SHORT
+      JTypeName.INT.box() -> INT
+      JTypeName.LONG.box() -> LONG
+      JTypeName.FLOAT.box() -> FLOAT
+      JTypeName.DOUBLE.box() -> DOUBLE
+      JTypeName.OBJECT -> ANY
+      PoetInterop.CN_JAVA_STRING -> STRING
+      PoetInterop.CN_JAVA_LIST -> LIST
+      PoetInterop.CN_JAVA_SET -> SET
+      PoetInterop.CN_JAVA_MAP -> MAP
+      else -> toKClassName()
+    }
+    is JParameterizedTypeName -> toKParameterizedTypeName()
+    is JTypeVariableName -> toKTypeVariableName()
+    is JWildcardTypeName -> TODO()
+    is ArrayTypeName -> ARRAY.parameterizedBy(componentType.toKTypeName())
+    else -> when (unboxIfBoxedPrimitive()) {
+      JTypeName.BOOLEAN -> BOOLEAN
+      JTypeName.BYTE -> BYTE
+      JTypeName.CHAR -> CHAR
+      JTypeName.SHORT -> SHORT
+      JTypeName.INT -> INT
+      JTypeName.LONG -> LONG
+      JTypeName.FLOAT -> FLOAT
+      JTypeName.DOUBLE -> DOUBLE
+      else -> error("Unrecognized type $this")
+    }
+  }
+}
+
+internal fun JTypeName.unboxIfBoxedPrimitive(): JTypeName {
+  return if (isBoxedPrimitive) {
+    unbox()
+  } else this
+}
+
+internal fun JTypeName.boxIfPrimitive(extraCondition: Boolean = true): JTypeName {
+  return if (extraCondition && isPrimitive && !isBoxedPrimitive) {
+    box()
+  } else this
+}

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/j2kInterop.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/j2kInterop.kt
@@ -34,6 +34,7 @@ import com.squareup.kotlinpoet.SHORT
 import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.STRING
 
+@KotlinPoetJavaPoetPreview
 public fun JClassName.toKClassName(): KClassName {
   return if (simpleNames().size == 1) {
     KClassName(packageName(), simpleName())
@@ -42,10 +43,12 @@ public fun JClassName.toKClassName(): KClassName {
   }
 }
 
+@KotlinPoetJavaPoetPreview
 public fun JParameterizedTypeName.toKParameterizedTypeName(): KParameterizedTypeName {
   return rawType.toKClassName().parameterizedBy(*typeArguments.map { it.toKTypeName() }.toTypedArray())
 }
 
+@KotlinPoetJavaPoetPreview
 public fun JTypeVariableName.toKTypeVariableName(): KTypeVariableName {
   return if (bounds.isEmpty()) {
     KTypeVariableName(name)
@@ -54,6 +57,7 @@ public fun JTypeVariableName.toKTypeVariableName(): KTypeVariableName {
   }
 }
 
+@KotlinPoetJavaPoetPreview
 public fun JWildcardTypeName.toKWildcardTypeName(): KWildcardTypeName {
   return if (lowerBounds.size == 1) {
     KWildcardTypeName.consumerOf(lowerBounds.first().toKTypeName())
@@ -63,6 +67,7 @@ public fun JWildcardTypeName.toKWildcardTypeName(): KWildcardTypeName {
   }
 }
 
+@KotlinPoetJavaPoetPreview
 public fun JTypeName.toKTypeName(): KTypeName {
   return when (this) {
     is JClassName -> when (this) {
@@ -99,12 +104,14 @@ public fun JTypeName.toKTypeName(): KTypeName {
   }
 }
 
+@OptIn(KotlinPoetJavaPoetPreview::class)
 internal fun JTypeName.unboxIfBoxedPrimitive(): JTypeName {
   return if (isBoxedPrimitive) {
     unbox()
   } else this
 }
 
+@OptIn(KotlinPoetJavaPoetPreview::class)
 internal fun JTypeName.boxIfPrimitive(extraCondition: Boolean = true): JTypeName {
   return if (extraCondition && isPrimitive && !isBoxedPrimitive) {
     box()

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/j2kInterop.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/j2kInterop.kt
@@ -16,6 +16,7 @@
 package com.squareup.kotlinpoet.javapoet
 
 import com.squareup.javapoet.ArrayTypeName
+import com.squareup.javapoet.TypeName
 import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.ARRAY
 import com.squareup.kotlinpoet.BOOLEAN
@@ -30,6 +31,7 @@ import com.squareup.kotlinpoet.MAP
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.SET
 import com.squareup.kotlinpoet.SHORT
+import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.STRING
 
 public fun JClassName.toKClassName(): KClassName {
@@ -49,6 +51,15 @@ public fun JTypeVariableName.toKTypeVariableName(): KTypeVariableName {
     KTypeVariableName(name)
   } else {
     KTypeVariableName(name, *bounds.map { it.toKTypeName() }.toTypedArray())
+  }
+}
+
+public fun JWildcardTypeName.toKWildcardTypeName(): KWildcardTypeName {
+  return if (lowerBounds.size == 1) {
+    KWildcardTypeName.consumerOf(lowerBounds.first().toKTypeName())
+  } else when (val upperBound = upperBounds[0]) {
+    TypeName.OBJECT -> STAR
+    else -> KWildcardTypeName.producerOf(upperBound.toKTypeName())
   }
 }
 
@@ -72,7 +83,7 @@ public fun JTypeName.toKTypeName(): KTypeName {
     }
     is JParameterizedTypeName -> toKParameterizedTypeName()
     is JTypeVariableName -> toKTypeVariableName()
-    is JWildcardTypeName -> TODO()
+    is JWildcardTypeName -> toKWildcardTypeName()
     is ArrayTypeName -> ARRAY.parameterizedBy(componentType.toKTypeName())
     else -> when (unboxIfBoxedPrimitive()) {
       JTypeName.BOOLEAN -> BOOLEAN

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/k2jInterop.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/k2jInterop.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.javapoet
+
+import com.squareup.javapoet.ArrayTypeName
+import com.squareup.kotlinpoet.ANY
+import com.squareup.kotlinpoet.ARRAY
+import com.squareup.kotlinpoet.BOOLEAN
+import com.squareup.kotlinpoet.BYTE
+import com.squareup.kotlinpoet.CHAR
+import com.squareup.kotlinpoet.DOUBLE
+import com.squareup.kotlinpoet.Dynamic
+import com.squareup.kotlinpoet.FLOAT
+import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.LIST
+import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.MAP
+import com.squareup.kotlinpoet.SET
+import com.squareup.kotlinpoet.SHORT
+import com.squareup.kotlinpoet.STRING
+
+public fun KClassName.toJClassName(shouldBox: Boolean = false): JTypeName {
+  return when (copy(nullable = false)) {
+    BOOLEAN -> JTypeName.BOOLEAN.boxIfPrimitive(shouldBox || isNullable)
+    BYTE -> JTypeName.BYTE.boxIfPrimitive(shouldBox || isNullable)
+    CHAR -> JTypeName.CHAR.boxIfPrimitive(shouldBox || isNullable)
+    SHORT -> JTypeName.SHORT.boxIfPrimitive(shouldBox || isNullable)
+    INT -> JTypeName.INT.boxIfPrimitive(shouldBox || isNullable)
+    LONG -> JTypeName.LONG.boxIfPrimitive(shouldBox || isNullable)
+    FLOAT -> JTypeName.FLOAT.boxIfPrimitive(shouldBox || isNullable)
+    DOUBLE -> JTypeName.DOUBLE.boxIfPrimitive(shouldBox || isNullable)
+    ANY -> JTypeName.OBJECT
+    STRING -> PoetInterop.CN_JAVA_STRING
+    LIST -> PoetInterop.CN_JAVA_LIST
+    SET -> PoetInterop.CN_JAVA_SET
+    MAP -> PoetInterop.CN_JAVA_MAP
+    else -> {
+      if (simpleNames.size == 1) {
+        JClassName.get(packageName, simpleName)
+      } else {
+        JClassName.get(packageName, simpleNames.first(), *simpleNames.drop(1).toTypedArray())
+      }
+    }
+  }
+}
+
+public fun KParameterizedTypeName.toJParameterizedOrArrayTypeName(): JTypeName {
+  return when (rawType) {
+    ARRAY -> {
+      val componentType = typeArguments.firstOrNull()?.toJTypeName()
+        ?: throw IllegalStateException("Array with no type! $this")
+      ArrayTypeName.of(componentType)
+    }
+    else -> {
+      JParameterizedTypeName.get(
+        rawType.toJClassName() as JClassName,
+        *typeArguments.map { it.toJTypeName(shouldBox = true) }.toTypedArray()
+      )
+    }
+  }
+}
+
+public fun KParameterizedTypeName.toJParameterizedTypeName(): JParameterizedTypeName {
+  check(rawType != ARRAY) {
+    "Array type! JavaPoet arrays are a custom TypeName. Use this function only for things you know are not arrays"
+  }
+  return toJParameterizedOrArrayTypeName() as JParameterizedTypeName
+}
+
+public fun KTypeVariableName.toJTypeVariableName(): JTypeVariableName {
+  return JTypeVariableName.get(name, *bounds.map { it.toJTypeName(shouldBox = true) }.toTypedArray())
+}
+
+public fun KTypeName.toJTypeName(shouldBox: Boolean = false): JTypeName {
+  return when (this) {
+    is KClassName -> toJClassName(shouldBox)
+    Dynamic -> throw IllegalStateException("Not applicable in Java!")
+    // TODO should we return a ParameterizedTypeName of the KFunction?
+    is LambdaTypeName -> throw IllegalStateException("Not applicable in Java!")
+    is KParameterizedTypeName -> toJParameterizedOrArrayTypeName()
+    is KTypeVariableName -> toJTypeVariableName()
+    is KWildcardTypeName -> TODO()
+  }
+}

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/k2jInterop.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/k2jInterop.kt
@@ -35,6 +35,7 @@ import com.squareup.kotlinpoet.SHORT
 import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.STRING
 
+@KotlinPoetJavaPoetPreview
 public fun KClassName.toJClassName(boxIfPrimitive: Boolean = false): JTypeName {
   return when (copy(nullable = false)) {
     BOOLEAN -> JTypeName.BOOLEAN.boxIfPrimitive(boxIfPrimitive || isNullable)
@@ -60,6 +61,7 @@ public fun KClassName.toJClassName(boxIfPrimitive: Boolean = false): JTypeName {
   }
 }
 
+@KotlinPoetJavaPoetPreview
 public fun KParameterizedTypeName.toJParameterizedOrArrayTypeName(): JTypeName {
   return when (rawType) {
     ARRAY -> {
@@ -76,6 +78,7 @@ public fun KParameterizedTypeName.toJParameterizedOrArrayTypeName(): JTypeName {
   }
 }
 
+@KotlinPoetJavaPoetPreview
 public fun KParameterizedTypeName.toJParameterizedTypeName(): JParameterizedTypeName {
   check(rawType != ARRAY) {
     "Array type! JavaPoet arrays are a custom TypeName. Use this function only for things you know are not arrays"
@@ -83,10 +86,12 @@ public fun KParameterizedTypeName.toJParameterizedTypeName(): JParameterizedType
   return toJParameterizedOrArrayTypeName() as JParameterizedTypeName
 }
 
+@KotlinPoetJavaPoetPreview
 public fun KTypeVariableName.toJTypeVariableName(): JTypeVariableName {
   return JTypeVariableName.get(name, *bounds.map { it.toJTypeName(boxIfPrimitive = true) }.toTypedArray())
 }
 
+@KotlinPoetJavaPoetPreview
 public fun KWildcardTypeName.toJWildcardTypeName(): JWildcardTypeName {
   return if (this == STAR) {
     JWildcardTypeName.subtypeOf(TypeName.OBJECT)
@@ -97,6 +102,7 @@ public fun KWildcardTypeName.toJWildcardTypeName(): JWildcardTypeName {
   }
 }
 
+@KotlinPoetJavaPoetPreview
 public fun KTypeName.toJTypeName(boxIfPrimitive: Boolean = false): JTypeName {
   return when (this) {
     is KClassName -> toJClassName(boxIfPrimitive)

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/k2jInterop.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/k2jInterop.kt
@@ -33,16 +33,16 @@ import com.squareup.kotlinpoet.SET
 import com.squareup.kotlinpoet.SHORT
 import com.squareup.kotlinpoet.STRING
 
-public fun KClassName.toJClassName(shouldBox: Boolean = false): JTypeName {
+public fun KClassName.toJClassName(boxIfPrimitive: Boolean = false): JTypeName {
   return when (copy(nullable = false)) {
-    BOOLEAN -> JTypeName.BOOLEAN.boxIfPrimitive(shouldBox || isNullable)
-    BYTE -> JTypeName.BYTE.boxIfPrimitive(shouldBox || isNullable)
-    CHAR -> JTypeName.CHAR.boxIfPrimitive(shouldBox || isNullable)
-    SHORT -> JTypeName.SHORT.boxIfPrimitive(shouldBox || isNullable)
-    INT -> JTypeName.INT.boxIfPrimitive(shouldBox || isNullable)
-    LONG -> JTypeName.LONG.boxIfPrimitive(shouldBox || isNullable)
-    FLOAT -> JTypeName.FLOAT.boxIfPrimitive(shouldBox || isNullable)
-    DOUBLE -> JTypeName.DOUBLE.boxIfPrimitive(shouldBox || isNullable)
+    BOOLEAN -> JTypeName.BOOLEAN.boxIfPrimitive(boxIfPrimitive || isNullable)
+    BYTE -> JTypeName.BYTE.boxIfPrimitive(boxIfPrimitive || isNullable)
+    CHAR -> JTypeName.CHAR.boxIfPrimitive(boxIfPrimitive || isNullable)
+    SHORT -> JTypeName.SHORT.boxIfPrimitive(boxIfPrimitive || isNullable)
+    INT -> JTypeName.INT.boxIfPrimitive(boxIfPrimitive || isNullable)
+    LONG -> JTypeName.LONG.boxIfPrimitive(boxIfPrimitive || isNullable)
+    FLOAT -> JTypeName.FLOAT.boxIfPrimitive(boxIfPrimitive || isNullable)
+    DOUBLE -> JTypeName.DOUBLE.boxIfPrimitive(boxIfPrimitive || isNullable)
     ANY -> JTypeName.OBJECT
     STRING -> PoetInterop.CN_JAVA_STRING
     LIST -> PoetInterop.CN_JAVA_LIST
@@ -68,7 +68,7 @@ public fun KParameterizedTypeName.toJParameterizedOrArrayTypeName(): JTypeName {
     else -> {
       JParameterizedTypeName.get(
         rawType.toJClassName() as JClassName,
-        *typeArguments.map { it.toJTypeName(shouldBox = true) }.toTypedArray()
+        *typeArguments.map { it.toJTypeName(boxIfPrimitive = true) }.toTypedArray()
       )
     }
   }
@@ -82,12 +82,12 @@ public fun KParameterizedTypeName.toJParameterizedTypeName(): JParameterizedType
 }
 
 public fun KTypeVariableName.toJTypeVariableName(): JTypeVariableName {
-  return JTypeVariableName.get(name, *bounds.map { it.toJTypeName(shouldBox = true) }.toTypedArray())
+  return JTypeVariableName.get(name, *bounds.map { it.toJTypeName(boxIfPrimitive = true) }.toTypedArray())
 }
 
-public fun KTypeName.toJTypeName(shouldBox: Boolean = false): JTypeName {
+public fun KTypeName.toJTypeName(boxIfPrimitive: Boolean = false): JTypeName {
   return when (this) {
-    is KClassName -> toJClassName(shouldBox)
+    is KClassName -> toJClassName(boxIfPrimitive)
     Dynamic -> throw IllegalStateException("Not applicable in Java!")
     // TODO should we return a ParameterizedTypeName of the KFunction?
     is LambdaTypeName -> throw IllegalStateException("Not applicable in Java!")

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/k2jInterop.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/k2jInterop.kt
@@ -16,6 +16,7 @@
 package com.squareup.kotlinpoet.javapoet
 
 import com.squareup.javapoet.ArrayTypeName
+import com.squareup.javapoet.TypeName
 import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.ARRAY
 import com.squareup.kotlinpoet.BOOLEAN
@@ -31,6 +32,7 @@ import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MAP
 import com.squareup.kotlinpoet.SET
 import com.squareup.kotlinpoet.SHORT
+import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.STRING
 
 public fun KClassName.toJClassName(boxIfPrimitive: Boolean = false): JTypeName {
@@ -85,6 +87,16 @@ public fun KTypeVariableName.toJTypeVariableName(): JTypeVariableName {
   return JTypeVariableName.get(name, *bounds.map { it.toJTypeName(boxIfPrimitive = true) }.toTypedArray())
 }
 
+public fun KWildcardTypeName.toJWildcardTypeName(): JWildcardTypeName {
+  return if (this == STAR) {
+    JWildcardTypeName.subtypeOf(TypeName.OBJECT)
+  } else if (inTypes.size == 1) {
+    JWildcardTypeName.supertypeOf(inTypes[0].toJTypeName())
+  } else {
+    JWildcardTypeName.subtypeOf(outTypes[0].toJTypeName())
+  }
+}
+
 public fun KTypeName.toJTypeName(boxIfPrimitive: Boolean = false): JTypeName {
   return when (this) {
     is KClassName -> toJClassName(boxIfPrimitive)
@@ -93,6 +105,6 @@ public fun KTypeName.toJTypeName(boxIfPrimitive: Boolean = false): JTypeName {
     is LambdaTypeName -> throw IllegalStateException("Not applicable in Java!")
     is KParameterizedTypeName -> toJParameterizedOrArrayTypeName()
     is KTypeVariableName -> toJTypeVariableName()
-    is KWildcardTypeName -> TODO()
+    is KWildcardTypeName -> toJWildcardTypeName()
   }
 }

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/k2jInterop.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/k2jInterop.kt
@@ -20,37 +20,66 @@ import com.squareup.javapoet.TypeName
 import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.ARRAY
 import com.squareup.kotlinpoet.BOOLEAN
+import com.squareup.kotlinpoet.BOOLEAN_ARRAY
 import com.squareup.kotlinpoet.BYTE
+import com.squareup.kotlinpoet.BYTE_ARRAY
 import com.squareup.kotlinpoet.CHAR
+import com.squareup.kotlinpoet.CHAR_ARRAY
 import com.squareup.kotlinpoet.DOUBLE
+import com.squareup.kotlinpoet.DOUBLE_ARRAY
 import com.squareup.kotlinpoet.Dynamic
+import com.squareup.kotlinpoet.ENUM
 import com.squareup.kotlinpoet.FLOAT
+import com.squareup.kotlinpoet.FLOAT_ARRAY
 import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.INT_ARRAY
 import com.squareup.kotlinpoet.LIST
 import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.LONG_ARRAY
 import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MAP
+import com.squareup.kotlinpoet.MUTABLE_LIST
+import com.squareup.kotlinpoet.MUTABLE_MAP
+import com.squareup.kotlinpoet.MUTABLE_SET
 import com.squareup.kotlinpoet.SET
 import com.squareup.kotlinpoet.SHORT
+import com.squareup.kotlinpoet.SHORT_ARRAY
 import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.STRING
+import com.squareup.kotlinpoet.U_BYTE
+import com.squareup.kotlinpoet.U_BYTE_ARRAY
+import com.squareup.kotlinpoet.U_INT
+import com.squareup.kotlinpoet.U_INT_ARRAY
+import com.squareup.kotlinpoet.U_LONG
+import com.squareup.kotlinpoet.U_LONG_ARRAY
+import com.squareup.kotlinpoet.U_SHORT
+import com.squareup.kotlinpoet.U_SHORT_ARRAY
 
 @KotlinPoetJavaPoetPreview
 public fun KClassName.toJClassName(boxIfPrimitive: Boolean = false): JTypeName {
   return when (copy(nullable = false)) {
     BOOLEAN -> JTypeName.BOOLEAN.boxIfPrimitive(boxIfPrimitive || isNullable)
-    BYTE -> JTypeName.BYTE.boxIfPrimitive(boxIfPrimitive || isNullable)
+    BYTE, U_BYTE -> JTypeName.BYTE.boxIfPrimitive(boxIfPrimitive || isNullable)
     CHAR -> JTypeName.CHAR.boxIfPrimitive(boxIfPrimitive || isNullable)
-    SHORT -> JTypeName.SHORT.boxIfPrimitive(boxIfPrimitive || isNullable)
-    INT -> JTypeName.INT.boxIfPrimitive(boxIfPrimitive || isNullable)
-    LONG -> JTypeName.LONG.boxIfPrimitive(boxIfPrimitive || isNullable)
+    SHORT, U_SHORT -> JTypeName.SHORT.boxIfPrimitive(boxIfPrimitive || isNullable)
+    INT, U_INT -> JTypeName.INT.boxIfPrimitive(boxIfPrimitive || isNullable)
+    LONG, U_LONG -> JTypeName.LONG.boxIfPrimitive(boxIfPrimitive || isNullable)
     FLOAT -> JTypeName.FLOAT.boxIfPrimitive(boxIfPrimitive || isNullable)
     DOUBLE -> JTypeName.DOUBLE.boxIfPrimitive(boxIfPrimitive || isNullable)
     ANY -> JTypeName.OBJECT
     STRING -> PoetInterop.CN_JAVA_STRING
-    LIST -> PoetInterop.CN_JAVA_LIST
-    SET -> PoetInterop.CN_JAVA_SET
-    MAP -> PoetInterop.CN_JAVA_MAP
+    LIST, MUTABLE_LIST -> PoetInterop.CN_JAVA_LIST
+    SET, MUTABLE_SET -> PoetInterop.CN_JAVA_SET
+    MAP, MUTABLE_MAP -> PoetInterop.CN_JAVA_MAP
+    BOOLEAN_ARRAY -> ArrayTypeName.of(JTypeName.BOOLEAN)
+    BYTE_ARRAY, U_BYTE_ARRAY -> ArrayTypeName.of(JTypeName.BYTE)
+    CHAR_ARRAY -> ArrayTypeName.of(JTypeName.CHAR)
+    SHORT_ARRAY, U_SHORT_ARRAY -> ArrayTypeName.of(JTypeName.SHORT)
+    INT_ARRAY, U_INT_ARRAY -> ArrayTypeName.of(JTypeName.INT)
+    LONG_ARRAY, U_LONG_ARRAY -> ArrayTypeName.of(JTypeName.LONG)
+    FLOAT_ARRAY -> ArrayTypeName.of(JTypeName.FLOAT)
+    DOUBLE_ARRAY -> ArrayTypeName.of(JTypeName.DOUBLE)
+    ENUM -> PoetInterop.CN_JAVA_ENUM
     else -> {
       if (simpleNames.size == 1) {
         JClassName.get(packageName, simpleName)

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/typeAliases.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/typeAliases.kt
@@ -19,18 +19,44 @@ package com.squareup.kotlinpoet.javapoet
  * Useful typealiases for colliding names
  */
 
+@KotlinPoetJavaPoetPreview
 public typealias KTypeName = com.squareup.kotlinpoet.TypeName
+
+@KotlinPoetJavaPoetPreview
 public typealias KClassName = com.squareup.kotlinpoet.ClassName
+
+@KotlinPoetJavaPoetPreview
 public typealias KTypeVariableName = com.squareup.kotlinpoet.TypeVariableName
+
+@KotlinPoetJavaPoetPreview
 public typealias KParameterizedTypeName = com.squareup.kotlinpoet.ParameterizedTypeName
+
+@KotlinPoetJavaPoetPreview
 public typealias KWildcardTypeName = com.squareup.kotlinpoet.WildcardTypeName
+
+@KotlinPoetJavaPoetPreview
 public typealias KTypeSpec = com.squareup.kotlinpoet.TypeSpec
+
+@KotlinPoetJavaPoetPreview
 public typealias KAnnotationSpec = com.squareup.kotlinpoet.AnnotationSpec
 
+@KotlinPoetJavaPoetPreview
 public typealias JTypeName = com.squareup.javapoet.TypeName
+
+@KotlinPoetJavaPoetPreview
 public typealias JClassName = com.squareup.javapoet.ClassName
+
+@KotlinPoetJavaPoetPreview
 public typealias JTypeVariableName = com.squareup.javapoet.TypeVariableName
+
+@KotlinPoetJavaPoetPreview
 public typealias JParameterizedTypeName = com.squareup.javapoet.ParameterizedTypeName
+
+@KotlinPoetJavaPoetPreview
 public typealias JWildcardTypeName = com.squareup.javapoet.WildcardTypeName
+
+@KotlinPoetJavaPoetPreview
 public typealias JTypeSpec = com.squareup.javapoet.TypeSpec
+
+@KotlinPoetJavaPoetPreview
 public typealias JAnnotationSpec = com.squareup.javapoet.AnnotationSpec

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/typeAliases.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/typeAliases.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.javapoet
+
+/*
+ * Useful typealiases for colliding names
+ */
+
+public typealias KTypeName = com.squareup.kotlinpoet.TypeName
+public typealias KClassName = com.squareup.kotlinpoet.ClassName
+public typealias KTypeVariableName = com.squareup.kotlinpoet.TypeVariableName
+public typealias KParameterizedTypeName = com.squareup.kotlinpoet.ParameterizedTypeName
+public typealias KWildcardTypeName = com.squareup.kotlinpoet.WildcardTypeName
+public typealias KTypeSpec = com.squareup.kotlinpoet.TypeSpec
+public typealias KAnnotationSpec = com.squareup.kotlinpoet.AnnotationSpec
+
+public typealias JTypeName = com.squareup.javapoet.TypeName
+public typealias JClassName = com.squareup.javapoet.ClassName
+public typealias JTypeVariableName = com.squareup.javapoet.TypeVariableName
+public typealias JParameterizedTypeName = com.squareup.javapoet.ParameterizedTypeName
+public typealias JWildcardTypeName = com.squareup.javapoet.WildcardTypeName
+public typealias JTypeSpec = com.squareup.javapoet.TypeSpec
+public typealias JAnnotationSpec = com.squareup.javapoet.AnnotationSpec

--- a/interop/javapoet/src/test/kotlin/com/squareup/kotlinpoet/javapoet/PoetInteropTest.kt
+++ b/interop/javapoet/src/test/kotlin/com/squareup/kotlinpoet/javapoet/PoetInteropTest.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.javapoet
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.javapoet.ArrayTypeName
+import com.squareup.kotlinpoet.ANY
+import com.squareup.kotlinpoet.ARRAY
+import com.squareup.kotlinpoet.BOOLEAN
+import com.squareup.kotlinpoet.BYTE
+import com.squareup.kotlinpoet.CHAR
+import com.squareup.kotlinpoet.DOUBLE
+import com.squareup.kotlinpoet.ENUM
+import com.squareup.kotlinpoet.FLOAT
+import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.INT_ARRAY
+import com.squareup.kotlinpoet.LIST
+import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.MAP
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.SET
+import com.squareup.kotlinpoet.SHORT
+import com.squareup.kotlinpoet.STAR
+import com.squareup.kotlinpoet.STRING
+import com.squareup.kotlinpoet.U_BYTE
+import com.squareup.kotlinpoet.U_INT
+import com.squareup.kotlinpoet.U_LONG
+import com.squareup.kotlinpoet.U_SHORT
+import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.typeNameOf
+import org.junit.Test
+
+@OptIn(ExperimentalStdlibApi::class, KotlinPoetJavaPoetPreview::class)
+class PoetInteropTest {
+
+  @Test
+  fun classNamesMatch() {
+    val kotlinPoetCN = PoetInteropTest::class.asClassName()
+    val javapoetCN = kotlinPoetCN.toJClassName()
+
+    assertThat(javapoetCN.toKTypeName()).isEqualTo(kotlinPoetCN)
+    assertThat(JClassName.get(PoetInteropTest::class.java)).isEqualTo(javapoetCN)
+  }
+
+  @Test
+  fun nestedClassNamesMatch() {
+    val kotlinPoetCN = PoetInteropTest::class.asClassName().nestedClass("Foo").nestedClass("Bar")
+    val javapoetCN = kotlinPoetCN.toJClassName()
+
+    assertThat(javapoetCN.toKTypeName()).isEqualTo(kotlinPoetCN)
+    assertThat(JClassName.get(PoetInteropTest::class.java).nestedClass("Foo").nestedClass("Bar"))
+      .isEqualTo(javapoetCN)
+  }
+
+  @Test
+  fun kotlinIntrinsicsMapCorrectlyToJava() {
+    // To Java
+    assertThat(LIST.toJTypeName()).isEqualTo(PoetInterop.CN_JAVA_LIST)
+    assertThat(SET.toJTypeName()).isEqualTo(PoetInterop.CN_JAVA_SET)
+    assertThat(MAP.toJTypeName()).isEqualTo(PoetInterop.CN_JAVA_MAP)
+    assertThat(STRING.toJTypeName()).isEqualTo(PoetInterop.CN_JAVA_STRING)
+    assertThat(ANY.toJTypeName()).isEqualTo(JTypeName.OBJECT)
+
+    // To Kotlin
+    assertThat(PoetInterop.CN_JAVA_LIST.toKTypeName()).isEqualTo(LIST)
+    assertThat(PoetInterop.CN_JAVA_SET.toKTypeName()).isEqualTo(SET)
+    assertThat(PoetInterop.CN_JAVA_MAP.toKTypeName()).isEqualTo(MAP)
+    assertThat(PoetInterop.CN_JAVA_STRING.toKTypeName()).isEqualTo(STRING)
+    assertThat(JTypeName.OBJECT.toKTypeName()).isEqualTo(ANY)
+  }
+
+  @Test
+  fun boxIfPrimitiveRequestReturnsBoxedPrimitive() {
+    assertThat(BOOLEAN.toJTypeName(boxIfPrimitive = true)).isEqualTo(JTypeName.BOOLEAN.box())
+    assertThat(BYTE.toJTypeName(boxIfPrimitive = true)).isEqualTo(JTypeName.BYTE.box())
+    assertThat(CHAR.toJTypeName(boxIfPrimitive = true)).isEqualTo(JTypeName.CHAR.box())
+    assertThat(SHORT.toJTypeName(boxIfPrimitive = true)).isEqualTo(JTypeName.SHORT.box())
+    assertThat(INT.toJTypeName(boxIfPrimitive = true)).isEqualTo(JTypeName.INT.box())
+    assertThat(LONG.toJTypeName(boxIfPrimitive = true)).isEqualTo(JTypeName.LONG.box())
+    assertThat(FLOAT.toJTypeName(boxIfPrimitive = true)).isEqualTo(JTypeName.FLOAT.box())
+    assertThat(DOUBLE.toJTypeName(boxIfPrimitive = true)).isEqualTo(JTypeName.DOUBLE.box())
+  }
+
+  @Test
+  fun primitivesAreUnboxedByDefault() {
+    assertThat(BOOLEAN.toJTypeName()).isEqualTo(JTypeName.BOOLEAN)
+    assertThat(BYTE.toJTypeName()).isEqualTo(JTypeName.BYTE)
+    assertThat(CHAR.toJTypeName()).isEqualTo(JTypeName.CHAR)
+    assertThat(SHORT.toJTypeName()).isEqualTo(JTypeName.SHORT)
+    assertThat(INT.toJTypeName()).isEqualTo(JTypeName.INT)
+    assertThat(LONG.toJTypeName()).isEqualTo(JTypeName.LONG)
+    assertThat(FLOAT.toJTypeName()).isEqualTo(JTypeName.FLOAT)
+    assertThat(DOUBLE.toJTypeName()).isEqualTo(JTypeName.DOUBLE)
+  }
+
+  @Test
+  fun nullablePrimitiveBoxedByDefault() {
+    assertThat(BOOLEAN.copy(nullable = true).toJTypeName()).isEqualTo(JTypeName.BOOLEAN.box())
+    assertThat(BYTE.copy(nullable = true).toJTypeName()).isEqualTo(JTypeName.BYTE.box())
+    assertThat(CHAR.copy(nullable = true).toJTypeName()).isEqualTo(JTypeName.CHAR.box())
+    assertThat(SHORT.copy(nullable = true).toJTypeName()).isEqualTo(JTypeName.SHORT.box())
+    assertThat(INT.copy(nullable = true).toJTypeName()).isEqualTo(JTypeName.INT.box())
+    assertThat(LONG.copy(nullable = true).toJTypeName()).isEqualTo(JTypeName.LONG.box())
+    assertThat(FLOAT.copy(nullable = true).toJTypeName()).isEqualTo(JTypeName.FLOAT.box())
+    assertThat(DOUBLE.copy(nullable = true).toJTypeName()).isEqualTo(JTypeName.DOUBLE.box())
+  }
+
+  @Test
+  fun arrayTypesConversion() {
+    assertThat(ARRAY.parameterizedBy(INT).toJParameterizedOrArrayTypeName())
+      .isEqualTo(ArrayTypeName.of(JTypeName.INT))
+    assertThat(ARRAY.parameterizedBy(INT.copy(nullable = true)).toJParameterizedOrArrayTypeName())
+      .isEqualTo(ArrayTypeName.of(JTypeName.INT.box()))
+    assertThat(ArrayTypeName.of(JTypeName.INT).toKTypeName()).isEqualTo(INT_ARRAY)
+    assertThat(ArrayTypeName.of(JTypeName.INT.box()).toKTypeName())
+      .isEqualTo(ARRAY.parameterizedBy(INT))
+  }
+
+  class GenericType<T>
+
+  @Test
+  fun wildcards() {
+    val inKType = typeNameOf<GenericType<in String>>()
+    val superJType = JParameterizedTypeName.get(
+      JClassName.get(GenericType::class.java),
+      JWildcardTypeName.supertypeOf(String::class.java)
+    )
+    assertThat(inKType.toJTypeName()).isEqualTo(superJType)
+    assertThat(superJType.toKTypeName()).isEqualTo(inKType)
+
+    val outKType = typeNameOf<GenericType<out String>>()
+    val extendsJType = JParameterizedTypeName.get(
+      JClassName.get(GenericType::class.java),
+      JWildcardTypeName.subtypeOf(String::class.java)
+    )
+    assertThat(outKType.toJTypeName()).isEqualTo(extendsJType)
+    assertThat(extendsJType.toKTypeName()).isEqualTo(outKType)
+
+    val star = typeNameOf<GenericType<*>>()
+    val extendsObjectJType = JParameterizedTypeName.get(
+      JClassName.get(GenericType::class.java),
+      JWildcardTypeName.subtypeOf(JTypeName.OBJECT)
+    )
+    assertThat(star.toJTypeName()).isEqualTo(extendsObjectJType)
+    assertThat(extendsObjectJType.toKTypeName()).isEqualTo(star)
+    assertThat(STAR.toJTypeName()).isEqualTo(JWildcardTypeName.subtypeOf(JTypeName.OBJECT))
+    assertThat(JWildcardTypeName.subtypeOf(JTypeName.OBJECT).toKTypeName()).isEqualTo(STAR)
+  }
+
+  @Test
+  fun complex() {
+    val complexType = typeNameOf<Map<String?, List<MutableMap<Int, IntArray>>>>()
+    val jType = JParameterizedTypeName.get(
+      JClassName.get(Map::class.java),
+      JClassName.get(String::class.java),
+      JParameterizedTypeName.get(
+        JClassName.get(List::class.java),
+        JParameterizedTypeName.get(
+          JClassName.get(Map::class.java),
+          JClassName.INT.box(),
+          ArrayTypeName.of(JClassName.INT)
+        )
+      )
+    )
+    assertThat(complexType.toJTypeName()).isEqualTo(jType)
+
+    assertThat(jType.toKTypeName())
+      .isEqualTo(typeNameOf<Map<String, List<MutableMap<Int, IntArray>>>>())
+  }
+
+  @Test
+  fun uTypesAreJustNormalTypesInJava() {
+    assertThat(U_BYTE.toJTypeName()).isEqualTo(JTypeName.BYTE)
+    assertThat(U_SHORT.toJTypeName()).isEqualTo(JTypeName.SHORT)
+    assertThat(U_INT.toJTypeName()).isEqualTo(JTypeName.INT)
+    assertThat(U_LONG.toJTypeName()).isEqualTo(JTypeName.LONG)
+  }
+
+  @Test
+  fun enums() {
+    assertThat(ENUM.toJTypeName()).isEqualTo(PoetInterop.CN_JAVA_ENUM)
+    assertThat(PoetInterop.CN_JAVA_ENUM.toKTypeName()).isEqualTo(ENUM)
+  }
+}


### PR DESCRIPTION
Resolves #417 and is based on the implementation I wrote in the past that @shaishavgandhi shared in the issue via https://gist.github.com/ShaishavGandhi/097033cc528ae25741186973e4d36ce4

This'll be pretty helpful for processors like Room that support generating both Java and Kotlin. I know we weren't sure a few years ago when the issue was first created, but I think KSP's dual support will create new avenues for this where this becomes helpful. We also have a bit of a stronger interop artifacts story now too.

TODO:
- [x] Tests (see below)
- [x] `WildcardTypeName` interop
- [x] Do we want to use an experimenta/preview annotation for these?
- [x] What about other Kotlin intrinsics? Should we cover the set contained in KotlinPoet itself (beyond just `LIST`, `SET`, etc)?