### PR TITLE
Added `useAsParameter` flag to AnnotationSpec

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -38,10 +38,11 @@ public class AnnotationSpec private constructor(
     get() = typeName as? ClassName ?: error("ClassName is not available. Call typeName instead.")
   public val typeName: TypeName = builder.typeName
   public val members: List<CodeBlock> = builder.members.toImmutableList()
+  public val useAsParameter: Boolean = builder.useAsParameter
   public val useSiteTarget: UseSiteTarget? = builder.useSiteTarget
 
   internal fun emit(codeWriter: CodeWriter, inline: Boolean, asParameter: Boolean = false) {
-    if (!asParameter) {
+    if (!asParameter && !useAsParameter) {
       codeWriter.emit("@")
     }
     if (useSiteTarget != null) {
@@ -115,6 +116,7 @@ public class AnnotationSpec private constructor(
   public class Builder internal constructor(
     internal val typeName: TypeName,
   ) : Taggable.Builder<Builder> {
+    internal var useAsParameter: Boolean = false
     internal var useSiteTarget: UseSiteTarget? = null
 
     public val members: MutableList<CodeBlock> = mutableListOf()
@@ -125,6 +127,11 @@ public class AnnotationSpec private constructor(
 
     public fun addMember(codeBlock: CodeBlock): Builder = apply {
       members += codeBlock
+    }
+
+    public fun useAsParameter(): Builder = apply {
+      this.useAsParameter = true
+      useSiteTarget(null)
     }
 
     public fun useSiteTarget(useSiteTarget: UseSiteTarget?): Builder = apply {


### PR DESCRIPTION
Greetings! 

I was looking for a way to solve an issue with moshi (https://github.com/square/moshi/issues/1581), but as far as I can tell it cannot be fixed in moshi only.

Moshi uses kotlinpoet to emit annotations. Kotlinpoet has a mechanism to emit annotation as a parameter (dropping initial '@' in the emission); this mechanism is started by the parent annotation, but there is no way to emit parent annotation itself as a parameter. And that is something that has to be done from moshi (afaiu) in order to properly generate a class adapter with nested annotations.

If this PR is approved, it would be possible to call this code from [DelegateKey](https://github.com/square/moshi/blob/1af40a433f2125421d9ced0f45e358cda1283c3f/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/DelegateKey.kt#L79) class in moshi:

```
private fun AnnotationSpec.asInstantiationExpression(): CodeBlock {
  return CodeBlock.of(
    "%L",
    this.toBuilder().useAsParameter().build()
  )
}
```