### PR TITLE
Added factory function FileSpec.builder(ClassName)

### DIFF
--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -166,6 +166,7 @@ public abstract interface annotation class com/squareup/kotlinpoet/ExperimentalK
 
 public final class com/squareup/kotlinpoet/FileSpec : com/squareup/kotlinpoet/Taggable {
 	public static final field Companion Lcom/squareup/kotlinpoet/FileSpec$Companion;
+	public static final fun builder (Lcom/squareup/kotlinpoet/ClassName;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public static final fun builder (Ljava/lang/String;Ljava/lang/String;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun get (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeSpec;)Lcom/squareup/kotlinpoet/FileSpec;
@@ -251,6 +252,7 @@ public final class com/squareup/kotlinpoet/FileSpec$Builder : com/squareup/kotli
 }
 
 public final class com/squareup/kotlinpoet/FileSpec$Companion {
+	public final fun builder (Lcom/squareup/kotlinpoet/ClassName;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun builder (Ljava/lang/String;Ljava/lang/String;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun get (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeSpec;)Lcom/squareup/kotlinpoet/FileSpec;
 	public final fun scriptBuilder (Ljava/lang/String;Ljava/lang/String;)Lcom/squareup/kotlinpoet/FileSpec$Builder;

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -520,6 +520,13 @@ public class FileSpec private constructor(
       return builder(packageName, fileName).addType(typeSpec).build()
     }
 
+    @JvmStatic public fun builder(className: ClassName): Builder {
+      require(className.simpleNames.size == 1) {
+        "nested types can't be used to name a file: ${className.simpleNames.joinToString(".")}"
+      }
+      return builder(className.packageName, className.simpleName)
+    }
+
     @JvmStatic public fun builder(packageName: String, fileName: String): Builder =
       Builder(packageName, fileName, isScript = false)
 

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -1198,4 +1198,18 @@ class FileSpecTest {
       """.trimMargin(),
     )
   }
+
+  @Test fun classNameFactory() {
+    val className = ClassName("com.example", "Example")
+    val spec = FileSpec.builder(className).build()
+    assertThat(spec.packageName).isEqualTo(className.packageName)
+    assertThat(spec.name).isEqualTo(className.simpleName)
+  }
+
+  @Test fun classNameFactoryIllegalArgumentExceptionOnNestedType() {
+    val className = ClassName("com.example", "Example", "Nested")
+    assertThrows<IllegalArgumentException> {
+      FileSpec.builder(className)
+    }
+  }
 }


### PR DESCRIPTION
Adds a convenience factory function for creating a `FileSpec` from a `ClassName`. 
Its 'packageName' and 'simpleName' properties will set the file's package and name respectively. In case a `ClassName` has more than one 'simpleName', it will throw an `IllegalArgumentException`.

Fixes #1386 