### PR TITLE
Don't test on JDK 10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,6 +101,9 @@ subprojects {
   for (majorVersion in 8..18) {
     // Adoptium JDK 9 cannot extract on Linux or Mac OS.
     if (majorVersion == 9) continue
+    // Started causing build failures in late 2022, e.g.:
+    // https://github.com/square/kotlinpoet/actions/runs/3816320722/jobs/6531532305.
+    if (majorVersion == 10) continue
 
     val jdkTest = tasks.register<Test>("testJdk$majorVersion") {
       val javaToolchains = project.extensions.getByType(JavaToolchainService::class)


### PR DESCRIPTION
Not sure what caused CI to start failing tests on JDK 10 and not sure what exactly is the issue, but JDK 10 is probably old enough to stop caring about it. Thoughts?