### PR TITLE
Fail compilation if you only pass one string to ClassName

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ClassName.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ClassName.kt
@@ -40,6 +40,13 @@ public class ClassName internal constructor(
   public constructor(packageName: String, simpleName: String, vararg simpleNames: String) :
     this(listOf(packageName, simpleName, *simpleNames))
 
+  @Deprecated(
+    "Simple names must not be empty. Did you forget an argument?",
+    level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith("ClassName(packageName, TODO())"),
+  )
+  public constructor(packageName: String) : this(packageName, listOf())
+
   /**
    * Returns a class name created from the given parts. For example, calling this with package name
    * `"java.util"` and simple names `"Map"`, `"Entry"` yields `Map.Entry`.

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
@@ -139,6 +139,7 @@ class ClassNameTest {
     // }
   }
 
+  @Suppress("DEPRECATION_ERROR") // Ensure still throws in case called from Java.
   @Test fun fromEmptySimpleName() {
     assertThrows<IllegalArgumentException> {
       ClassName("foo" /* no simple name */)


### PR DESCRIPTION
Tried to test, but even with `@Suppress("DEPRECATION_ERROR")` the compiler spit out the error.

Closes #1221 