### PR TITLE
Switch AnnotationSpec.get() to use more portable arrayOf() syntax

### DIFF
--- a/interop/kotlinx-metadata/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecsTest.kt
+++ b/interop/kotlinx-metadata/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecsTest.kt
@@ -1744,7 +1744,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
       """
       @kotlin.SinceKotlin(version = "1.3")
       @kotlin.`annotation`.Retention(value = kotlin.`annotation`.AnnotationRetention.RUNTIME)
-      @kotlin.`annotation`.Target(allowedTargets = [kotlin.`annotation`.AnnotationTarget.CLASS])
+      @kotlin.`annotation`.Target(allowedTargets = arrayOf(kotlin.`annotation`.AnnotationTarget.CLASS))
       public annotation class Metadata(
         @get:kotlin.jvm.JvmName(name = "k")
         public val kind: kotlin.Int = throw NotImplementedError("Stub!"),
@@ -1779,7 +1779,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     assertThat(typeSpec.trimmedToString()).isEqualTo(
       """
       @kotlin.`annotation`.Retention(value = kotlin.`annotation`.AnnotationRetention.RUNTIME)
-      @kotlin.`annotation`.Target(allowedTargets = [kotlin.`annotation`.AnnotationTarget.CLASS])
+      @kotlin.`annotation`.Target(allowedTargets = arrayOf(kotlin.`annotation`.AnnotationTarget.CLASS))
       public annotation class Metadata(
         @get:kotlin.jvm.JvmName(name = "k")
         public val kind: kotlin.Int = throw NotImplementedError("Stub!"),

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -170,12 +170,12 @@ public class AnnotationSpec private constructor(
       builder.add("%T::class", t.asTypeName())
 
     override fun visitArray(values: List<AnnotationValue>, name: String): CodeBlock.Builder {
-      builder.add("[⇥⇥")
+      builder.add("arrayOf(⇥⇥")
       values.forEachIndexed { index, value ->
         if (index > 0) builder.add(", ")
         value.accept(this, name)
       }
-      builder.add("⇤⇤]")
+      builder.add("⇤⇤)")
       return builder
     }
   }
@@ -207,12 +207,12 @@ public class AnnotationSpec private constructor(
           val member = CodeBlock.builder()
           member.add("%L = ", method.name)
           if (value.javaClass.isArray) {
-            member.add("[⇥⇥")
+            member.add("arrayOf(⇥⇥")
             for (i in 0 until Array.getLength(value)) {
               if (i > 0) member.add(", ")
               member.add(Builder.memberForValue(Array.get(value, i)))
             }
-            member.add("⇤⇤]")
+            member.add("⇤⇤)")
             builder.addMember(member.build())
             continue
           }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
@@ -110,11 +110,11 @@ class AnnotationSpecTest {
         |  f = 11.1,
         |  j = AnnotationSpecTest.AnnotationA(),
         |  l = Override::class,
-        |  m = [9, 8, 1],
+        |  m = arrayOf(9, 8, 1),
         |  o = AnnotationSpecTest.Breakfast.PANCAKES,
         |  p = 1701,
         |  q = AnnotationSpecTest.AnnotationC(value = "bar"),
-        |  r = [Float::class, Double::class]
+        |  r = arrayOf(Float::class, Double::class)
         |)
         |public class Taco
         |""".trimMargin()
@@ -140,11 +140,11 @@ class AnnotationSpecTest {
         |  f = 11.1,
         |  j = AnnotationSpecTest.AnnotationA(),
         |  l = Override::class,
-        |  m = [9, 8, 1],
+        |  m = arrayOf(9, 8, 1),
         |  o = AnnotationSpecTest.Breakfast.PANCAKES,
         |  p = 1701,
         |  q = AnnotationSpecTest.AnnotationC(value = "bar"),
-        |  r = [Float::class, Double::class]
+        |  r = arrayOf(Float::class, Double::class)
         |)
         |public class IsAnnotated
         |""".trimMargin()
@@ -186,11 +186,11 @@ class AnnotationSpecTest {
         |@AnnotationSpecTest.HasDefaultsAnnotation(
         |  f = 11.1,
         |  l = Override::class,
-        |  m = [9, 8, 1],
+        |  m = arrayOf(9, 8, 1),
         |  o = AnnotationSpecTest.Breakfast.PANCAKES,
         |  p = 1701,
         |  q = AnnotationSpecTest.AnnotationC(value = "bar"),
-        |  r = [Float::class, Double::class]
+        |  r = arrayOf(Float::class, Double::class)
         |)
         |public class Taco
         |""".trimMargin()
@@ -217,18 +217,18 @@ class AnnotationSpecTest {
         |  d = 8,
         |  e = 9.0f,
         |  f = 11.1,
-        |  g = ['\u0000', '쫾', 'z', '€', 'ℕ', '"', '\'', '\t', '\n'],
+        |  g = arrayOf('\u0000', '쫾', 'z', '€', 'ℕ', '"', '\'', '\t', '\n'),
         |  h = true,
         |  i = AnnotationSpecTest.Breakfast.WAFFLES,
         |  j = AnnotationSpecTest.AnnotationA(),
         |  k = "maple",
         |  l = Override::class,
-        |  m = [9, 8, 1],
-        |  n = [AnnotationSpecTest.Breakfast.WAFFLES, AnnotationSpecTest.Breakfast.PANCAKES],
+        |  m = arrayOf(9, 8, 1),
+        |  n = arrayOf(AnnotationSpecTest.Breakfast.WAFFLES, AnnotationSpecTest.Breakfast.PANCAKES),
         |  o = AnnotationSpecTest.Breakfast.PANCAKES,
         |  p = 1701,
         |  q = AnnotationSpecTest.AnnotationC(value = "bar"),
-        |  r = [Float::class, Double::class]
+        |  r = arrayOf(Float::class, Double::class)
         |)
         |public class Taco
         |""".trimMargin()
@@ -359,7 +359,8 @@ class AnnotationSpecTest {
             |import java.lang.Boolean
             |import java.lang.Object
             |
-            |@JavaClassWithArrayValueAnnotation.AnnotationWithArrayValue(value = [Object::class, Boolean::class])
+            |@JavaClassWithArrayValueAnnotation.AnnotationWithArrayValue(value = arrayOf(Object::class,
+            |        Boolean::class))
             |public class Result
             |""".trimMargin()
     )
@@ -387,7 +388,7 @@ class AnnotationSpecTest {
         |import java.lang.Object
         |import kotlin.Boolean
         |
-        |@AnnotationSpecTest.AnnotationWithArrayValue(value = [Object::class, Boolean::class])
+        |@AnnotationSpecTest.AnnotationWithArrayValue(value = arrayOf(Object::class, Boolean::class))
         |public class Result
         """.trimMargin()
     )
@@ -408,7 +409,8 @@ class AnnotationSpecTest {
         |import java.lang.Boolean
         |import java.lang.Object
         |
-        |@JavaClassWithArrayValueAnnotation.AnnotationWithArrayValue(value = [Object::class, Boolean::class])
+        |@JavaClassWithArrayValueAnnotation.AnnotationWithArrayValue(value = arrayOf(Object::class,
+        |        Boolean::class))
         |public class Result
         """.trimMargin()
     )
@@ -428,7 +430,7 @@ class AnnotationSpecTest {
         |import java.lang.Object
         |import kotlin.Boolean
         |
-        |@AnnotationSpecTest.AnnotationWithArrayValue(value = [Object::class, Boolean::class])
+        |@AnnotationSpecTest.AnnotationWithArrayValue(value = arrayOf(Object::class, Boolean::class))
         |public class Result
         """.trimMargin()
     )


### PR DESCRIPTION
This allows these annotation specs' members to be more portable regardless of whether it's used as an annotation or constructor called. See https://github.com/square/moshi/pull/1390#issuecomment-944953034 for more details