### PR TITLE
Support definitely non-nullable types

### DIFF
--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeVariableNameTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeVariableNameTest.kt
@@ -255,14 +255,14 @@ class TypeVariableNameTest {
 
   @Test
   fun definitelyNonNullableType_simple() {
-    val typeName = TypeVariableName("T").asDefinitelyNonNullableType()
+    val typeName = TypeVariableName("T").copy()
     assertThat(typeName.toString()).isEqualTo("T & Any")
   }
 
   @Test
   fun definitelyNonNullableType_errorWhenNonNullableMadeNullable() {
     assertFailsWith<IllegalArgumentException> {
-      TypeVariableName("T").asDefinitelyNonNullableType()
+      TypeVariableName("T").copy()
         .copy(nullable = true)
     }
   }
@@ -271,7 +271,7 @@ class TypeVariableNameTest {
   fun definitelyNonNullableType_errorWhenNullableMadeNonNullable() {
     assertFailsWith<IllegalArgumentException> {
       (TypeVariableName("T").copy(nullable = true) as TypeVariableName)
-        .asDefinitelyNonNullableType()
+        .copy()
     }
   }
 
@@ -279,7 +279,7 @@ class TypeVariableNameTest {
   fun definitelyNonNullableType_errorWhenNonNullAny() {
     assertFailsWith<IllegalArgumentException> {
       TypeVariableName("T", listOf(ANY))
-        .asDefinitelyNonNullableType()
+        .copy()
     }
   }
 }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeVariableNameTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeVariableNameTest.kt
@@ -19,6 +19,7 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.kotlinpoet.TypeVariableName.Companion.NULLABLE_ANY_LIST
 import java.io.Serializable
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 
 class TypeVariableNameTest {
   @Test fun nullableAnyIsImplicitBound() {
@@ -251,4 +252,34 @@ class TypeVariableNameTest {
   }
 
   class GenericClass<T>
+
+  @Test
+  fun definitelyNonNullableType_simple() {
+    val typeName = TypeVariableName("T").asDefinitelyNonNullableType()
+    assertThat(typeName.toString()).isEqualTo("T & Any")
+  }
+
+  @Test
+  fun definitelyNonNullableType_errorWhenNonNullableMadeNullable() {
+    assertFailsWith<IllegalArgumentException> {
+      TypeVariableName("T").asDefinitelyNonNullableType()
+        .copy(nullable = true)
+    }
+  }
+
+  @Test
+  fun definitelyNonNullableType_errorWhenNullableMadeNonNullable() {
+    assertFailsWith<IllegalArgumentException> {
+      (TypeVariableName("T").copy(nullable = true) as TypeVariableName)
+        .asDefinitelyNonNullableType()
+    }
+  }
+
+  @Test
+  fun definitelyNonNullableType_errorWhenNonNullAny() {
+    assertFailsWith<IllegalArgumentException> {
+      TypeVariableName("T", listOf(ANY))
+        .asDefinitelyNonNullableType()
+    }
+  }
 }


### PR DESCRIPTION
From https://kotlinlang.org/docs/whatsnew17.html#stable-definitely-non-nullable-types

Open to suggestions on the API for this, went back and forth on an explicit `asDefinitelyNonNullable()` or `copy(isDefinitelyNonNullable: Boolean)` overload. Also open to suggestions on whether or not any of the checks are cases we should silently "fix" for them, like setting `isDefinitelyNonNullable` to false if copying over as `nullable`.