### PR TITLE
add FunSpec.Builder.endControlFlowWithComma

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/CodeBlock.kt
@@ -442,6 +442,11 @@ public class CodeBlock private constructor(
       add("}\n")
     }
 
+    public fun endControlFlowWithComma(): Builder = apply {
+      unindent()
+      add("},\n")
+    }
+
     public fun addStatement(format: String, vararg args: Any?): Builder = apply {
       add("«")
       add(format, *args)

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -550,6 +550,10 @@ public class FunSpec private constructor(
       body.endControlFlow()
     }
 
+    public fun endControlFlowWithComma(): Builder = apply {
+      body.endControlFlowWithComma()
+    }
+
     public fun addStatement(format: String, vararg args: Any): Builder = apply {
       body.addStatement(format, *args)
     }


### PR DESCRIPTION
When generating code that includes constructor invocation, we come across the need to end the control flow with `},`, not just `}`
ex)
```kotlin
val some = SomeClass(
    name = if ( // some condition ) {
        "a"
    } else {
        "b"
    },
    age = 10,
)
```
we could do 
```kotlin
funSpecBuilder
    ~
    .endControlFlow()
    .addStatement(",")
    ~
    .build()
```
but this would end up as:
```kotlin
}
,
````
which is't ideal.