### PR TITLE
MkDocs 1.2.3

### DIFF
--- a/.github/workflows/mkdocs-requirements.txt
+++ b/.github/workflows/mkdocs-requirements.txt
@@ -5,7 +5,7 @@ livereload==2.6.3
 lunr==0.5.8
 Markdown==3.2.2
 MarkupSafe==1.1.1
-mkdocs==1.1.2
+mkdocs==1.2.3
 mkdocs-macros-plugin==0.4.9
 mkdocs-material==5.5.7
 mkdocs-material-extensions==1.0


### PR DESCRIPTION
Fixes [CVE-2021-40978](https://github.com/advisories/GHSA-qh9q-34h6-hcv9)