### PR TITLE
Return the generated path from FileSpec.writeTo().

### DIFF
--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -207,9 +207,11 @@ public final class com/squareup/kotlinpoet/FileSpec : com/squareup/kotlinpoet/An
 	public static synthetic fun toBuilder$default (Lcom/squareup/kotlinpoet/FileSpec;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun toJavaFileObject ()Ljavax/tools/JavaFileObject;
 	public fun toString ()Ljava/lang/String;
-	public final fun writeTo (Ljava/io/File;)V
+	public final fun writeTo (Ljava/io/File;)Ljava/io/File;
+	public final synthetic fun writeTo (Ljava/io/File;)V
 	public final fun writeTo (Ljava/lang/Appendable;)V
-	public final fun writeTo (Ljava/nio/file/Path;)V
+	public final fun writeTo (Ljava/nio/file/Path;)Ljava/nio/file/Path;
+	public final synthetic fun writeTo (Ljava/nio/file/Path;)V
 	public final fun writeTo (Ljavax/annotation/processing/Filer;)V
 }
 

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
@@ -30,6 +30,7 @@ import javax.tools.JavaFileObject
 import javax.tools.JavaFileObject.Kind
 import javax.tools.SimpleJavaFileObject
 import javax.tools.StandardLocation
+import kotlin.DeprecationLevel.HIDDEN
 import kotlin.reflect.KClass
 
 /**
@@ -71,9 +72,18 @@ public class FileSpec private constructor(
     codeWriter.close()
   }
 
-  /** Writes this to `directory` as UTF-8 using the standard directory structure.  */
+  @Deprecated("", level = HIDDEN)
+  @JvmName("writeTo") // For binary compatibility.
+  public fun oldWriteTo(directory: Path) {
+    writeTo(directory)
+  }
+
+  /**
+   * Writes this to [directory] as UTF-8 using the standard directory structure
+   * and returns the newly output path.
+   */
   @Throws(IOException::class)
