### PR TITLE
Disallow enum constants and properties called "name" and "ordinal"

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -651,7 +651,7 @@ public class TypeSpec private constructor(
       typeSpec: TypeSpec = anonymousClassBuilder().build()
     ): Builder = apply {
       require(name != "name" && name != "ordinal") {
-        "constant with name \"$name\" conflicts with a property with the same name"
+        "constant with name \"$name\" conflicts with a supertype member with the same name"
       }
       enumConstants[name] = typeSpec
     }

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -650,6 +650,9 @@ public class TypeSpec private constructor(
       name: String,
       typeSpec: TypeSpec = anonymousClassBuilder().build()
     ): Builder = apply {
+      require(name != "name" && name != "ordinal") {
+        "constant with name \"$name\" conflicts with a property with the same name"
+      }
       enumConstants[name] = typeSpec
     }
 
@@ -664,6 +667,11 @@ public class TypeSpec private constructor(
         }
         require(propertySpec.getter == null && propertySpec.setter == null) {
           "properties in expect classes can't have getters and setters"
+        }
+      }
+      if (isEnum) {
+        require(propertySpec.name != "name" && propertySpec.name != "ordinal") {
+          "${propertySpec.name} is a final supertype member and can't be redeclared or overridden"
         }
       }
       propertySpecs += propertySpec

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -48,6 +48,7 @@ import kotlin.reflect.KFunction
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.fail
 
 class TypeSpecTest {
@@ -5013,6 +5014,42 @@ class TypeSpecTest {
 
       """.trimIndent()
     )
+  }
+
+  // https://github.com/square/kotlinpoet/issues/1183
+  @Test fun `forbidden enum constant names`() {
+    var exception = assertFailsWith<IllegalArgumentException> {
+      TypeSpec.enumBuilder("Topping")
+        .addEnumConstant("name")
+    }
+    assertThat(exception.message)
+      .isEqualTo("constant with name \"name\" conflicts with a property with the same name")
+
+    @Suppress("RemoveExplicitTypeArguments")
+    exception = assertFailsWith<IllegalArgumentException> {
+      TypeSpec.enumBuilder("Topping")
+        .addEnumConstant("ordinal")
+    }
+    assertThat(exception.message)
+      .isEqualTo("constant with name \"ordinal\" conflicts with a property with the same name")
+  }
+
+  // https://github.com/square/kotlinpoet/issues/1183
+  @Test fun `forbidden enum property names`() {
+    var exception = assertFailsWith<IllegalArgumentException> {
+      TypeSpec.enumBuilder("Topping")
+        .addProperty("name", String::class)
+    }
+    assertThat(exception.message)
+      .isEqualTo("name is a final supertype member and can't be redeclared or overridden")
+
+    @Suppress("RemoveExplicitTypeArguments")
+    exception = assertFailsWith<IllegalArgumentException> {
+      TypeSpec.enumBuilder("Topping")
+        .addProperty("ordinal", String::class)
+    }
+    assertThat(exception.message)
+      .isEqualTo("ordinal is a final supertype member and can't be redeclared or overridden")
   }
 
   companion object {

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -5022,16 +5022,18 @@ class TypeSpecTest {
       TypeSpec.enumBuilder("Topping")
         .addEnumConstant("name")
     }
-    assertThat(exception.message)
-      .isEqualTo("constant with name \"name\" conflicts with a property with the same name")
+    assertThat(exception.message).isEqualTo(
+      "constant with name \"name\" conflicts with a supertype member with the same name"
+    )
 
     @Suppress("RemoveExplicitTypeArguments")
     exception = assertFailsWith<IllegalArgumentException> {
       TypeSpec.enumBuilder("Topping")
         .addEnumConstant("ordinal")
     }
-    assertThat(exception.message)
-      .isEqualTo("constant with name \"ordinal\" conflicts with a property with the same name")
+    assertThat(exception.message).isEqualTo(
+      "constant with name \"ordinal\" conflicts with a supertype member with the same name"
+    )
   }
 
   // https://github.com/square/kotlinpoet/issues/1183
@@ -5040,16 +5042,18 @@ class TypeSpecTest {
       TypeSpec.enumBuilder("Topping")
         .addProperty("name", String::class)
     }
-    assertThat(exception.message)
-      .isEqualTo("name is a final supertype member and can't be redeclared or overridden")
+    assertThat(exception.message).isEqualTo(
+      "name is a final supertype member and can't be redeclared or overridden"
+    )
 
     @Suppress("RemoveExplicitTypeArguments")
     exception = assertFailsWith<IllegalArgumentException> {
       TypeSpec.enumBuilder("Topping")
         .addProperty("ordinal", String::class)
     }
-    assertThat(exception.message)
-      .isEqualTo("ordinal is a final supertype member and can't be redeclared or overridden")
+    assertThat(exception.message).isEqualTo(
+      "ordinal is a final supertype member and can't be redeclared or overridden"
+    )
   }
 
   companion object {


### PR DESCRIPTION
Since it's a well-known limitation, perhaps it does make sense to validate it in the library.

Fixes #1183 