### PR TITLE
Revert "Update dependency mkdocs to v1.3.1"

### DIFF
--- a/.github/workflows/mkdocs-requirements.txt
+++ b/.github/workflows/mkdocs-requirements.txt
@@ -5,7 +5,7 @@ livereload==2.6.3
 lunr==0.6.2
 Markdown==3.4.1
 MarkupSafe==2.1.1
-mkdocs==1.3.1
+mkdocs==1.3.0
 mkdocs-macros-plugin==0.7.0
 mkdocs-material==8.3.9
 mkdocs-material-extensions==1.0.3


### PR DESCRIPTION
This reverts commit 3f65469c00c58b1651ee9e240ea33cfab2cbe6ab.

Unbreaks the "publish" CI job.