-  public fun writeTo(directory: Path) {
+  public fun writeTo(directory: Path): Path {
     require(Files.notExists(directory) || Files.isDirectory(directory)) {
       "path $directory exists but is not a directory."
     }
@@ -88,11 +98,21 @@ public class FileSpec private constructor(
 
     val outputPath = outputDirectory.resolve("$name.$extension")
     OutputStreamWriter(Files.newOutputStream(outputPath), UTF_8).use { writer -> writeTo(writer) }
+    return outputPath
   }
 
-  /** Writes this to `directory` as UTF-8 using the standard directory structure.  */
+  @Deprecated("", level = HIDDEN)
+  @JvmName("writeTo") // For binary compatibility.
+  public fun oldWriteTo(directory: File) {
+    writeTo(directory)
+  }
+
+  /**
+   * Writes this to [directory] as UTF-8 using the standard directory structure
+   * and returns the newly output file.
+   */
   @Throws(IOException::class)
-  public fun writeTo(directory: File): Unit = writeTo(directory.toPath())
+  public fun writeTo(directory: File): File = writeTo(directory.toPath()).toFile()
 
   /** Writes this to `filer`.  */
   @Throws(IOException::class)

--- a/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/FileWritingTest.kt
+++ b/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/FileWritingTest.kt
@@ -69,37 +69,37 @@ class FileWritingTest {
 
   @Test fun pathDefaultPackage() {
     val type = TypeSpec.classBuilder("Test").build()
-    FileSpec.get("", type).writeTo(fsRoot)
+    val testPath = FileSpec.get("", type).writeTo(fsRoot)
 
-    val testPath = fsRoot.resolve("Test.kt")
+    assertThat(testPath).isEqualTo(fsRoot.resolve("Test.kt"))
     assertThat(Files.exists(testPath)).isTrue()
   }
 
   @Test fun pathDefaultPackageWithSubdirectory() {
     val type = TypeSpec.classBuilder("Test").build()
-    FileSpec.get("", type).writeTo(fsRoot.resolve("sub"))
+    val testPath = FileSpec.get("", type).writeTo(fsRoot.resolve("sub"))
 
-    val testPath = fsRoot.resolve("sub/Test.kt")
+    assertThat(testPath).isEqualTo(fsRoot.resolve("sub/Test.kt"))
     assertThat(Files.exists(testPath)).isTrue()
   }
 
   @Test fun fileDefaultPackage() {
     val type = TypeSpec.classBuilder("Test").build()
-    FileSpec.get("", type).writeTo(tmp.root)
+    val testFile = FileSpec.get("", type).writeTo(tmp.root)
 
-    val testFile = File(tmp.root, "Test.kt")
+    assertThat(testFile).isEqualTo(File(tmp.root, "Test.kt"))
     assertThat(testFile.exists()).isTrue()
   }
 
   @Test fun pathNestedClasses() {
     val type = TypeSpec.classBuilder("Test").build()
-    FileSpec.get("foo", type).writeTo(fsRoot)
-    FileSpec.get("foo.bar", type).writeTo(fsRoot)
-    FileSpec.get("foo.bar.baz", type).writeTo(fsRoot)
+    val fooPath = FileSpec.get("foo", type).writeTo(fsRoot)
+    val barPath = FileSpec.get("foo.bar", type).writeTo(fsRoot)
+    val bazPath = FileSpec.get("foo.bar.baz", type).writeTo(fsRoot)
 
-    val fooPath = fsRoot.resolve(fs.getPath("foo", "Test.kt"))
-    val barPath = fsRoot.resolve(fs.getPath("foo", "bar", "Test.kt"))
-    val bazPath = fsRoot.resolve(fs.getPath("foo", "bar", "baz", "Test.kt"))
+    assertThat(fooPath).isEqualTo(fsRoot.resolve(fs.getPath("foo", "Test.kt")))
+    assertThat(barPath).isEqualTo(fsRoot.resolve(fs.getPath("foo", "bar", "Test.kt")))
+    assertThat(bazPath).isEqualTo(fsRoot.resolve(fs.getPath("foo", "bar", "baz", "Test.kt")))
     assertThat(Files.exists(fooPath)).isTrue()
     assertThat(Files.exists(barPath)).isTrue()
     assertThat(Files.exists(bazPath)).isTrue()
@@ -107,16 +107,16 @@ class FileWritingTest {
 
   @Test fun fileNestedClasses() {
     val type = TypeSpec.classBuilder("Test").build()
-    FileSpec.get("foo", type).writeTo(tmp.root)
-    FileSpec.get("foo.bar", type).writeTo(tmp.root)
-    FileSpec.get("foo.bar.baz", type).writeTo(tmp.root)
+    val fooFile = FileSpec.get("foo", type).writeTo(tmp.root)
+    val barFile = FileSpec.get("foo.bar", type).writeTo(tmp.root)
+    val bazFile = FileSpec.get("foo.bar.baz", type).writeTo(tmp.root)
 
     val fooDir = File(tmp.root, "foo")
-    val fooFile = File(fooDir, "Test.kt")
+    assertThat(fooFile).isEqualTo(File(fooDir, "Test.kt"))
     val barDir = File(fooDir, "bar")
-    val barFile = File(barDir, "Test.kt")
+    assertThat(barFile).isEqualTo(File(barDir, "Test.kt"))
     val bazDir = File(barDir, "baz")
-    val bazFile = File(bazDir, "Test.kt")
+    assertThat(bazFile).isEqualTo(File(bazDir, "Test.kt"))
     assertThat(fooFile.exists()).isTrue()
     assertThat(barFile.exists()).isTrue()
     assertThat(bazFile.exists()).isTrue()


### PR DESCRIPTION
Hi,

I have a use case where it would be nice to know the path that is generated in the writeTo method.

This is similar to how JavaPoet's JavaFile.writeToPath() and JavaFile.writeToFile() work.

Note: I haven't updated all methods in FileWritingTest because I wanted to get a round of review first. I'll be happy to do the same to the rest of the file for consistency.

Closes #1719 