### PR TITLE
Add `Unit` and `CharSequence` convert

### DIFF
--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/PoetInterop.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/PoetInterop.kt
@@ -18,6 +18,7 @@ package com.squareup.kotlinpoet.javapoet
 /** Various JavaPoet and KotlinPoet representations of some common types. */
 @OptIn(KotlinPoetJavaPoetPreview::class)
 internal object PoetInterop {
+  internal val CN_JAVA_CHAR_SEQUENCE = JClassName.get("java.lang", "CharSequence")
   internal val CN_JAVA_STRING = JClassName.get("java.lang", "String")
   internal val CN_JAVA_LIST = JClassName.get("java.util", "List")
   internal val CN_JAVA_SET = JClassName.get("java.util", "Set")

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/j2kInterop.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/j2kInterop.kt
@@ -24,6 +24,7 @@ import com.squareup.kotlinpoet.BYTE
 import com.squareup.kotlinpoet.BYTE_ARRAY
 import com.squareup.kotlinpoet.CHAR
 import com.squareup.kotlinpoet.CHAR_ARRAY
+import com.squareup.kotlinpoet.CHAR_SEQUENCE
 import com.squareup.kotlinpoet.DOUBLE
 import com.squareup.kotlinpoet.DOUBLE_ARRAY
 import com.squareup.kotlinpoet.ENUM
@@ -41,6 +42,7 @@ import com.squareup.kotlinpoet.SHORT
 import com.squareup.kotlinpoet.SHORT_ARRAY
 import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.STRING
+import com.squareup.kotlinpoet.UNIT
 
 @KotlinPoetJavaPoetPreview
 public fun JClassName.toKClassName(): KClassName {
@@ -53,7 +55,9 @@ public fun JClassName.toKClassName(): KClassName {
     JTypeName.LONG.box() -> LONG
     JTypeName.FLOAT.box() -> FLOAT
     JTypeName.DOUBLE.box() -> DOUBLE
+    JTypeName.VOID.box() -> UNIT
     JTypeName.OBJECT -> ANY
+    PoetInterop.CN_JAVA_CHAR_SEQUENCE -> CHAR_SEQUENCE
     PoetInterop.CN_JAVA_STRING -> STRING
     PoetInterop.CN_JAVA_LIST -> LIST
     PoetInterop.CN_JAVA_SET -> SET
@@ -122,6 +126,7 @@ public fun JTypeName.toKTypeName(): KTypeName {
       JTypeName.LONG -> LONG
       JTypeName.FLOAT -> FLOAT
       JTypeName.DOUBLE -> DOUBLE
+      JTypeName.VOID -> UNIT
       else -> error("Unrecognized type $this")
     }
   }

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/j2kInterop.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/j2kInterop.kt
@@ -42,7 +42,6 @@ import com.squareup.kotlinpoet.SHORT
 import com.squareup.kotlinpoet.SHORT_ARRAY
 import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.STRING
-import com.squareup.kotlinpoet.UNIT
 
 @KotlinPoetJavaPoetPreview
 public fun JClassName.toKClassName(): KClassName {
@@ -55,7 +54,6 @@ public fun JClassName.toKClassName(): KClassName {
     JTypeName.LONG.box() -> LONG
     JTypeName.FLOAT.box() -> FLOAT
     JTypeName.DOUBLE.box() -> DOUBLE
-    JTypeName.VOID.box() -> UNIT
     JTypeName.OBJECT -> ANY
     PoetInterop.CN_JAVA_CHAR_SEQUENCE -> CHAR_SEQUENCE
     PoetInterop.CN_JAVA_STRING -> STRING
@@ -126,7 +124,6 @@ public fun JTypeName.toKTypeName(): KTypeName {
       JTypeName.LONG -> LONG
       JTypeName.FLOAT -> FLOAT
       JTypeName.DOUBLE -> DOUBLE
-      JTypeName.VOID -> UNIT
       else -> error("Unrecognized type $this")
     }
   }

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/k2jInterop.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/k2jInterop.kt
@@ -47,7 +47,6 @@ import com.squareup.kotlinpoet.SHORT
 import com.squareup.kotlinpoet.SHORT_ARRAY
 import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.STRING
-import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.U_BYTE
 import com.squareup.kotlinpoet.U_BYTE_ARRAY
 import com.squareup.kotlinpoet.U_INT
@@ -68,7 +67,6 @@ public fun KClassName.toJClassName(boxIfPrimitive: Boolean = false): JTypeName {
     LONG, U_LONG -> JTypeName.LONG.boxIfPrimitive(boxIfPrimitive || isNullable)
     FLOAT -> JTypeName.FLOAT.boxIfPrimitive(boxIfPrimitive || isNullable)
     DOUBLE -> JTypeName.DOUBLE.boxIfPrimitive(boxIfPrimitive || isNullable)
-    UNIT -> JTypeName.VOID
     ANY -> JTypeName.OBJECT
     CHAR_SEQUENCE -> PoetInterop.CN_JAVA_CHAR_SEQUENCE
     STRING -> PoetInterop.CN_JAVA_STRING

--- a/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/k2jInterop.kt
+++ b/interop/javapoet/src/main/kotlin/com/squareup/kotlinpoet/javapoet/k2jInterop.kt
@@ -25,6 +25,7 @@ import com.squareup.kotlinpoet.BYTE
 import com.squareup.kotlinpoet.BYTE_ARRAY
 import com.squareup.kotlinpoet.CHAR
 import com.squareup.kotlinpoet.CHAR_ARRAY
+import com.squareup.kotlinpoet.CHAR_SEQUENCE
 import com.squareup.kotlinpoet.DOUBLE
 import com.squareup.kotlinpoet.DOUBLE_ARRAY
 import com.squareup.kotlinpoet.Dynamic
@@ -46,6 +47,7 @@ import com.squareup.kotlinpoet.SHORT
 import com.squareup.kotlinpoet.SHORT_ARRAY
 import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.STRING
+import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.U_BYTE
 import com.squareup.kotlinpoet.U_BYTE_ARRAY
 import com.squareup.kotlinpoet.U_INT
@@ -66,7 +68,9 @@ public fun KClassName.toJClassName(boxIfPrimitive: Boolean = false): JTypeName {
     LONG, U_LONG -> JTypeName.LONG.boxIfPrimitive(boxIfPrimitive || isNullable)
     FLOAT -> JTypeName.FLOAT.boxIfPrimitive(boxIfPrimitive || isNullable)
     DOUBLE -> JTypeName.DOUBLE.boxIfPrimitive(boxIfPrimitive || isNullable)
+    UNIT -> JTypeName.VOID
     ANY -> JTypeName.OBJECT
+    CHAR_SEQUENCE -> PoetInterop.CN_JAVA_CHAR_SEQUENCE
     STRING -> PoetInterop.CN_JAVA_STRING
     LIST, MUTABLE_LIST -> PoetInterop.CN_JAVA_LIST
     SET, MUTABLE_SET -> PoetInterop.CN_JAVA_SET


### PR DESCRIPTION
KotlinPoet Version: 1.10.2
kotlinpoet-javapoet Version: 1.10.2
Ksp Version: 1.5.31-1.0.0

```java
class Taco {
    public void add(CharSequence seasoning) { }
}
```

returnType
```kotlin
// Returns a KotlinPoet `ClassName` of value `kotlin.Unit`
val kTypeName = addKsFunction.returnType?.toTypeName()

// Returns a JavaPoet `ClassName` of value `kotlin.Unit`
val jTypeName = kTypeName?.toJTypeName()

```

paramType

```kotlin
// Returns a KotlinPoet `ClassName` of value `kotlin.CharSequence`
val kTypeName = seasoningKsValue.type.toTypeName()

// Returns a JavaPoet `ClassName` of value `kotlin.CharSequence`
val jTypeName = kTypeName.toJTypeName()
```

I expect get `void` and `java.lang.CharSequence`


