### PR TITLE
Inline val property if its getter is inline

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -65,7 +65,7 @@ public class PropertySpec private constructor(
     inlineAnnotations: Boolean = inline
   ) {
     val isInlineProperty = getter?.modifiers?.contains(KModifier.INLINE) ?: false &&
-      setter?.modifiers?.contains(KModifier.INLINE) ?: false
+      (!mutable || setter?.modifiers?.contains(KModifier.INLINE) ?: false)
     val propertyModifiers = if (isInlineProperty) modifiers + KModifier.INLINE else modifiers
     if (emitKdoc) {
       codeWriter.emitKdoc(kdoc.ensureEndsWithNewLine())

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -69,7 +69,7 @@ class PropertySpecTest {
     }.hasMessageThat().isEqualTo("parameterless setter cannot have code")
   }
 
-  @Test fun inlineSingleAccessor() {
+  @Test fun inlineSingleAccessorVal() {
     val prop = PropertySpec.builder("foo", String::class)
       .getter(
         FunSpec.getterBuilder()
@@ -81,7 +81,26 @@ class PropertySpecTest {
 
     assertThat(prop.toString()).isEqualTo(
       """
-      |val foo: kotlin.String
+      |inline val foo: kotlin.String
+      |  get() = "foo"
+      |""".trimMargin()
+    )
+  }
+
+  @Test fun inlineSingleAccessorVar() {
+    val prop = PropertySpec.builder("foo", String::class)
+      .mutable()
+      .getter(
+        FunSpec.getterBuilder()
+          .addModifiers(KModifier.INLINE)
+          .addStatement("return %S", "foo")
+          .build()
+      )
+      .build()
+
+    assertThat(prop.toString()).isEqualTo(
+      """
+      |var foo: kotlin.String
       |  inline get() = "foo"
       |""".trimMargin()
     )
@@ -255,8 +274,8 @@ class PropertySpecTest {
       .build()
     assertThat(prop.toString()).isEqualTo(
       """
-      |private val <T : kotlin.Any> kotlin.reflect.KClass<T>.someFunction: T
-      |  inline get() = stuff as T
+      |private inline val <T : kotlin.Any> kotlin.reflect.KClass<T>.someFunction: T
+      |  get() = stuff as T
       |""".trimMargin()
     )
   }
@@ -296,8 +315,8 @@ class PropertySpecTest {
       .build()
     assertThat(prop.toString()).isEqualTo(
       """
-      |private val <reified T> kotlin.reflect.KClass<T>.someFunction: T
-      |  inline get() = stuff as T
+      |private inline val <reified T> kotlin.reflect.KClass<T>.someFunction: T
+      |  get() = stuff as T
       |""".trimMargin()
     )
   }


### PR DESCRIPTION
Fixes #1217 

Potential followup: should we inline a property (whether val or var) if it only has one accessor and it's inline?