### PR TITLE
Fix extra newline when a property has an initializer with statement (#941)

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -107,7 +107,12 @@ public class PropertySpec private constructor(
       )
     }
     codeWriter.emitWhereBlock(typeVariables)
-    if (!inline) codeWriter.emit("\n")
+    if (!inline) {
+      val newlineAlready = withInitializer && initializer?.hasStatements() == true
+      if (!newlineAlready) {
+        codeWriter.emit("\n")
+      }
+    }
     val implicitAccessorModifiers = EnumSet.noneOf(KModifier::class.java)
     for (modifier in implicitModifiers) {
       // Omit visibility modifiers, accessor visibility will default to the property's visibility.

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -502,7 +502,6 @@ class PropertySpecTest {
       |  println("arg=${'$'}arg")
       |}
       |
-      |
       """.trimMargin(),
     )
   }


### PR DESCRIPTION
Fix extra newline when a property has an initializer with a statement in it (#941)