### PR TITLE
Test only JDKs 8, 11, 17, and 19

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,8 +103,9 @@ subprojects {
   // because there are no matching toolchains for several older JDK versions.
   if ("CI" in System.getenv()) {
     // Copied from https://github.com/square/retrofit/blob/master/retrofit/build.gradle#L28.
-    // Create a test task for each supported JDK.
-    for (majorVersion in 8..19) {
+    // Create a test task for each supported JDK. We check every "LTS" + current version.
+    val versionsToTest = listOf(8, 11, 17, 19)
+    for (majorVersion in versionsToTest) {
       val jdkTest = tasks.register<Test>("testJdk$majorVersion") {
         val javaToolchains = project.extensions.getByType(JavaToolchainService::class)
         javaLauncher.set(javaToolchains.launcherFor {


### PR DESCRIPTION
JDK 10 seems just plain broken we can focus instead on "LTS" + current for more or less the same coverage.