### PR TITLE
Remove LambdaTypeName from TypeName#findRawType

### DIFF
--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/utils.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/utils.kt
@@ -18,7 +18,6 @@ package com.squareup.kotlinpoet.ksp
 import com.google.devtools.ksp.isLocal
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeName
@@ -31,18 +30,6 @@ internal fun TypeName.findRawType(): ClassName? {
   return when (this) {
     is ClassName -> this
     is ParameterizedTypeName -> rawType
-    is LambdaTypeName -> {
-      var count = parameters.size
-      if (receiver != null) {
-        count++
-      }
-      val functionSimpleName = if (count >= 23) {
-        "FunctionN"
-      } else {
-        "Function$count"
-      }
-      ClassName("kotlin.jvm.functions", functionSimpleName)
-    }
     else -> null
   }
 }


### PR DESCRIPTION
Currently LambdaTypeName is referenced in TypeName#findRawType (which is only invoked for Aliases).
However  this is dead code which you can see if you run [this test](https://github.com/square/kotlinpoet/blob/81679e2643caa042adcc9cd7d2db39386977379b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt#L395) with coverage. Additionally it references Java instead of Kotlin, which can break KMP cases. Therefore it can be removed.