### PR TITLE
Fix arguments handling in KSType.toTypeName()

### DIFF
--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KsTypes.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KsTypes.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.kotlinpoet.ksp
 
-import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
@@ -64,12 +63,6 @@ internal fun KSType.toTypeName(
   }
   val type = when (val decl = declaration) {
     is KSClassDeclaration -> {
-      val arguments = if (decl.classKind == ClassKind.ANNOTATION_CLASS) {
-        arguments
-      } else {
-        typeArguments
-      }
-
       decl.toClassName().withTypeArguments(arguments.map { it.toTypeName(typeParamResolver) })
     }
     is KSTypeParameter -> typeParamResolver[decl.name.getShortName()]

--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
@@ -22,8 +22,10 @@ import com.google.devtools.ksp.isConstructor
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.ParameterSpec
@@ -65,6 +67,32 @@ class TestProcessor(private val env: SymbolProcessorEnvironment) : SymbolProcess
           decl.annotations
             .filterNot { it.shortName.getShortName() == "ExampleAnnotation" }
             .map { it.toAnnotationSpec() }.asIterable(),
+        )
+        val allSupertypes = decl.superTypes.toList()
+        val superclassReference = if (allSupertypes.isNotEmpty()) {
+          allSupertypes[0].takeIf {
+            val resolved = it.resolve()
+            resolved is KSClassDeclaration && resolved.classKind == ClassKind.CLASS
+          }
+        } else {
+          null
+        }
+        val superInterfaces = if (superclassReference != null) {
+          allSupertypes.drop(1)
+        } else {
+          allSupertypes
+        }
+
+        superclassReference?.let {
+          val typeName = it.toTypeName(decl.typeParameters.toTypeParameterResolver())
+          if (typeName != ANY) {
+            superclass(typeName)
+          }
+        }
+        addSuperinterfaces(
+          superInterfaces.map { it.toTypeName(decl.typeParameters.toTypeParameterResolver()) }
+            .filterNot { it == ANY }
+            .toList(),
         )
       }
     val classTypeParams = decl.typeParameters.toTypeParameterResolver()

--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
@@ -69,18 +69,18 @@ class TestProcessor(private val env: SymbolProcessorEnvironment) : SymbolProcess
             .map { it.toAnnotationSpec() }.asIterable(),
         )
         val allSupertypes = decl.superTypes.toList()
-        val superclassReference = if (allSupertypes.isNotEmpty()) {
-          allSupertypes[0].takeIf {
+        val (superclassReference, superInterfaces) = if (allSupertypes.isNotEmpty()) {
+          val superClass = allSupertypes.firstOrNull {
             val resolved = it.resolve()
             resolved is KSClassDeclaration && resolved.classKind == ClassKind.CLASS
           }
+          if (superClass != null) {
+            superClass to allSupertypes.filterNot { it == superClass }
+          } else {
+            null to allSupertypes
+          }
         } else {
-          null
-        }
-        val superInterfaces = if (superclassReference != null) {
-          allSupertypes.drop(1)
-        } else {
-          allSupertypes
+          null to allSupertypes
         }
 
         superclassReference?.let {


### PR DESCRIPTION
This more or less undoes #1321 as it broke arguments handling in an unrelated way to annotations. I'm not able to actually repro the original issue it sought to solve in #1304, and added a regression test. This resolves #1513, though the examples there were not helpful either. All in all, I have a headache. 