### PR TITLE
Ignore java deprecated annotations on synthetic methods for annotations

### DIFF
--- a/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/classinspectors/ClassInspectorUtil.kt
+++ b/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/classinspectors/ClassInspectorUtil.kt
@@ -54,6 +54,7 @@ internal object ClassInspectorUtil {
   internal val JVM_FIELD_SPEC = AnnotationSpec.builder(JVM_FIELD).build()
   internal val JVM_SYNTHETIC = JvmSynthetic::class.asClassName()
   internal val JVM_SYNTHETIC_SPEC = AnnotationSpec.builder(JVM_SYNTHETIC).build()
+  internal val JAVA_DEPRECATED = java.lang.Deprecated::class.asClassName()
   private val JVM_TRANSIENT = Transient::class.asClassName()
   private val JVM_VOLATILE = Volatile::class.asClassName()
   private val IMPLICIT_FIELD_ANNOTATIONS = setOf(

--- a/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/classinspectors/ElementsClassInspector.kt
+++ b/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/classinspectors/ElementsClassInspector.kt
@@ -28,6 +28,7 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+import com.squareup.kotlinpoet.metadata.classinspectors.ClassInspectorUtil.JAVA_DEPRECATED
 import com.squareup.kotlinpoet.metadata.classinspectors.ClassInspectorUtil.JVM_NAME
 import com.squareup.kotlinpoet.metadata.classinspectors.ClassInspectorUtil.filterOutNullabilityAnnotations
 import com.squareup.kotlinpoet.metadata.hasAnnotations
@@ -421,6 +422,8 @@ public class ElementsClassInspector private constructor(
             val method = typeElement.lookupMethod(annotationsHolderSignature, ElementFilter::methodsIn)
               ?: return@let MethodData.SYNTHETIC
             annotations += method.annotationSpecs()
+              // Cover for https://github.com/square/kotlinpoet/issues/1046
+              .filterNot { it.typeName == JAVA_DEPRECATED }
           }
         }
 

--- a/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/classinspectors/ReflectiveClassInspector.kt
+++ b/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/classinspectors/ReflectiveClassInspector.kt
@@ -22,6 +22,7 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+import com.squareup.kotlinpoet.metadata.classinspectors.ClassInspectorUtil.JAVA_DEPRECATED
 import com.squareup.kotlinpoet.metadata.classinspectors.ClassInspectorUtil.filterOutNullabilityAnnotations
 import com.squareup.kotlinpoet.metadata.hasAnnotations
 import com.squareup.kotlinpoet.metadata.hasConstant
@@ -415,6 +416,8 @@ public class ReflectiveClassInspector private constructor(
                   " found in $targetClass."
               )
             annotations += method.annotationSpecs()
+              // Cover for https://github.com/square/kotlinpoet/issues/1046
+              .filterNot { it.typeName == JAVA_DEPRECATED }
           }
         }
 

--- a/interop/kotlinx-metadata/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecsTest.kt
+++ b/interop/kotlinx-metadata/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecsTest.kt
@@ -13,7 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("RemoveRedundantQualifierName", "RedundantSuspendModifier", "NOTHING_TO_INLINE")
+@file:OptIn(KotlinPoetMetadataPreview::class)
+@file:Suppress(
+  "DEPRECATION",
+  "NOTHING_TO_INLINE",
+  "RedundantSuspendModifier",
+  "RedundantUnitReturnType",
+  "RedundantVisibilityModifier",
+  "RemoveEmptyPrimaryConstructor",
+  "RemoveRedundantQualifierName",
+  "UNUSED_PARAMETER",
+  "unused",
+)
 package com.squareup.kotlinpoet.metadata.specs
 
 import com.google.common.truth.Truth.assertThat
@@ -40,8 +51,6 @@ import kotlin.annotation.AnnotationTarget.TYPE_PARAMETER
 import kotlin.properties.Delegates
 import kotlin.test.fail
 
-@KotlinPoetMetadataPreview
-@Suppress("unused", "UNUSED_PARAMETER")
 class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
 
   @Test


### PR DESCRIPTION
Resolves #1046. We can't properly test it because it's a kept-specific issue and our tests don't actually use kapt. Filed an issue on kapt separately here https://youtrack.jetbrains.com/issue/KT-48922