### PR TITLE
Fix StackOverflowError when calling KSTypeArgument.toTypeName() for a wildcard in a recursive type bound

### DIFF
--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt
@@ -159,12 +159,12 @@ public fun KSTypeParameter.toTypeVariableName(
 public fun KSTypeArgument.toTypeName(
   typeParamResolver: TypeParameterResolver = TypeParameterResolver.EMPTY
 ): TypeName {
-  val typeName = type?.toTypeName(typeParamResolver) ?: return STAR
+  val type = this.type ?: return STAR
   return when (variance) {
-    COVARIANT -> WildcardTypeName.producerOf(typeName)
-    CONTRAVARIANT -> WildcardTypeName.consumerOf(typeName)
+    COVARIANT -> WildcardTypeName.producerOf(type.toTypeName(typeParamResolver))
+    CONTRAVARIANT -> WildcardTypeName.consumerOf(type.toTypeName(typeParamResolver))
     Variance.STAR -> STAR
-    INVARIANT -> typeName
+    INVARIANT -> type.toTypeName(typeParamResolver)
   }
 }
 


### PR DESCRIPTION
### The Problem
When you call `toTypeName()` for a `KSType` that has a wildcard in the position of a recursive type bound, KotlinPoet ends up in an infinite recursion, resulting in a `StackOverflowError`.

For example, Kotlin enums implement `Enum<E : Enum<E>>`, and when you try to get the `TypeName` for this `val`, it fails.
```
val foo: Enum<*>
```

The infinite recursion occurs here:
```
...
at com.squareup.kotlinpoet.ksp.KsTypesKt.toTypeName(ksTypes.kt:182)
at com.squareup.kotlinpoet.ksp.KsTypesKt.toTypeName(ksTypes.kt:162)
at com.squareup.kotlinpoet.ksp.KsTypesKt.toTypeName(ksTypes.kt:66)
at com.squareup.kotlinpoet.ksp.KsTypesKt.toTypeName(ksTypes.kt:182)
```

### The Solution

This PR fixes that by making the recursive call in `KSTypeArgument.toTypeName` only _after_ it determines that the type parameter does not have a `STAR` variance.

### Testing
I've added a simple test case, but if you're interested, you can also refer to https://github.com/popematt/kotlinpoet-ksp-bug-repro for a full gradle project demonstrating the issue.

I was not able to run `./gradlew clean build` because of some missing JDK10 dependencies on my computer. However, I can run `./gradlew clean interop:ksp:build` and `./gradlew clean interop:ksp:test-processor:test`. I think my changes are non-intrusive enough that it should compile just fine in the CI workflow.
