### PR TITLE
Ignore KSP annotation arguments without a value

### DIFF
--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/Annotations.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/Annotations.kt
@@ -38,10 +38,11 @@ public fun KSAnnotation.toAnnotationSpec(): AnnotationSpec {
   useSiteTarget?.let { builder.useSiteTarget(it.kpAnalog) }
   // TODO support type params once they're exposed https://github.com/google/ksp/issues/753
   for (argument in arguments) {
+    val value = argument.value ?: continue
     val member = CodeBlock.builder()
     val name = argument.name!!.getShortName()
     member.add("%N = ", name)
-    addValueToBlock(argument.value!!, member)
+    addValueToBlock(value, member)
     builder.addMember(member.build())
   }
   return builder.build()


### PR DESCRIPTION
Fixes #1357.

Kotlin doesn't add the default values to the generated metadata meaning KSP doesn't know what the default value is.
KSP has some kind of workaround for the JVM target, but there is no such workaround for other targets like Native.

In Kotlin Native something as simple as the following will result in a `NullPointerException`:
```kotlin
@Deprecated("deprecated")
val myDeprecatedProperty = 1
```

Simply ignoring the arguments that don't have an explicit value fixes the issue.

Since the compilation tests don't support Kotlin Native I wasn't able to add a test case for this.
However I do have a reproducer:
- Checkout https://github.com/rickclephas/KMP-NativeCoroutines/commit/9fb454ec7b450540f562727879158e7e3818151e
- Run `./gradlew :shared:linkDebugFrameworkIosSimulatorArm64` in the `sample` directory
- Publish a kotlinpoet SNAPSHOT version to local maven repo
- Checkout https://github.com/rickclephas/KMP-NativeCoroutines/commit/b047b45754e197841b32bd2372281d3abc8abfa1
- Run the `linkDebugFrameworkIosSimulatorArm64` again

The first time the compilation should fail with a `NullPointerException`, the second time it should succeed.