### PR TITLE
Add 'yield' to the list of reserved keywords

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -247,6 +247,9 @@ private val KEYWORDS = setOf(
   "tailrec",
   "value",
   "vararg",
+
+  // Other reserved keywords
+  "yield",
 )
 
 private const val ALLOWED_CHARACTER = '$'


### PR DESCRIPTION
This is not documented, but `yield` is actually reserved too ([source](https://github.com/JetBrains/kotlin/blob/v1.6.0/compiler/frontend/src/org/jetbrains/kotlin/psi/psiUtil/ReservedChecking.kt#L27)).