### PR TITLE
Add support for context receivers @PropertySpec and fix issues with annotations

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -87,8 +87,8 @@ public class FunSpec private constructor(
     } else {
       codeWriter.emitKdoc(kdoc.ensureEndsWithNewLine())
     }
-    codeWriter.emitAnnotations(annotations, false)
     codeWriter.emitContextReceivers(contextReceiverTypes, suffix = "\n")
+    codeWriter.emitAnnotations(annotations, false)
     codeWriter.emitModifiers(modifiers, implicitModifiers)
 
     if (!isConstructor && !name.isAccessor) {
@@ -368,6 +368,7 @@ public class FunSpec private constructor(
     @ExperimentalKotlinPoetApi
     public fun contextReceivers(receiverTypes: Iterable<TypeName>): Builder = apply {
       check(!name.isConstructor) { "constructors cannot have context receivers" }
+      check(!name.isAccessor) { "$name cannot have context receivers" }
       contextReceiverTypes += receiverTypes
     }
 

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -60,7 +60,7 @@ public class PropertySpec private constructor(
     }
     if (contextReceiverTypes.isNotEmpty()) {
       check(!mutable) { "mutable properties cannot have context receivers" }
-      require(getter != null){ "immutable properties with context receivers require a $GETTER" }
+      require(getter != null) { "immutable properties with context receivers require a $GETTER" }
     }
   }
 

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -59,11 +59,10 @@ public class PropertySpec private constructor(
       "only a mutable property can have a setter"
     }
     if (contextReceiverTypes.isNotEmpty()) {
+      requireNotNull(getter) { "properties with context receivers require a $GETTER" }
       if (mutable) {
-        requireNotNull(getter) { "mutable properties with context receivers require a $GETTER" }
         requireNotNull(setter) { "mutable properties with context receivers require a $SETTER" }
       }
-      requireNotNull(getter) { "immutable properties with context receivers require a $GETTER" }
     }
   }
 

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -59,8 +59,11 @@ public class PropertySpec private constructor(
       "only a mutable property can have a setter"
     }
     if (contextReceiverTypes.isNotEmpty()) {
-      check(!mutable) { "mutable properties cannot have context receivers" }
-      require(getter != null) { "immutable properties with context receivers require a $GETTER" }
+      if (mutable) {
+        requireNotNull(getter) { "mutable properties with context receivers require a $GETTER" }
+        requireNotNull(setter) { "mutable properties with context receivers require a $SETTER" }
+      }
+      requireNotNull(getter) { "immutable properties with context receivers require a $GETTER" }
     }
   }
 

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -24,6 +24,7 @@ import javax.lang.model.element.Element
 import kotlin.reflect.KClass
 
 /** A generated property declaration. */
