### PR TITLE
Work around KT-52315

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -115,7 +115,12 @@ public class TypeSpec private constructor(
       if (enumName != null) {
         codeWriter.emitKdoc(kdocWithConstructorParameters())
         codeWriter.emitAnnotations(annotationSpecs, false)
-        codeWriter.emitCode("%N", enumName)
+        // These aren't keywords anymore but still break if unquoted. https://youtrack.jetbrains.com/issue/KT-52315
+        if ((enumName == "header" || enumName == "impl") && superclassConstructorParametersBlock.isNotEmpty()) {
+          codeWriter.emitCode("`$enumName`")
+        } else {
+          codeWriter.emitCode("%N", enumName)
+        }
         if (superclassConstructorParametersBlock.isNotEmpty()) {
           codeWriter.emit("(")
           codeWriter.emitCode(superclassConstructorParametersBlock)

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -115,12 +115,7 @@ public class TypeSpec private constructor(
       if (enumName != null) {
         codeWriter.emitKdoc(kdocWithConstructorParameters())
         codeWriter.emitAnnotations(annotationSpecs, false)
-        // These aren't keywords anymore but still break if unquoted. https://youtrack.jetbrains.com/issue/KT-52315
-        if ((enumName == "header" || enumName == "impl") && superclassConstructorParametersBlock.isNotEmpty()) {
-          codeWriter.emitCode("`$enumName`")
-        } else {
-          codeWriter.emitCode("%N", enumName)
-        }
+        codeWriter.emitCode("%N", enumName)
         if (superclassConstructorParametersBlock.isNotEmpty()) {
           codeWriter.emit("(")
           codeWriter.emitCode(superclassConstructorParametersBlock)

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Util.kt
@@ -248,6 +248,10 @@ private val KEYWORDS = setOf(
   "value",
   "vararg",
 
+  // These aren't keywords anymore but still break some code if unescaped. https://youtrack.jetbrains.com/issue/KT-52315
+  "header",
+  "impl",
+
   // Other reserved keywords
   "yield",
 )

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -4899,7 +4899,7 @@ class TypeSpecTest {
   }
 
   // https://youtrack.jetbrains.com/issue/KT-52315
-  @Test fun escapeEnumConstantNamesWithConstructors() {
+  @Test fun escapeHeaderAndImplAsEnumConstantNames() {
     val primaryConstructor = FunSpec.constructorBuilder()
       .addParameter("int", Int::class)
       .build()

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -4898,6 +4898,43 @@ class TypeSpecTest {
     )
   }
 
+  // https://youtrack.jetbrains.com/issue/KT-52315
+  @Test fun escapeEnumConstantNamesWithConstructors() {
+    val primaryConstructor = FunSpec.constructorBuilder()
+      .addParameter("int", Int::class)
+      .build()
+    val enum = TypeSpec
+      .enumBuilder("MyEnum")
+      .primaryConstructor(primaryConstructor)
+      .addEnumConstant(
+        "header",
+        TypeSpec.anonymousClassBuilder()
+          .addSuperclassConstructorParameter("%L", 1)
+          .build()
+      )
+      .addEnumConstant(
+        "impl",
+        TypeSpec.anonymousClassBuilder()
+          .addSuperclassConstructorParameter("%L", 2)
+          .build()
+      )
+      .build()
+    assertThat(toString(enum)).isEqualTo(
+      """
+      |package com.squareup.tacos
+      |
+      |import kotlin.Int
+      |
+      |public enum class MyEnum(
+      |  int: Int,
+      |) {
+      |  `header`(1),
+      |  `impl`(2),
+      |}
+      |""".trimMargin()
+    )
+  }
+
   @Test fun escapeClassNames() {
     val type = TypeSpec.classBuilder("fun").build()
     assertThat(type.toString()).isEqualTo(


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-52315

`header` and `impl` are deprecated and do not behave as modifier
keywords anymore... except in this specific case, seemingly.