### PR TITLE
Make equals consistent with compareTo for ClassName

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -40,6 +40,13 @@ public class AnnotationSpec private constructor(
   public val members: List<CodeBlock> = builder.members.toImmutableList()
   public val useSiteTarget: UseSiteTarget? = builder.useSiteTarget
 
+  /** Lazily-initialized toString of this type name.  */
+  private val cachedString by lazy {
+    buildCodeString {
+      emit(this, inline = true, asParameter = false)
+    }
+  }
+
   internal fun emit(codeWriter: CodeWriter, inline: Boolean, asParameter: Boolean = false) {
     if (!asParameter) {
       codeWriter.emit("@")
@@ -96,9 +103,7 @@ public class AnnotationSpec private constructor(
 
   override fun hashCode(): Int = toString().hashCode()
 
-  override fun toString(): String = buildCodeString {
-    emit(this, inline = true, asParameter = false)
-  }
+  override fun toString(): String = cachedString
 
   public enum class UseSiteTarget(internal val keyword: String) {
     FILE("file"),

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -23,6 +23,7 @@ import javax.lang.model.element.TypeElement
 import javax.lang.model.element.VariableElement
 import javax.lang.model.type.TypeMirror
 import javax.lang.model.util.SimpleAnnotationValueVisitor8
+import kotlin.LazyThreadSafetyMode.NONE
 import kotlin.reflect.KClass
 
 /** A generated annotation on a declaration. */
@@ -41,7 +42,7 @@ public class AnnotationSpec private constructor(
   public val useSiteTarget: UseSiteTarget? = builder.useSiteTarget
 
   /** Lazily-initialized toString of this AnnotationSpec.  */
-  private val cachedString by lazy {
+  private val cachedString by lazy(NONE) {
     buildCodeString {
       emit(this, inline = true, asParameter = false)
     }

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -40,7 +40,7 @@ public class AnnotationSpec private constructor(
   public val members: List<CodeBlock> = builder.members.toImmutableList()
   public val useSiteTarget: UseSiteTarget? = builder.useSiteTarget
 
-  /** Lazily-initialized toString of this type name.  */
+  /** Lazily-initialized toString of this AnnotationSpec.  */
   private val cachedString by lazy {
     buildCodeString {
       emit(this, inline = true, asParameter = false)

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ClassName.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ClassName.kt
@@ -79,7 +79,7 @@ public class ClassName internal constructor(
   private val comparableNames = names.joinToString()
 
   /** String representation of the annotations used when comparing to other ClassName */
-  private val comparableAnnotations by lazy { annotations.joinToString() }
+  private val comparableAnnotations = annotations.joinToString()
 
   /** Fully qualified name using `.` as a separator, like `kotlin.collections.Map.Entry`. */
   public val canonicalName: String = if (names[0].isEmpty())

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
@@ -286,23 +286,27 @@ class ClassNameTest {
   }
 
   @Test fun compareToDifferentiatesPackagesFromSimpleNames() {
-    val outerFooNestedBar = ClassName("com.example", "Foo", "Bar")
+    val parentFooNestedBar = ClassName("com.example", "Foo", "Bar")
     val packageFooClassBar = ClassName("com.example.Foo", "Bar")
-    val outerFooNestedBaz = ClassName("com.example", "Foo", "Baz")
+    val parentFooNestedBaz = ClassName("com.example", "Foo", "Baz")
     val packageFooClassBaz = ClassName("com.example.Foo", "Baz")
-    val outerGooNestedBar = ClassName("com.example", "Goo", "Bar")
+    val parentGooNestedBar = ClassName("com.example", "Goo", "Bar")
     val packageGooClassBar = ClassName("com.example.Goo", "Bar")
 
     val list = listOf(
-      outerFooNestedBar, packageFooClassBar, outerFooNestedBaz, packageFooClassBaz, outerGooNestedBar,
+      parentFooNestedBar,
+      packageFooClassBar,
+      parentFooNestedBaz,
+      packageFooClassBaz,
+      parentGooNestedBar,
       packageGooClassBar,
     )
 
     assertThat(list.sorted()).isEqualTo(
       listOf(
-        outerFooNestedBar,
-        outerFooNestedBaz,
-        outerGooNestedBar,
+        parentFooNestedBar,
+        parentFooNestedBaz,
+        parentGooNestedBar,
         packageFooClassBar,
         packageFooClassBaz,
         packageGooClassBar,
@@ -370,7 +374,7 @@ class ClassNameTest {
     )
     val twoTags = ClassName(
       listOf("com.example", "Foo"),
-      tags = mapOf(String::class to "test", UInt::class to 1),
+      tags = mapOf(String::class to "test", Int::class to 1),
     )
 
     assertThat(noTags.compareTo(oneTag)).isEqualTo(0)


### PR DESCRIPTION
Follow-up of https://github.com/square/kotlinpoet/pull/1477#discussion_r1108320463

To make compareTo consistent with equals we have to ensure:

> e1.compareTo(e2) == 0 has the same boolean value as e1.equals(e2) for every e1 and e2 of class C. 

https://blog.joda.org/2012/11/pitfalls-of-consistent-with-equals.html

In other words, we cannot get a `compareTo == 0` result for two unequal ClassName.

For ClassName, we are comparing by name parts, by nullability, then by annotations. 

Comparing by name parts and nullability are safe because equality of ClassName is defined by equality of name (in ClassName.kt) and nullability (through the super TypeName).

In general, comparing by using `joinToString()` on some list property included in equals checks is not safe when you have two elements in the list x and y where `listOf(x, y).joinToString()` is the same as `listOf(x + y).joinToString()`. 

I made a Kotlin Playground to show how this could break in general:
https://pl.kotl.in/oCxOv0Sjh

For `AnnotationSpec`, it is safe because we can never have a single AnnotationSpec in a list that gives the same `joinToString()` as two separate AnnotationSpec in a list and because equality of AnnotationSpec is equality of string representation.