+@OptIn(ExperimentalKotlinPoetApi::class)
 public class PropertySpec private constructor(
   builder: Builder,
   private val tagMap: TagMap = builder.buildTagMap(),
@@ -42,6 +43,9 @@ public class PropertySpec private constructor(
   public val setter: FunSpec? = builder.setter
   public val receiverType: TypeName? = builder.receiverType
 
+  @ExperimentalKotlinPoetApi
+  public val contextReceiverTypes: List<TypeName> = builder.contextReceiverTypes.toImmutableList()
+
   init {
     require(
       typeVariables.none { it.isReified } ||
@@ -53,6 +57,10 @@ public class PropertySpec private constructor(
     }
     require(mutable || setter == null) {
       "only a mutable property can have a setter"
+    }
+    if (contextReceiverTypes.isNotEmpty()) {
+      check(!mutable) { "mutable properties cannot have context receivers" }
+      require(getter != null){ "immutable properties with context receivers require a $GETTER" }
     }
   }
 
@@ -70,6 +78,7 @@ public class PropertySpec private constructor(
     if (emitKdoc) {
       codeWriter.emitKdoc(kdoc.ensureEndsWithNewLine())
     }
+    codeWriter.emitContextReceivers(contextReceiverTypes, suffix = "\n")
     codeWriter.emitAnnotations(annotations, inlineAnnotations)
     codeWriter.emitModifiers(propertyModifiers, implicitModifiers)
     codeWriter.emitCode(if (mutable) "var·" else "val·")
@@ -174,6 +183,7 @@ public class PropertySpec private constructor(
     internal var getter: FunSpec? = null
     internal var setter: FunSpec? = null
     internal var receiverType: TypeName? = null
+    internal val contextReceiverTypes: MutableList<TypeName> = mutableListOf()
 
     public val annotations: MutableList<AnnotationSpec> = mutableListOf()
     public val modifiers: MutableList<KModifier> = mutableListOf()
@@ -269,6 +279,15 @@ public class PropertySpec private constructor(
     public fun receiver(receiverType: Type): Builder = receiver(receiverType.asTypeName())
 
     public fun receiver(receiverType: KClass<*>): Builder = receiver(receiverType.asTypeName())
+
+    @ExperimentalKotlinPoetApi
+    public fun contextReceivers(receiverTypes: Iterable<TypeName>): Builder = apply {
+      contextReceiverTypes += receiverTypes
+    }
+
+    @ExperimentalKotlinPoetApi
+    public fun contextReceivers(vararg receiverType: TypeName): Builder =
+      contextReceivers(receiverType.toList())
 
     public fun build(): PropertySpec {
       if (KModifier.INLINE in modifiers) {

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -18,6 +18,8 @@ package com.squareup.kotlinpoet
 import com.google.common.collect.Iterables.getOnlyElement
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.compile.CompilationRule
+import com.squareup.kotlinpoet.FunSpec.Companion.GETTER
+import com.squareup.kotlinpoet.FunSpec.Companion.SETTER
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import org.junit.Rule
 import java.io.Closeable
@@ -480,6 +482,22 @@ class FunSpecTest {
     )
   }
 
+  @Test fun annotatedFunctionWithContextReceiver() {
+    val funSpec = FunSpec.builder("foo")
+      .addAnnotation(AnnotationSpec.get(TestAnnotation()))
+      .contextReceivers(STRING)
+      .build()
+
+    assertThat(funSpec.toString()).isEqualTo(
+      """
+      |context(kotlin.String)
+      |@com.squareup.kotlinpoet.FunSpecTest.TestAnnotation
+      |public fun foo(): kotlin.Unit {
+      |}
+      |""".trimMargin()
+    )
+  }
+
   @Test fun functionWithAnnotatedContextReceiver() {
     val genericType = STRING.copy(annotations = listOf(AnnotationSpec.get(TestAnnotation())))
     val funSpec = FunSpec.builder("foo")
@@ -500,6 +518,18 @@ class FunSpecTest {
       FunSpec.constructorBuilder()
         .contextReceivers(STRING)
     }.hasMessageThat().isEqualTo("constructors cannot have context receivers")
+  }
+
+  @Test fun accessorWithContextReceiver() {
+    assertThrows<IllegalStateException> {
+      FunSpec.getterBuilder()
+        .contextReceivers(STRING)
+    }.hasMessageThat().isEqualTo("$GETTER cannot have context receivers")
+
+    assertThrows<IllegalStateException> {
+      FunSpec.setterBuilder()
+        .contextReceivers(STRING)
+    }.hasMessageThat().isEqualTo("$SETTER cannot have context receivers")
   }
 
   @Test fun functionParamSingleLambdaParam() {

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -590,7 +590,7 @@ class PropertySpecTest {
         )
         .build()
     }.hasMessageThat()
-      .isEqualTo("mutable properties with context receivers require a $GETTER")
+      .isEqualTo("properties with context receivers require a $GETTER")
   }
 
   @Test fun valWithContextReceiverWithoutGetter() {
@@ -600,7 +600,7 @@ class PropertySpecTest {
         .contextReceivers(INT)
         .build()
     }.hasMessageThat()
-      .isEqualTo("immutable properties with context receivers require a $GETTER")
+      .isEqualTo("properties with context receivers require a $GETTER")
   }
 
   @Test fun varWithContextReceiver() {


### PR DESCRIPTION
# Summary
As discussed in #1244, here is a PR to add support for context receivers @`PropertySpec`.

# Proposed Changes
1. Make `contextReceivers` available in `PropertySpec` builder
2. Throw exceptions when: property is mutable or immutable without a getter
3. Update `FunSpec` to throw exception when a context receiver is added to an accessor
4. Fix order in which context receivers and annotations are emitted: context receivers must come first