### PR TITLE
Implement basic tests for KSP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   alias(libs.plugins.kotlin.jvm) apply false
+  alias(libs.plugins.ksp) apply false
   alias(libs.plugins.dokka) apply false
   alias(libs.plugins.spotless) apply false
   alias(libs.plugins.mavenPublish) apply false
@@ -50,7 +51,7 @@ subprojects {
   configure<KotlinProjectExtension> {
     explicitApi()
   }
-  if ("tests" !in name && buildFile.exists()) {
+  if ("test" !in name && buildFile.exists()) {
     apply(plugin = "org.jetbrains.dokka")
     apply(plugin = "com.vanniktech.maven.publish")
     afterEvaluate {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,12 +48,12 @@ subprojects {
   }
 
   apply(plugin = "org.jetbrains.kotlin.jvm")
-  configure<KotlinProjectExtension> {
-    explicitApi()
-  }
   if ("test" !in name && buildFile.exists()) {
     apply(plugin = "org.jetbrains.dokka")
     apply(plugin = "com.vanniktech.maven.publish")
+    configure<KotlinProjectExtension> {
+      explicitApi()
+    }
     afterEvaluate {
       tasks.named<DokkaTask>("dokkaHtml") {
         val projectFolder = project.path.trim(':').replace(':', '-')

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,9 @@ autoCommon = { module = "com.google.auto:auto-common", version = "1.1.2" }
 guava = { module = "com.google.guava:guava", version = "30.1.1-jre" }
 javapoet = "com.squareup:javapoet:1.13.0"
 
+autoService = "com.google.auto:auto-service-annotations:1.0"
+autoService-ksp = "dev.zacsweers.autoservice:auto-service-ksp:1.0.0"
+
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlin-metadata = { module = "org.jetbrains.kotlinx:kotlinx-metadata-jvm", version = "0.3.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ autoCommon = { module = "com.google.auto:auto-common", version = "1.1.2" }
 guava = { module = "com.google.guava:guava", version = "30.1.1-jre" }
 javapoet = "com.squareup:javapoet:1.13.0"
 
-autoService = "com.google.auto:auto-service-annotations:1.0"
+autoService = "com.google.auto.service:auto-service-annotations:1.0"
 autoService-ksp = "dev.zacsweers.autoservice:auto-service-ksp:1.0.0"
 
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@
 
 [versions]
 kotlin = "1.5.30"
+kct = "1.4.4"
 ksp = "1.5.30-1.0.0"
 ktlint = "0.41.0"
 
@@ -43,4 +44,5 @@ truth = { module = "com.google.truth:truth", version = "1.1.3" }
 compileTesting = { module = "com.google.testing.compile:compile-testing", version = "0.19" }
 jimfs = { module = "com.google.jimfs:jimfs", version = "1.2" }
 ecj = { module = "org.eclipse.jdt.core.compiler:ecj", version = "4.6.1" }
-kotlinCompileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version = "1.4.3" }
+kotlinCompileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version.ref = "kct" }
+kotlinCompileTesting-ksp = { module = "com.github.tschuchortdev:kotlin-compile-testing-ksp", version.ref = "kct" }

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksClassDeclarations.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksClassDeclarations.kt
@@ -15,20 +15,11 @@
  */
 package com.squareup.kotlinpoet.ksp
 
-import com.google.devtools.ksp.isLocal
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.squareup.kotlinpoet.ClassName
 
 /** Returns the [ClassName] representation of this [KSClassDeclaration]. */
 @KotlinPoetKspPreview
 public fun KSClassDeclaration.toClassName(): ClassName {
-  require(!isLocal()) {
-    "Local/anonymous classes are not supported!"
-  }
-  val pkgName = packageName.asString()
-  val typesString = checkNotNull(qualifiedName).asString().removePrefix("$pkgName.")
-
-  val simpleNames = typesString
-    .split(".")
-  return ClassName(pkgName, simpleNames)
+  return toClassNameInternal()
 }

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt
@@ -56,7 +56,15 @@ public fun KSType.toTypeName(
   typeParamResolver: TypeParameterResolver = TypeParameterResolver.EMPTY
 ): TypeName {
   val type = when (val decl = declaration) {
-    is KSClassDeclaration -> decl.toClassName().parameterizedBy(arguments.map { it.toTypeName(typeParamResolver) })
+    is KSClassDeclaration -> {
+      decl.toClassName().let { cn ->
+        if (arguments.isEmpty()) {
+          cn
+        } else {
+          cn.parameterizedBy(arguments.map { it.toTypeName(typeParamResolver) })
+        }
+      }
+    }
     is KSTypeParameter -> typeParamResolver[decl.name.getShortName()]
     is KSTypeAlias -> {
       val extraResolver = if (decl.typeParameters.isEmpty()) {

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt
@@ -27,7 +27,6 @@ import com.google.devtools.ksp.symbol.Variance.COVARIANT
 import com.google.devtools.ksp.symbol.Variance.INVARIANT
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.KModifier
-import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeVariableName
@@ -50,20 +49,17 @@ public fun KSType.toClassName(): ClassName {
  * @param typeParamResolver an optional resolver for enclosing declarations' type parameters. Parent
  *                          declarations can be anything with generics that child nodes declare as
  *                          defined by [KSType.arguments].
+ * @param unwrapTypeAliases optionally controls whether typealiases should be unwrapped to their
+ *                          aliased type. Useful in cases where only the aliased type matters
  */
 @KotlinPoetKspPreview
 public fun KSType.toTypeName(
-  typeParamResolver: TypeParameterResolver = TypeParameterResolver.EMPTY
+  typeParamResolver: TypeParameterResolver = TypeParameterResolver.EMPTY,
+  unwrapTypeAliases: Boolean = false
 ): TypeName {
   val type = when (val decl = declaration) {
     is KSClassDeclaration -> {
-      decl.toClassName().let { cn ->
-        if (arguments.isEmpty()) {
-          cn
-        } else {
-          cn.parameterizedBy(arguments.map { it.toTypeName(typeParamResolver) })
-        }
-      }
+      decl.toClassName().withTypeArguments(arguments.map { it.toTypeName(typeParamResolver) })
     }
     is KSTypeParameter -> typeParamResolver[decl.name.getShortName()]
     is KSTypeAlias -> {
@@ -72,13 +68,16 @@ public fun KSType.toTypeName(
       } else {
         decl.typeParameters.toTypeParameterResolver(typeParamResolver)
       }
-      val args = arguments.map { it.toTypeName(typeParamResolver) }
-      val firstPass = decl.type.resolve().toTypeName(extraResolver).copy(nullable = isMarkedNullable)
-      if (args.isNotEmpty()) {
-        firstPass.rawType().parameterizedBy(args)
+      val firstPass = if (unwrapTypeAliases) {
+        decl.type.resolve()
+          .toTypeName(extraResolver, unwrapTypeAliases)
+          .copy(nullable = isMarkedNullable)
+          .rawType()
       } else {
-        firstPass
+        decl.toClassNameInternal()
       }
+      firstPass
+        .withTypeArguments(arguments.map { it.toTypeName(typeParamResolver) })
     }
     else -> error("Unsupported type: $declaration")
   }
@@ -93,13 +92,16 @@ public fun KSType.toTypeName(
  * @param typeParamResolver an optional resolver for enclosing declarations' type parameters. Parent
  *                          declarations can be anything with generics that child nodes declare as
  *                          defined by [KSType.arguments].
+ * @param unwrapTypeAliases optionally controls whether typealiases should be unwrapped to their
+ *                          aliased type. Useful in cases where only the aliased type matters
  */
 @KotlinPoetKspPreview
 public fun KSTypeParameter.toTypeVariableName(
   typeParamResolver: TypeParameterResolver = TypeParameterResolver.EMPTY,
+  unwrapTypeAliases: Boolean = false
 ): TypeVariableName {
   val typeVarName = name.getShortName()
-  val typeVarBounds = bounds.map { it.toTypeName(typeParamResolver) }.toList()
+  val typeVarBounds = bounds.map { it.toTypeName(typeParamResolver, unwrapTypeAliases) }.toList()
   val typeVarVariance = when (variance) {
     COVARIANT -> KModifier.OUT
     CONTRAVARIANT -> KModifier.IN
@@ -115,10 +117,15 @@ public fun KSTypeParameter.toTypeVariableName(
  * @param typeParamResolver an optional resolver for enclosing declarations' type parameters. Parent
  *                          declarations can be anything with generics that child nodes declare as
  *                          defined by [KSType.arguments].
+ * @param unwrapTypeAliases optionally controls whether typealiases should be unwrapped to their
+ *                          aliased type. Useful in cases where only the aliased type matters
  */
 @KotlinPoetKspPreview
-public fun KSTypeArgument.toTypeName(typeParamResolver: TypeParameterResolver): TypeName {
-  val typeName = type?.resolve()?.toTypeName(typeParamResolver) ?: return STAR
+public fun KSTypeArgument.toTypeName(
+  typeParamResolver: TypeParameterResolver,
+  unwrapTypeAliases: Boolean = false
+): TypeName {
+  val typeName = type?.resolve()?.toTypeName(typeParamResolver, unwrapTypeAliases) ?: return STAR
   return when (variance) {
     COVARIANT -> WildcardTypeName.producerOf(typeName)
     CONTRAVARIANT -> WildcardTypeName.consumerOf(typeName)
@@ -134,11 +141,14 @@ public fun KSTypeArgument.toTypeName(typeParamResolver: TypeParameterResolver): 
  * @param typeParamResolver an optional resolver for enclosing declarations' type parameters. Parent
  *                          declarations can be anything with generics that child nodes declare as
  *                          defined by [KSType.arguments].
+ * @param unwrapTypeAliases optionally controls whether typealiases should be unwrapped to their
+ *                          aliased type. Useful in cases where only the aliased type matters
  */
 @KotlinPoetKspPreview
 public fun KSTypeReference.toTypeName(
-  typeParamResolver: TypeParameterResolver = TypeParameterResolver.EMPTY
+  typeParamResolver: TypeParameterResolver = TypeParameterResolver.EMPTY,
+  unwrapTypeAliases: Boolean = false
 ): TypeName {
   val type = resolve()
-  return type.toTypeName(typeParamResolver)
+  return type.toTypeName(typeParamResolver, unwrapTypeAliases)
 }

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/modifiers.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/modifiers.kt
@@ -1,0 +1,74 @@
+package com.squareup.kotlinpoet.ksp
+
+import com.google.devtools.ksp.symbol.Modifier
+import com.google.devtools.ksp.symbol.Modifier.ABSTRACT
+import com.google.devtools.ksp.symbol.Modifier.ACTUAL
+import com.google.devtools.ksp.symbol.Modifier.ANNOTATION
+import com.google.devtools.ksp.symbol.Modifier.CROSSINLINE
+import com.google.devtools.ksp.symbol.Modifier.DATA
+import com.google.devtools.ksp.symbol.Modifier.ENUM
+import com.google.devtools.ksp.symbol.Modifier.EXPECT
+import com.google.devtools.ksp.symbol.Modifier.EXTERNAL
+import com.google.devtools.ksp.symbol.Modifier.FINAL
+import com.google.devtools.ksp.symbol.Modifier.FUN
+import com.google.devtools.ksp.symbol.Modifier.IN
+import com.google.devtools.ksp.symbol.Modifier.INFIX
+import com.google.devtools.ksp.symbol.Modifier.INLINE
+import com.google.devtools.ksp.symbol.Modifier.INNER
+import com.google.devtools.ksp.symbol.Modifier.INTERNAL
+import com.google.devtools.ksp.symbol.Modifier.LATEINIT
+import com.google.devtools.ksp.symbol.Modifier.NOINLINE
+import com.google.devtools.ksp.symbol.Modifier.OPEN
+import com.google.devtools.ksp.symbol.Modifier.OPERATOR
+import com.google.devtools.ksp.symbol.Modifier.OUT
+import com.google.devtools.ksp.symbol.Modifier.OVERRIDE
+import com.google.devtools.ksp.symbol.Modifier.PRIVATE
+import com.google.devtools.ksp.symbol.Modifier.PROTECTED
+import com.google.devtools.ksp.symbol.Modifier.PUBLIC
+import com.google.devtools.ksp.symbol.Modifier.REIFIED
+import com.google.devtools.ksp.symbol.Modifier.SEALED
+import com.google.devtools.ksp.symbol.Modifier.SUSPEND
+import com.google.devtools.ksp.symbol.Modifier.TAILREC
+import com.google.devtools.ksp.symbol.Modifier.VALUE
+import com.google.devtools.ksp.symbol.Modifier.VARARG
+import com.squareup.kotlinpoet.KModifier
+
+/**
+ * Returns the [KModifier] representation of this [Modifier] or null if this is a Java-only
+ * modifier (i.e. prefixed with `JAVA_`), which do not have obvious [KModifier] analogues.
+ */
+public fun Modifier.toKModifier(): KModifier? {
+  return when (this) {
+    PUBLIC -> KModifier.PUBLIC
+    PRIVATE -> KModifier.PRIVATE
+    INTERNAL -> KModifier.INTERNAL
+    PROTECTED -> KModifier.PROTECTED
+    IN -> KModifier.IN
+    OUT -> KModifier.OUT
+    OVERRIDE -> KModifier.OVERRIDE
+    LATEINIT -> KModifier.LATEINIT
+    ENUM -> KModifier.ENUM
+    SEALED -> KModifier.SEALED
+    ANNOTATION -> KModifier.ANNOTATION
+    DATA -> KModifier.DATA
+    INNER -> KModifier.INNER
+    FUN -> KModifier.FUN
+    VALUE -> KModifier.VALUE
+    SUSPEND -> KModifier.SUSPEND
+    TAILREC -> KModifier.TAILREC
+    OPERATOR -> KModifier.OPERATOR
+    INFIX -> KModifier.INFIX
+    INLINE -> KModifier.INLINE
+    EXTERNAL -> KModifier.EXTERNAL
+    ABSTRACT -> KModifier.ABSTRACT
+    FINAL -> KModifier.FINAL
+    OPEN -> KModifier.OPEN
+    VARARG -> KModifier.VARARG
+    NOINLINE -> KModifier.NOINLINE
+    CROSSINLINE -> KModifier.CROSSINLINE
+    REIFIED -> KModifier.REIFIED
+    EXPECT -> KModifier.EXPECT
+    ACTUAL -> KModifier.ACTUAL
+    else -> null
+  }
+}

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/modifiers.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/modifiers.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.kotlinpoet.ksp
 
 import com.google.devtools.ksp.symbol.Modifier

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/originatingKSFiles.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/originatingKSFiles.kt
@@ -119,6 +119,24 @@ public fun FileSpec.writeTo(
   originatingKSFiles: Iterable<KSFile> = originatingKSFiles()
 ) {
   val dependencies = kspDependencies(aggregating, originatingKSFiles)
+  writeTo(codeGenerator, dependencies)
+}
+
+/**
+ * Writes this [FileSpec] to a given [codeGenerator] with the given [dependencies].
+ *
+ * See [the docs](https://github.com/google/ksp/blob/main/docs/incremental.md) for more information.
+ *
+ * @see FileSpec.originatingKSFiles
+ * @see kspDependencies
+ * @param codeGenerator the [CodeGenerator] to write to.
+ * @param dependencies the [Dependencies] to create a new file with.
+ */
+@KotlinPoetKspPreview
+public fun FileSpec.writeTo(
+  codeGenerator: CodeGenerator,
+  dependencies: Dependencies
+) {
   val file = codeGenerator.createNewFile(dependencies, packageName, name)
   // Don't use writeTo(file) because that tries to handle directories under the hood
   OutputStreamWriter(file, StandardCharsets.UTF_8)

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/utils.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/utils.kt
@@ -15,9 +15,12 @@
  */
 package com.squareup.kotlinpoet.ksp
 
+import com.google.devtools.ksp.isLocal
+import com.google.devtools.ksp.symbol.KSDeclaration
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeName
 
 internal fun TypeName.rawType(): ClassName {
@@ -42,4 +45,24 @@ internal fun TypeName.findRawType(): ClassName? {
     }
     else -> null
   }
+}
+
+internal fun ClassName.withTypeArguments(arguments: List<TypeName>): TypeName {
+  return if (arguments.isEmpty()) {
+    this
+  } else {
+    this.parameterizedBy(arguments)
+  }
+}
+
+internal fun KSDeclaration.toClassNameInternal(): ClassName {
+  require(!isLocal()) {
+    "Local/anonymous classes are not supported!"
+  }
+  val pkgName = packageName.asString()
+  val typesString = checkNotNull(qualifiedName).asString().removePrefix("$pkgName.")
+
+  val simpleNames = typesString
+    .split(".")
+  return ClassName(pkgName, simpleNames)
 }

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/visibilities.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/visibilities.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.kotlinpoet.ksp
 
 import com.google.devtools.ksp.symbol.Visibility

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/visibilities.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/visibilities.kt
@@ -1,0 +1,24 @@
+package com.squareup.kotlinpoet.ksp
+
+import com.google.devtools.ksp.symbol.Visibility
+import com.google.devtools.ksp.symbol.Visibility.INTERNAL
+import com.google.devtools.ksp.symbol.Visibility.JAVA_PACKAGE
+import com.google.devtools.ksp.symbol.Visibility.LOCAL
+import com.google.devtools.ksp.symbol.Visibility.PRIVATE
+import com.google.devtools.ksp.symbol.Visibility.PROTECTED
+import com.google.devtools.ksp.symbol.Visibility.PUBLIC
+import com.squareup.kotlinpoet.KModifier
+
+/**
+ * Returns the [KModifier] representation of this visibility or null if this is [JAVA_PACKAGE]
+ * or [LOCAL] (which do not have obvious [KModifier] alternatives).
+ */
+public fun Visibility.toKModifier(): KModifier? {
+  return when (this) {
+    PUBLIC -> KModifier.PUBLIC
+    PRIVATE -> KModifier.PRIVATE
+    PROTECTED -> KModifier.PROTECTED
+    INTERNAL -> KModifier.INTERNAL
+    else -> null
+  }
+}

--- a/interop/ksp/test-processor/build.gradle.kts
+++ b/interop/ksp/test-processor/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
   implementation(libs.autoService)
   compileOnly(libs.ksp.api)
   ksp(libs.autoService.ksp)
+  // Always force the latest version of the KSP impl in tests to match what we're building against
+  testImplementation(libs.ksp)
   testImplementation(libs.kotlinCompileTesting)
   testImplementation(libs.kotlinCompileTesting.ksp)
   testImplementation(libs.kotlin.junit)

--- a/interop/ksp/test-processor/build.gradle.kts
+++ b/interop/ksp/test-processor/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
 dependencies {
   implementation(project(":kotlinpoet"))
   implementation(project(":interop:ksp"))
+  implementation(libs.autoService)
   compileOnly(libs.ksp.api)
   ksp(libs.autoService.ksp)
 }

--- a/interop/ksp/test-processor/build.gradle.kts
+++ b/interop/ksp/test-processor/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Square, Inc.
+ * Copyright (C) 2021 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,23 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-pluginManagement {
-  repositories {
-    mavenCentral()
-    gradlePluginPortal()
-  }
+
+plugins {
+  id("com.google.devtools.ksp")
 }
 
-include(
-    ":kotlinpoet",
-    ":interop:javapoet",
-    ":interop:kotlinx-metadata:classinspectors:elements",
-    ":interop:kotlinx-metadata:classinspectors:reflect",
-    ":interop:kotlinx-metadata:core",
-    ":interop:kotlinx-metadata:specs",
-    ":interop:kotlinx-metadata:specs-tests",
-    ":interop:ksp",
-    ":interop:ksp:test-processor",
-)
-
-enableFeaturePreview("VERSION_CATALOGS")
+dependencies {
+  implementation(project(":kotlinpoet"))
+  implementation(project(":interop:ksp"))
+  compileOnly(libs.ksp.api)
+  ksp(libs.autoService.ksp)
+}

--- a/interop/ksp/test-processor/build.gradle.kts
+++ b/interop/ksp/test-processor/build.gradle.kts
@@ -24,4 +24,8 @@ dependencies {
   implementation(libs.autoService)
   compileOnly(libs.ksp.api)
   ksp(libs.autoService.ksp)
+  testImplementation(libs.kotlinCompileTesting)
+  testImplementation(libs.kotlinCompileTesting.ksp)
+  testImplementation(libs.kotlin.junit)
+  testImplementation(libs.truth)
 }

--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/ExampleAnnotation.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/ExampleAnnotation.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.kotlinpoet.ksp.test.processor
 
 annotation class ExampleAnnotation

--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/ExampleAnnotation.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/ExampleAnnotation.kt
@@ -1,0 +1,3 @@
+package com.squareup.kotlinpoet.ksp.test.processor
+
+annotation class ExampleAnnotation

--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.ksp.test.processor
+
+import com.google.devtools.ksp.getDeclaredFunctions
+import com.google.devtools.ksp.getDeclaredProperties
+import com.google.devtools.ksp.getVisibility
+import com.google.devtools.ksp.isConstructor
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.ksp.KotlinPoetKspPreview
+import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
+import com.squareup.kotlinpoet.ksp.kspDependencies
+import com.squareup.kotlinpoet.ksp.originatingKSFiles
+import com.squareup.kotlinpoet.ksp.toKModifier
+import com.squareup.kotlinpoet.ksp.toTypeName
+import com.squareup.kotlinpoet.ksp.toTypeParameterResolver
+import com.squareup.kotlinpoet.ksp.toTypeVariableName
+import com.squareup.kotlinpoet.ksp.writeTo
+
+/**
+ * A simple processor that generates a skeleton API of classes annotated with [ExampleAnnotation]
+ * for test and verification purposes.
+ */
+@OptIn(KotlinPoetKspPreview::class)
+class TestProcessor(private val env: SymbolProcessorEnvironment) : SymbolProcessor {
+  override fun process(resolver: Resolver): List<KSAnnotated> {
+    resolver.getSymbolsWithAnnotation(ExampleAnnotation::class.java.canonicalName)
+      .forEach(::process)
+    return emptyList()
+  }
+
+  private fun process(decl: KSAnnotated) {
+    check(decl is KSClassDeclaration)
+
+    val classBuilder = TypeSpec.classBuilder(decl.simpleName.getShortName())
+      .addOriginatingKSFile(decl.containingFile!!)
+      .apply {
+        decl.getVisibility().toKModifier()?.let { addModifiers(it) }
+        addModifiers(decl.modifiers.mapNotNull { it.toKModifier() })
+      }
+    val classTypeParams = decl.typeParameters.toTypeParameterResolver()
+    classBuilder.addTypeVariables(decl.typeParameters.map { it.toTypeVariableName(classTypeParams) })
+
+    // Add properties
+    for (property in decl.getDeclaredProperties()) {
+      classBuilder.addProperty(
+        PropertySpec.builder(
+          property.simpleName.getShortName(),
+          property.type.toTypeName(classTypeParams)
+        )
+          .addOriginatingKSFile(decl.containingFile!!)
+          .mutable(property.isMutable)
+          .apply {
+            property.getVisibility().toKModifier()?.let { addModifiers(it) }
+            addModifiers(property.modifiers.mapNotNull { it.toKModifier() })
+          }
+          .build()
+      )
+    }
+
+    // Add functions
+    for (function in decl.getDeclaredFunctions().filterNot { it.isConstructor() }) {
+      val functionTypeParams = function.typeParameters.toTypeParameterResolver(classTypeParams)
+      classBuilder.addFunction(
+        FunSpec.builder(function.simpleName.getShortName())
+          .addOriginatingKSFile(decl.containingFile!!)
+          .apply {
+            function.getVisibility().toKModifier()?.let { addModifiers(it) }
+            addModifiers(function.modifiers.mapNotNull { it.toKModifier() })
+          }
+          .addTypeVariables(function.typeParameters.map { it.toTypeVariableName(functionTypeParams) })
+          .addParameters(
+            function.parameters.map { parameter ->
+              val parameterType = parameter.type.toTypeName(functionTypeParams)
+              parameter.name?.let {
+                ParameterSpec.builder(it.getShortName(), parameterType).build()
+              } ?: ParameterSpec.unnamed(parameterType)
+            }
+          )
+          .build()
+      )
+    }
+
+    val typeSpec = classBuilder.build()
+    val fileSpec = FileSpec.builder(decl.packageName.asString(), "Test${typeSpec.name}")
+      .addType(typeSpec)
+      .build()
+
+    // Ensure that we're properly de-duping these under the hood.
+    check(fileSpec.originatingKSFiles().size == 1)
+
+    val dependencies = fileSpec.kspDependencies(aggregating = true)
+    check(dependencies.originatingFiles.size == 1)
+    check(dependencies.originatingFiles[0] == decl.containingFile)
+
+    fileSpec.writeTo(env.codeGenerator, dependencies)
+  }
+}

--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
@@ -106,6 +106,7 @@ class TestProcessor(private val env: SymbolProcessorEnvironment) : SymbolProcess
               } ?: ParameterSpec.unnamed(parameterType)
             }
           )
+          .returns(function.returnType!!.toTypeName(functionTypeParams))
           .build()
       )
     }

--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
@@ -46,15 +46,9 @@ import com.squareup.kotlinpoet.ksp.writeTo
 @OptIn(KotlinPoetKspPreview::class)
 class TestProcessor(private val env: SymbolProcessorEnvironment) : SymbolProcessor {
 
-  // Temporary to disable multiple rounds in tests due to https://github.com/google/ksp/issues/621
-  private var hasRun = false
-
   override fun process(resolver: Resolver): List<KSAnnotated> {
-    if (!hasRun) {
-      hasRun = true
-      resolver.getSymbolsWithAnnotation(ExampleAnnotation::class.java.canonicalName)
-        .forEach(::process)
-    }
+    resolver.getSymbolsWithAnnotation(ExampleAnnotation::class.java.canonicalName)
+      .forEach(::process)
     return emptyList()
   }
 

--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
@@ -45,9 +45,16 @@ import com.squareup.kotlinpoet.ksp.writeTo
  */
 @OptIn(KotlinPoetKspPreview::class)
 class TestProcessor(private val env: SymbolProcessorEnvironment) : SymbolProcessor {
+
+  // Temporary to disable multiple rounds in tests due to https://github.com/google/ksp/issues/621
+  private var hasRun = false
+
   override fun process(resolver: Resolver): List<KSAnnotated> {
-    resolver.getSymbolsWithAnnotation(ExampleAnnotation::class.java.canonicalName)
-      .forEach(::process)
+    if (!hasRun) {
+      hasRun = true
+      resolver.getSymbolsWithAnnotation(ExampleAnnotation::class.java.canonicalName)
+        .forEach(::process)
+    }
     return emptyList()
   }
 

--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorProvider.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorProvider.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.ksp.test.processor
+
+import com.google.auto.service.AutoService
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+
+@AutoService(SymbolProcessorProvider::class)
+class TestProcessorProvider : SymbolProcessorProvider {
+  override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+    return TestProcessor(environment)
+  }
+}

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -56,15 +56,15 @@ class TestProcessorTest {
              var propF: T? = null
 
              fun functionA(): String {
-               TODO()
+               error()
              }
 
              fun functionB(): R {
-               TODO()
+               error()
              }
 
              fun <F> functionC(param1: String, param2: T, param3: F, param4: F?): R {
-               TODO()
+               error()
              }
 
              suspend fun functionD(

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -1,0 +1,109 @@
+/*
+  * Copyright (C) 2021 Square, Inc.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *    https://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package com.squareup.kotlinpoet.ksp.test.processor
+
+import com.google.common.truth.Truth.assertThat
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.SourceFile.Companion.kotlin
+import com.tschuchort.compiletesting.kspIncremental
+import com.tschuchort.compiletesting.kspSourcesDir
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class TestProcessorTest {
+
+  @Rule
+  @JvmField
+  val temporaryFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun smokeTest() {
+    val compilation = prepareCompilation(
+      kotlin(
+        "Example.kt",
+        """
+           package test
+           import com.squareup.kotlinpoet.ksp.test.processor.ExampleAnnotation
+
+           @ExampleAnnotation
+           class SmokeTestClass<T, R : Any, E : Enum<E>> {
+             private val propA: String = ""
+             internal val propB: String = ""
+             val propC: Int = 0
+             val propD: Int? = null
+             lateinit var propE: String
+             var propF: T? = null
+
+             fun functionA(): String {
+               TODO()
+             }
+
+             fun functionB(): R {
+               TODO()
+             }
+
+             fun <F> functionC(param1: String, param2: T, param3: F, param4: F?): R {
+               TODO()
+             }
+           }
+           """
+      )
+    )
+    val result = compilation.compile()
+    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    val generatedFileText = File(compilation.kspSourcesDir, "kotlin/test/TestSmokeTestClass.kt")
+      .readText()
+    assertThat(generatedFileText).isEqualTo(
+      """
+      TODO
+      """.trimIndent()
+    )
+  }
+
+  // TODO
+  //  - writeTo
+  //  - originating files
+  //  - typealias
+  //  - generic typealias
+  //  - class
+  //  - generic class
+  //  - function
+  //  - generic function
+  //  - generic property
+  //  - nullable type
+  //  - complicated self referencing generics
+  //  - generic annotation
+  //  - wildcardtypename
+  //  - unnamed parameter
+  //  - function types
+  //  - suspend types
+
+  private fun prepareCompilation(vararg sourceFiles: SourceFile): KotlinCompilation {
+    return KotlinCompilation()
+      .apply {
+        workingDir = temporaryFolder.root
+        inheritClassPath = true
+        symbolProcessorProviders = listOf(TestProcessorProvider())
+        sources = sourceFiles.asList()
+        verbose = false
+        kspIncremental = true // The default now
+      }
+  }
+}

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -40,6 +40,7 @@ class TestProcessorTest {
         "Example.kt",
         """
            package test
+
            import com.squareup.kotlinpoet.ksp.test.processor.ExampleAnnotation
 
            @ExampleAnnotation
@@ -72,7 +73,41 @@ class TestProcessorTest {
       .readText()
     assertThat(generatedFileText).isEqualTo(
       """
-      TODO
+      package test
+
+      import kotlin.Any
+      import kotlin.Enum
+      import kotlin.Int
+      import kotlin.String
+
+      public class SmokeTestClass<T, R : Any, E : Enum<E>> {
+        private val propA: String
+
+        internal val propB: String
+
+        public val propC: Int
+
+        public val propD: Int?
+
+        public lateinit var propE: String
+
+        public var propF: T?
+
+        public fun functionA(): String {
+        }
+
+        public fun functionB(): R {
+        }
+
+        public fun <F> functionC(
+          param1: String,
+          param2: T,
+          param3: F,
+          param4: F?
+        ): R {
+        }
+      }
+
       """.trimIndent()
     )
   }

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -43,6 +43,9 @@ class TestProcessorTest {
 
            import com.squareup.kotlinpoet.ksp.test.processor.ExampleAnnotation
 
+           typealias TypeAliasName = String
+           typealias GenericTypeAlias = List<String>
+
            @ExampleAnnotation
            class SmokeTestClass<T, R : Any, E : Enum<E>> {
              private val propA: String = ""
@@ -63,6 +66,42 @@ class TestProcessorTest {
              fun <F> functionC(param1: String, param2: T, param3: F, param4: F?): R {
                TODO()
              }
+
+             suspend fun functionD(
+               param1: () -> String,
+               param2: (String) -> String,
+               param3: String.() -> String
+             ) {
+             }
+
+             // A whole bunch of wild types from Moshi's codegen smoke tests
+             fun wildTypes(
+               age: Int,
+               nationalities: List<String>,
+               weight: Float,
+               tattoos: Boolean = false,
+               race: String?,
+               hasChildren: Boolean = false,
+               favoriteFood: String? = null,
+               favoriteDrink: String? = "Water",
+               wildcardOut: MutableList<out String>,
+               nullableWildcardOut: MutableList<out String?>,
+               wildcardIn: Array<in String>,
+               any: List<*>,
+               anyTwo: List<Any>,
+               anyOut: MutableList<out Any>,
+               nullableAnyOut: MutableList<out Any?>,
+               favoriteThreeNumbers: IntArray,
+               favoriteArrayValues: Array<String>,
+               favoriteNullableArrayValues: Array<String?>,
+               nullableSetListMapArrayNullableIntWithDefault: Set<List<Map<String, Array<IntArray?>>>>?,
+               // These are actually currently rendered incorrectly and always unwrapped
+               aliasedName: TypeAliasName,
+               genericAlias: GenericTypeAlias,
+               nestedArray: Array<Map<String, Any>>?
+             ) {
+
+             }
            }
            """
       )
@@ -76,9 +115,20 @@ class TestProcessorTest {
       package test
 
       import kotlin.Any
+      import kotlin.Array
+      import kotlin.Boolean
       import kotlin.Enum
+      import kotlin.Float
+      import kotlin.Function0
+      import kotlin.Function1
       import kotlin.Int
+      import kotlin.IntArray
       import kotlin.String
+      import kotlin.Unit
+      import kotlin.collections.List
+      import kotlin.collections.Map
+      import kotlin.collections.MutableList
+      import kotlin.collections.Set
 
       public class SmokeTestClass<T, R : Any, E : Enum<E>> {
         private val propA: String
@@ -106,6 +156,39 @@ class TestProcessorTest {
           param4: F?
         ): R {
         }
+
+        public suspend fun functionD(
+          param1: Function0<String>,
+          param2: Function1<String, String>,
+          param3: Function1<String, String>
+        ): Unit {
+        }
+
+        public fun wildTypes(
+          age: Int,
+          nationalities: List<String>,
+          weight: Float,
+          tattoos: Boolean,
+          race: String?,
+          hasChildren: Boolean,
+          favoriteFood: String?,
+          favoriteDrink: String?,
+          wildcardOut: MutableList<out String>,
+          nullableWildcardOut: MutableList<out String?>,
+          wildcardIn: Array<in String>,
+          any: List<*>,
+          anyTwo: List<Any>,
+          anyOut: MutableList<out Any>,
+          nullableAnyOut: MutableList<*>,
+          favoriteThreeNumbers: IntArray,
+          favoriteArrayValues: Array<String>,
+          favoriteNullableArrayValues: Array<String?>,
+          nullableSetListMapArrayNullableIntWithDefault: Set<List<Map<String, Array<IntArray?>>>>?,
+          aliasedName: String,
+          genericAlias: List<String>,
+          nestedArray: Array<Map<String, Any>>?
+        ): Unit {
+        }
       }
 
       """.trimIndent()
@@ -113,22 +196,12 @@ class TestProcessorTest {
   }
 
   // TODO
-  //  - writeTo
-  //  - originating files
   //  - typealias
   //  - generic typealias
-  //  - class
-  //  - generic class
-  //  - function
-  //  - generic function
-  //  - generic property
-  //  - nullable type
   //  - complicated self referencing generics
   //  - generic annotation
-  //  - wildcardtypename
   //  - unnamed parameter
-  //  - function types
-  //  - suspend types
+  //  - toTypeName() unwraps typealiases
 
   private fun prepareCompilation(vararg sourceFiles: SourceFile): KotlinCompilation {
     return KotlinCompilation()


### PR DESCRIPTION
This doesn't fully cover all the cases I can think of, but want to start with this.

Along the way this adds intro for modifiers and visibility.

The test infra for this is a simple `SymbolProcessor` that reads an annotated class and produces a stencil of its API with modifiers, properties, functions, all the correct type information.

Still TODO after this
- [x] Some TODOs listed in the test
- [x] The test processor has to force itself to only run one round due to https://github.com/google/ksp/issues/621. Note that this is only an issue for unit testing
- [x] type aliases need more work. The moshi implementation would always unwrap these but we likely don't want to do that here.