### PR TITLE
Remove future from mkdocs-requirements.txt

### DIFF
--- a/.github/workflows/mkdocs-requirements.txt
+++ b/.github/workflows/mkdocs-requirements.txt
@@ -1,5 +1,4 @@
 click==8.1.3
-future==0.18.2
 Jinja2==3.1.2
 livereload==2.6.3
 lunr==0.6.2


### PR DESCRIPTION
Attempt to address https://github.com/square/kotlinpoet/security/dependabot/1. Not sure if there's a better way to check if this package is actually used, so trying to remove it to see if the build still passes. The package has not been updated since June 2020, so not sure there will be a release that fixes the vulnerability: https://github.com/PythonCharmers/python-future.