### PR TITLE
Fix transitive aliases

### DIFF
--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt
@@ -72,7 +72,7 @@ internal fun KSType.toTypeName(
 
       var resolvedType: KSType
       var mappedArgs: List<KSTypeArgument>
-      var extraResolver: TypeParameterResolver
+      var extraResolver: TypeParameterResolver = typeParamResolver
       while (true) {
         resolvedType = typeAlias.type.resolve()
         mappedArgs = mapTypeArgumentsFromTypeAliasToAbbreviatedType(
@@ -81,9 +81,9 @@ internal fun KSType.toTypeName(
           abbreviatedType = resolvedType,
         )
         extraResolver = if (typeAlias.typeParameters.isEmpty()) {
-          typeParamResolver
+          extraResolver
         } else {
-          typeAlias.typeParameters.toTypeParameterResolver(typeParamResolver)
+          typeAlias.typeParameters.toTypeParameterResolver(extraResolver)
         }
 
         typeAlias = resolvedType.declaration as? KSTypeAlias ?: break
@@ -94,7 +94,7 @@ internal fun KSType.toTypeName(
         .toTypeName(extraResolver)
         .copy(nullable = isMarkedNullable)
         .rawType()
-        .withTypeArguments(mappedArgs.map { it.toTypeName(typeParamResolver) })
+        .withTypeArguments(mappedArgs.map { it.toTypeName(extraResolver) })
 
       val aliasArgs = typeArguments.map { it.toTypeName(typeParamResolver) }
 


### PR DESCRIPTION
As the test case describes - transitive Aliases are break (since KSP 1.7.0-1.6.0, but not in prior versions). This aims to resolve the issue by cascading the `extraResolver` for Aliases and use it also for arguments of Aliases.