### PR TITLE
Implement basic support for script files via `FileSpec`

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -378,6 +378,8 @@ internal class CodeWriter constructor(
       is TypeSpec -> o.emit(this, null)
       is AnnotationSpec -> o.emit(this, inline = true, asParameter = isConstantContext)
       is PropertySpec -> o.emit(this, emptySet())
+      is FunSpec -> o.emit(this, null, setOf(KModifier.PUBLIC), true)
+      is TypeAliasSpec -> o.emit(this)
       is CodeBlock -> emitCode(o, isConstantContext = isConstantContext)
       else -> emit(o.toString())
     }

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/CodeWriter.kt
@@ -378,7 +378,12 @@ internal class CodeWriter constructor(
       is TypeSpec -> o.emit(this, null)
       is AnnotationSpec -> o.emit(this, inline = true, asParameter = isConstantContext)
       is PropertySpec -> o.emit(this, emptySet())
-      is FunSpec -> o.emit(this, null, setOf(KModifier.PUBLIC), true)
+      is FunSpec -> o.emit(
+        codeWriter = this,
+        enclosingName = null,
+        implicitModifiers = setOf(KModifier.PUBLIC),
+        includeKdocTags = true
+      )
       is TypeAliasSpec -> o.emit(this)
       is CodeBlock -> emitCode(o, isConstantContext = isConstantContext)
       else -> emit(o.toString())

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -427,7 +427,7 @@ public class FileSpec private constructor(
 
     /**
      * @param controlFlow the control flow construct and its code, such as "else if (foo == 10)".
-     * *     Shouldn't contain braces or newline characters.
+     * Shouldn't contain braces or newline characters.
      */
     public fun nextControlFlow(controlFlow: String, vararg args: Any): Builder = apply {
       body.nextControlFlow(controlFlow, *args)

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -257,11 +257,7 @@ public class FileSpec private constructor(
           "Use-site target ${annotationSpec.useSiteTarget} not supported for file annotations."
         )
       }
-      if (isScript) {
-        body.add("%L", spec)
-      } else {
-        annotations += spec
-      }
+      annotations += spec
     }
 
     public fun addAnnotation(annotation: ClassName): Builder =

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -419,7 +419,7 @@ public class FileSpec private constructor(
 
     /**
      * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
-     * * Shouldn't contain braces or newline characters.
+     * Shouldn't contain braces or newline characters.
      */
     public fun beginControlFlow(controlFlow: String, vararg args: Any): Builder = apply {
       body.beginControlFlow(controlFlow, *args)

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -53,9 +53,9 @@ public class FileSpec private constructor(
   public val name: String = builder.name
   public val members: List<Any> = builder.members.toList()
   public val body: CodeBlock = builder.body.build()
+  public val isScript: Boolean = builder.isScript
   private val memberImports = builder.memberImports.associateBy(Import::qualifiedName)
   private val indent = builder.indent
-  private val isScript = builder.isScript
   private val extension = if (isScript) "kts" else "kt"
 
   @Throws(IOException::class)
@@ -231,7 +231,7 @@ public class FileSpec private constructor(
   public class Builder internal constructor(
     public val packageName: String,
     public val name: String,
-    internal val isScript: Boolean,
+    public val isScript: Boolean,
   ) : Taggable.Builder<Builder> {
     internal val comment = CodeBlock.builder()
     internal val memberImports = sortedSetOf<Import>()
@@ -269,6 +269,7 @@ public class FileSpec private constructor(
     public fun addAnnotation(annotation: KClass<*>): Builder =
       addAnnotation(annotation.asClassName())
 
+    /** Adds a file-site comment. This is prefixed to the start of the file and different from [addBodyComment]. */
     public fun addFileComment(format: String, vararg args: Any): Builder = apply {
       comment.add(format.replace(' ', '·'), *args)
     }
@@ -402,18 +403,31 @@ public class FileSpec private constructor(
     }
 
     public fun addCode(format: String, vararg args: Any?): Builder = apply {
+      check(isScript) {
+        "addCode() is only allowed in script files"
+      }
       body.add(format, *args)
     }
 
     public fun addNamedCode(format: String, args: Map<String, *>): Builder = apply {
+      check(isScript) {
+        "addNamedCode() is only allowed in script files"
+      }
       body.addNamed(format, args)
     }
 
     public fun addCode(codeBlock: CodeBlock): Builder = apply {
+      check(isScript) {
+        "addCode() is only allowed in script files"
+      }
       body.add(codeBlock)
     }
 
+    /** Adds a comment to the body of this script file in the order that it was added. */
     public fun addBodyComment(format: String, vararg args: Any): Builder = apply {
+      check(isScript) {
+        "addBodyComment() is only allowed in script files"
+      }
       body.add("//·${format.replace(' ', '·')}\n", *args)
     }
 
@@ -422,6 +436,9 @@ public class FileSpec private constructor(
      * Shouldn't contain braces or newline characters.
      */
     public fun beginControlFlow(controlFlow: String, vararg args: Any): Builder = apply {
+      check(isScript) {
+        "beginControlFlow() is only allowed in script files"
+      }
       body.beginControlFlow(controlFlow, *args)
     }
 
@@ -430,18 +447,30 @@ public class FileSpec private constructor(
      * Shouldn't contain braces or newline characters.
      */
     public fun nextControlFlow(controlFlow: String, vararg args: Any): Builder = apply {
+      check(isScript) {
+        "nextControlFlow() is only allowed in script files"
+      }
       body.nextControlFlow(controlFlow, *args)
     }
 
     public fun endControlFlow(): Builder = apply {
+      check(isScript) {
+        "endControlFlow() is only allowed in script files"
+      }
       body.endControlFlow()
     }
 
     public fun addStatement(format: String, vararg args: Any): Builder = apply {
+      check(isScript) {
+        "addStatement() is only allowed in script files"
+      }
       body.addStatement(format, *args)
     }
 
     public fun clearBody(): Builder = apply {
+      check(isScript) {
+        "clearBody() is only allowed in script files"
+      }
       body.clear()
     }
 

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileReadingTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileReadingTest.kt
@@ -54,7 +54,7 @@ class FileReadingTest {
   @Test fun javaFileObjectInputStreamIsUtf8() {
     val source = FileSpec.builder("foo", "Test")
       .addType(TypeSpec.classBuilder("Test").build())
-      .addComment("Pi\u00f1ata\u00a1")
+      .addFileComment("Pi\u00f1ata\u00a1")
       .build()
     val bytes = ByteStreams.toByteArray(source.toJavaFileObject().openInputStream())
 

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -733,7 +733,7 @@ class FileSpecTest {
   @Test fun topOfFileComment() {
     val source = FileSpec.builder("com.squareup.tacos", "Taco")
       .addType(TypeSpec.classBuilder("Taco").build())
-      .addComment("Generated %L by KotlinPoet. DO NOT EDIT!", "2015-01-13")
+      .addFileComment("Generated %L by KotlinPoet. DO NOT EDIT!", "2015-01-13")
       .build()
     assertThat(source.toString()).isEqualTo(
       """
@@ -748,7 +748,7 @@ class FileSpecTest {
   @Test fun emptyLinesInTopOfFileComment() {
     val source = FileSpec.builder("com.squareup.tacos", "Taco")
       .addType(TypeSpec.classBuilder("Taco").build())
-      .addComment("\nGENERATED FILE:\n\nDO NOT EDIT!\n")
+      .addFileComment("\nGENERATED FILE:\n\nDO NOT EDIT!\n")
       .build()
     assertThat(source.toString()).isEqualTo(
       """
@@ -877,7 +877,7 @@ class FileSpecTest {
   @Test fun generalBuilderEqualityTest() {
     val source = FileSpec.builder("com.squareup.tacos", "Taco")
       .addAnnotation(JvmMultifileClass::class)
-      .addComment("Generated 2015-01-13 by KotlinPoet. DO NOT EDIT!")
+      .addFileComment("Generated 2015-01-13 by KotlinPoet. DO NOT EDIT!")
       .addImport("com.squareup.tacos.internal", "INGREDIENTS")
       .addTypeAlias(TypeAliasSpec.builder("Int8", Byte::class).build())
       .indent("  ")
@@ -951,10 +951,10 @@ class FileSpecTest {
   @Test fun clearComment() {
     val builder = FileSpec.builder("com.taco", "Taco")
       .addFunction(FunSpec.builder("aFunction").build())
-      .addComment("Hello!")
+      .addFileComment("Hello!")
 
     builder.clearComment()
-      .addComment("Goodbye!")
+      .addFileComment("Goodbye!")
 
     assertThat(builder.build().comment.toString()).isEqualTo("Goodbye!")
   }
@@ -1042,7 +1042,7 @@ class FileSpecTest {
 
   @Test fun longComment() {
     val file = FileSpec.builder("com.squareup.tacos", "Taco")
-      .addComment(
+      .addFileComment(
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do " +
           "eiusmod tempor incididunt ut labore et dolore magna aliqua."
       )
@@ -1094,6 +1094,40 @@ class FileSpecTest {
       |public fun f2(): Unit {
       |  // this is a very very very very very very very very very very long line with a very long lambda type: suspend String.(foo: List<Map<in String, Collection<Map<FileSpecTest.WackyKey, out FileSpecTest.OhNoThisDoesNotCompile>>>>) -> String
       |}
+      |""".trimMargin()
+    )
+  }
+
+  @Test fun simpleScriptTest() {
+    val spec = FileSpec.scriptBuilder("Taco")
+      .addProperty(PropertySpec.builder("prop", String::class).initializer("\"hi\"").build())
+      .addCode("\n")
+      .addStatement("println(%S)", "hello!")
+      .addCode("\n")
+      .addFunction(
+        FunSpec.builder("localFun")
+          .build()
+      )
+      .addCode("\n")
+      .addType(TypeSpec.classBuilder("Yay").build())
+      .addCode("\n")
+      .addStatement("val yayInstance = Yay()")
+      .build()
+    assertThat(spec.toString()).isEqualTo(
+      """
+      |import kotlin.String
+      |import kotlin.Unit
+      |
+      |val prop: String = "hi"
+      |
+      |println("hello!")
+      |
+      |public fun localFun(): Unit {
+      |}
+      |
+      |public class Yay
+      |
+      |val yayInstance = Yay()
       |""".trimMargin()
     )
   }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileWritingTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileWritingTest.kt
@@ -278,7 +278,7 @@ class FileWritingTest {
   @Test fun fileIsUtf8() {
     val source = FileSpec.builder("foo", "Taco")
       .addType(TypeSpec.classBuilder("Taco").build())
-      .addComment("Pi\u00f1ata\u00a1")
+      .addFileComment("Pi\u00f1ata\u00a1")
       .build()
     source.writeTo(fsRoot)
 

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TaggableTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TaggableTest.kt
@@ -91,7 +91,7 @@ class TaggableTest(val builder: Taggable.Builder<*>) {
       is FileSpec.Builder -> build().apply {
         toBuilder()
           .tag(1)
-          .addComment("Test")
+          .addFileComment("Test")
           .build()
       }
       is FunSpec.Builder -> build().apply {


### PR DESCRIPTION
Resolves #608

This implements a basic entry-point + impl for generating script files via `FileSpec`. Entry starts via `FileSpec.scriptBuilder`, which then imposes certain behaviors under the hood.

Namely - when it's a script, it will add all members plus new exposed codeblock APIs to an internal `body` CodeBlock. This ensures that everything added here reflects the order they were added, and requires adding support for `FunSpec` and `TypeAliasSpec` literals too. This is sort of a net bonus as local functions are also now easy to generate.

There's probably a few more rough edges here, namely condition checks (guarding codeblock APIs' use when not a script, etc). Starting with this to get feedback and go from here!

Another option question is whether or not _these_ files would be worth dropping implicit kotlin.* imports for, as they're quite unconventional to have in scripts