### PR TITLE
Optimize holder interfaces

### DIFF
--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -742,6 +742,7 @@ public final class com/squareup/kotlinpoet/Taggable$Builder$DefaultImpls {
 public final class com/squareup/kotlinpoet/Taggable$DefaultImpls {
 	public static fun getTags (Lcom/squareup/kotlinpoet/Taggable;)Ljava/util/Map;
 	public static fun tag (Lcom/squareup/kotlinpoet/Taggable;Ljava/lang/Class;)Ljava/lang/Object;
+	public static fun tag (Lcom/squareup/kotlinpoet/Taggable;Lkotlin/reflect/KClass;)Ljava/lang/Object;
 }
 
 public final class com/squareup/kotlinpoet/TypeAliasSpec : com/squareup/kotlinpoet/Taggable {
@@ -798,7 +799,7 @@ public final class com/squareup/kotlinpoet/TypeAliasSpec$Companion {
 
 public abstract class com/squareup/kotlinpoet/TypeName : com/squareup/kotlinpoet/Taggable {
 	public static final field Companion Lcom/squareup/kotlinpoet/TypeName$Companion;
-	public synthetic fun <init> (ZLjava/util/List;Lcom/squareup/kotlinpoet/TagMap;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZLjava/util/List;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun copy (ZLjava/util/List;)Lcom/squareup/kotlinpoet/TypeName;
 	public abstract fun copy (ZLjava/util/List;Ljava/util/Map;)Lcom/squareup/kotlinpoet/TypeName;
 	public static synthetic fun copy$default (Lcom/squareup/kotlinpoet/TypeName;ZLjava/util/List;ILjava/lang/Object;)Lcom/squareup/kotlinpoet/TypeName;

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/OriginatingElementsHolder.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/OriginatingElementsHolder.kt
@@ -43,6 +43,7 @@ internal fun OriginatingElementsHolder.Builder<*>.buildOriginatingElements() =
 internal fun List<Element>.buildOriginatingElements() =
   OriginatingElements(toImmutableList())
 
-internal class OriginatingElements(
+@JvmInline
+internal value class OriginatingElements(
   override val originatingElements: List<Element>
 ) : OriginatingElementsHolder

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Taggable.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/Taggable.kt
@@ -148,7 +148,7 @@ public inline fun <reified T : Any> TypeAliasSpec.Builder.tag(tag: T?): TypeAlia
 public inline fun <reified T : Any> TypeSpec.Builder.tag(tag: T?): TypeSpec.Builder =
   tag(T::class, tag)
 
-internal fun Taggable.Builder<*>.buildTagMap(): TagMap = TagMap(tags.toImmutableMap())
+internal fun Taggable.Builder<*>.buildTagMap(): TagMap = TagMap(tags)
 
 @JvmInline
 internal value class TagMap private constructor(override val tags: Map<KClass<*>, Any>) : Taggable {


### PR DESCRIPTION
Started with #1269, but a new feature of Kotlin 1.7 is we can inline these holder classes to make them not allocate. https://kotlinlang.org/docs/whatsnew17.html#allow-implementation-by-delegation-to-an-inlined-value-of-an-inline-class