### PR TITLE
Fix KDoc link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1533,6 +1533,6 @@ License
 
  [dl]: https://search.maven.org/remote_content?g=com.squareup&a=kotlinpoet&v=LATEST
  [snap]: https://s01.oss.sonatype.org/content/repositories/snapshots/com/squareup/kotlinpoet/
- [kdoc]: https://square.github.io/kotlinpoet/1.x/kotlinpoet/com.squareup.kotlinpoet/
+ [kdoc]: https://square.github.io/kotlinpoet/1.x/kotlinpoet/kotlinpoet/com.squareup.kotlinpoet/
  [javapoet]: https://github.com/square/javapoet/
  [formatter]: https://developer.android.com/reference/java/util/Formatter.html


### PR DESCRIPTION
For convenience:
Older link: https://square.github.io/kotlinpoet/1.x/kotlinpoet/com.squareup.kotlinpoet/
Fixed link: https://square.github.io/kotlinpoet/1.x/kotlinpoet/kotlinpoet/com.squareup.kotlinpoet/

Alternatively some changes to the KDoc generation step to remove the extra `kotlinpoet` in the URL could be explored.