### PR TITLE
Downgrade Markdown to <3.4

### DIFF
--- a/.github/workflows/mkdocs-requirements.txt
+++ b/.github/workflows/mkdocs-requirements.txt
@@ -3,7 +3,7 @@ future==0.18.2
 Jinja2==3.1.2
 livereload==2.6.3
 lunr==0.6.2
-Markdown==3.4.1
+Markdown<3.4 # See https://github.com/mkdocs/mkdocs/issues/2892.
 MarkupSafe==2.1.1
 mkdocs==1.3.0
 mkdocs-macros-plugin==0.7.0


### PR DESCRIPTION
3.4 broke mkdocs (see linked Github issue) and it looks like there are no plans to support it. Downgrading the version to unblock future mkdocs updates.