### PR TITLE
Add basic support for default imports

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -167,7 +167,6 @@ public class FileSpec private constructor(
       .filterNot(defaultImportsFilter)
       .toSortedSet()
       .plus(aliasedImports.map { it.toString() }.toSortedSet())
-      .toList()
 
     if (imports.isNotEmpty()) {
       for (import in imports) {

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -150,7 +150,7 @@ public class FileSpec private constructor(
     val importedMemberNames = codeWriter.importedMembers.values.map { it.canonicalName }
 
     // If we don't have default imports or are collecting them, we don't need to filter
-    var defaultImportsFilter: (String) -> Boolean = { true }
+    var defaultImportsFilter: (String) -> Boolean = { false }
     if (!collectingImports && defaultImports.isNotEmpty()) {
       val defaultImports = defaultImports.map(String::escapeSegmentsIfNecessary)
       defaultImportsFilter = { importName ->

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -150,10 +150,10 @@ public class FileSpec private constructor(
     val importedMemberNames = codeWriter.importedMembers.values.map { it.canonicalName }
 
     // If we don't have default imports or are collecting them, we don't need to filter
-    var defaultImportsFilter: (String) -> Boolean = { false }
+    var isDefaultImport: (String) -> Boolean = { false }
     if (!collectingImports && defaultImports.isNotEmpty()) {
       val defaultImports = defaultImports.map(String::escapeSegmentsIfNecessary)
-      defaultImportsFilter = { importName ->
+      isDefaultImport = { importName ->
         importName.substringBeforeLast(".") in defaultImports
       }
     }
@@ -164,7 +164,7 @@ public class FileSpec private constructor(
       .filterNot { it in memberImports.keys }
       .map { it.escapeSegmentsIfNecessary() }
       .plus(nonAliasedImports.asSequence().map { it.toString() })
-      .filterNot(defaultImportsFilter)
+      .filterNot(isDefaultImport)
       .toSortedSet()
       .plus(aliasedImports.map { it.toString() }.toSortedSet())
 

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -413,7 +413,12 @@ public class FileSpec private constructor(
       memberImports += Import(memberName.canonicalName, `as`)
     }
 
-    /** Adds a default import for the given [packageName]. */
+    /**
+     * Adds a default import for the given [packageName].
+     *
+     * The format of this should be the qualified name of the package, e.g. `kotlin`, `java.lang`,
+     * `org.gradle.api`, etc.
+     */
     public fun addDefaultPackageImport(packageName: String): Builder = apply {
       defaultImports += packageName
     }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -22,7 +22,9 @@ import com.squareup.kotlinpoet.KModifier.VARARG
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import java.util.Collections
 import java.util.Date
+import java.util.concurrent.Callable
 import java.util.concurrent.TimeUnit
+import java.util.function.Function
 import kotlin.test.Ignore
 import kotlin.test.Test
 
@@ -1128,6 +1130,29 @@ class FileSpecTest {
       |public class Yay
       |
       |val yayInstance = Yay()
+      |""".trimMargin()
+    )
+  }
+
+  @Test fun defaultImports() {
+    val spec = FileSpec.scriptBuilder("Taco")
+      .addProperty(PropertySpec.builder("prop0", STRING.copy(nullable = true)).initializer("null").build())
+      .addProperty(PropertySpec.builder("prop1", INT.copy(nullable = true)).initializer("null").build())
+      .addProperty(PropertySpec.builder("prop2", typeNameOf<Map<String, Any>?>()).initializer("null").build())
+      .addProperty(PropertySpec.builder("prop3", typeNameOf<Callable<String>?>()).initializer("null").build())
+      .addProperty(PropertySpec.builder("prop4", typeNameOf<Function<Int, Int>?>()).initializer("null").build())
+      .addKotlinDefaultImports()
+      .addDefaultPackageImport("java.util.function")
+      .build()
+    assertThat(spec.toString()).isEqualTo(
+      """
+      |import java.util.concurrent.Callable
+      |
+      |val prop0: String? = null
+      |val prop1: Int? = null
+      |val prop2: Map<String, Any>? = null
+      |val prop3: @FunctionalInterface Callable<String>? = null
+      |val prop4: @FunctionalInterface Function<Int, Int>? = null
       |""".trimMargin()
     )
   }


### PR DESCRIPTION
This implements support for specifying custom default imports in `FileSpec`. The goal here is mostly targeting script generation, but I've also added a helper that allows for opt-in inclusion of kotlin's default imports to this (i.e. they would then be _excluded_ during writing).

Open to suggestions on other tests to add!

Ref #960, #361, #763