### PR TITLE
Correct generation of typealiases with type args

### DIFF
--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt
@@ -53,7 +53,8 @@ public fun KSType.toClassName(): ClassName {
  */
 @KotlinPoetKspPreview
 public fun KSType.toTypeName(
-  typeParamResolver: TypeParameterResolver = TypeParameterResolver.EMPTY
+  typeParamResolver: TypeParameterResolver = TypeParameterResolver.EMPTY,
+  typeArguments: List<KSTypeArgument> = emptyList(),
 ): TypeName {
   val type = when (val decl = declaration) {
     is KSClassDeclaration -> {
@@ -74,8 +75,10 @@ public fun KSType.toTypeName(
         .rawType()
         .withTypeArguments(mappedArgs)
 
+      val aliasArgs = typeArguments.map { it.toTypeName(typeParamResolver) }
+
       decl.toClassNameInternal()
-        .withTypeArguments(mappedArgs)
+        .withTypeArguments(aliasArgs)
         .copy(tags = mapOf(TypeAliasTag::class to TypeAliasTag(abbreviatedType)))
     }
     else -> error("Unsupported type: $declaration")
@@ -118,7 +121,7 @@ public fun KSTypeParameter.toTypeVariableName(
 public fun KSTypeArgument.toTypeName(
   typeParamResolver: TypeParameterResolver
 ): TypeName {
-  val typeName = type?.resolve()?.toTypeName(typeParamResolver) ?: return STAR
+  val typeName = type?.toTypeName(typeParamResolver) ?: return STAR
   return when (variance) {
     COVARIANT -> WildcardTypeName.producerOf(typeName)
     CONTRAVARIANT -> WildcardTypeName.consumerOf(typeName)
@@ -139,5 +142,5 @@ public fun KSTypeArgument.toTypeName(
 public fun KSTypeReference.toTypeName(
   typeParamResolver: TypeParameterResolver = TypeParameterResolver.EMPTY
 ): TypeName {
-  return resolve().toTypeName(typeParamResolver)
+  return resolve().toTypeName(typeParamResolver, element?.typeArguments.orEmpty())
 }

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt
@@ -53,8 +53,13 @@ public fun KSType.toClassName(): ClassName {
  */
 @KotlinPoetKspPreview
 public fun KSType.toTypeName(
-  typeParamResolver: TypeParameterResolver = TypeParameterResolver.EMPTY,
-  typeArguments: List<KSTypeArgument> = emptyList(),
+  typeParamResolver: TypeParameterResolver = TypeParameterResolver.EMPTY
+): TypeName = toTypeName(typeParamResolver, emptyList())
+
+@KotlinPoetKspPreview
+internal fun KSType.toTypeName(
+  typeParamResolver: TypeParameterResolver,
+  typeArguments: List<KSTypeArgument>,
 ): TypeName {
   val type = when (val decl = declaration) {
     is KSClassDeclaration -> {

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -46,6 +46,7 @@ class TestProcessorTest {
 
            typealias TypeAliasName = String
            typealias GenericTypeAlias = List<String>
+           typealias ParameterizedTypeAlias<T> = List<T>
 
            @ExampleAnnotation
            class SmokeTestClass<T, R : Any, E : Enum<E>> {
@@ -99,6 +100,7 @@ class TestProcessorTest {
                // These are actually currently rendered incorrectly and always unwrapped
                aliasedName: TypeAliasName,
                genericAlias: GenericTypeAlias,
+               parameterizedTypeAlias: ParameterizedTypeAlias<String>,
                nestedArray: Array<Map<String, Any>>?
              ) {
 
@@ -186,7 +188,8 @@ class TestProcessorTest {
           favoriteNullableArrayValues: Array<String?>,
           nullableSetListMapArrayNullableIntWithDefault: Set<List<Map<String, Array<IntArray?>>>>?,
           aliasedName: TypeAliasName,
-          genericAlias: GenericTypeAlias<String>,
+          genericAlias: GenericTypeAlias,
+          parameterizedTypeAlias: ParameterizedTypeAlias<String>,
           nestedArray: Array<Map<String, Any>>?
         ): Unit {
         }


### PR DESCRIPTION
If you had `typealias Foo = List<String>` then `toTypeName()` would
incorrectly generate `Foo<String>` instead of `Foo`. This is because
`KSType.arguments`, returns the arguments of the underlying type, _not_
the alias. In order to get the alias args you need to use
`KSTypeReference.element.typeArguments` instead.