### PR TITLE
Do not emit superfluous `Unit` in return type position

### DIFF
--- a/interop/kotlinx-metadata/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/FacadeFileTest.kt
+++ b/interop/kotlinx-metadata/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/FacadeFileTest.kt
@@ -50,7 +50,6 @@ class FacadeFileTest : MultiClassInspectorTest() {
       import kotlin.Int
       import kotlin.Long
       import kotlin.String
-      import kotlin.Unit
       import kotlin.collections.List
       import kotlin.jvm.JvmField
       import kotlin.jvm.JvmName
@@ -58,21 +57,21 @@ class FacadeFileTest : MultiClassInspectorTest() {
       import kotlin.jvm.Synchronized
 
       @JvmName(name = "jvmStaticFunction")
-      public fun jvmNameFunction(): Unit {
+      public fun jvmNameFunction() {
       }
 
       public fun jvmOverloads(
         param1: String,
         optionalParam2: String = throw NotImplementedError("Stub!"),
         nullableParam3: String? = throw NotImplementedError("Stub!"),
-      ): Unit {
+      ) {
       }
 
-      public fun regularFun(): Unit {
+      public fun regularFun() {
       }
 
       @Synchronized
-      public fun synchronizedFun(): Unit {
+      public fun synchronizedFun() {
       }
 
       public val BINARY_PROP: Int = 11
@@ -186,7 +185,6 @@ class FacadeFileTest : MultiClassInspectorTest() {
       import kotlin.Int
       import kotlin.Long
       import kotlin.String
-      import kotlin.Unit
       import kotlin.collections.List
       import kotlin.jvm.JvmName
       import kotlin.jvm.JvmOverloads
@@ -194,7 +192,7 @@ class FacadeFileTest : MultiClassInspectorTest() {
       import kotlin.jvm.Synchronized
 
       @JvmName(name = "jvmStaticFunction")
-      public fun jvmNameFunction(): Unit {
+      public fun jvmNameFunction() {
       }
 
       @JvmOverloads
@@ -202,14 +200,14 @@ class FacadeFileTest : MultiClassInspectorTest() {
         param1: String,
         optionalParam2: String = throw NotImplementedError("Stub!"),
         nullableParam3: String? = throw NotImplementedError("Stub!"),
-      ): Unit {
+      ) {
       }
 
-      public fun regularFun(): Unit {
+      public fun regularFun() {
       }
 
       @Synchronized
-      public fun synchronizedFun(): Unit {
+      public fun synchronizedFun() {
       }
 
       public val BINARY_PROP: Int = throw NotImplementedError("Stub!")

--- a/interop/kotlinx-metadata/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecsTest.kt
+++ b/interop/kotlinx-metadata/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecsTest.kt
@@ -264,13 +264,13 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
       public class SuspendTypes() {
         public val testProp: suspend (kotlin.Int, kotlin.Long) -> kotlin.String = throw NotImplementedError("Stub!")
 
-        public suspend fun testComplexSuspendFun(body: suspend (kotlin.Int, suspend (kotlin.Long) -> kotlin.String) -> kotlin.String): kotlin.Unit {
+        public suspend fun testComplexSuspendFun(body: suspend (kotlin.Int, suspend (kotlin.Long) -> kotlin.String) -> kotlin.String) {
         }
 
-        public fun testFun(body: suspend (kotlin.Int, kotlin.Long) -> kotlin.String): kotlin.Unit {
+        public fun testFun(body: suspend (kotlin.Int, kotlin.Long) -> kotlin.String) {
         }
 
-        public suspend fun testSuspendFun(param1: kotlin.String): kotlin.Unit {
+        public suspend fun testSuspendFun(param1: kotlin.String) {
         }
       }
       """.trimIndent(),
@@ -297,10 +297,10 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     assertThat(typeSpec.trimmedToString()).isEqualTo(
       """
       public class Parameters() {
-        public inline fun hasDefault(param1: kotlin.String = throw NotImplementedError("Stub!")): kotlin.Unit {
+        public inline fun hasDefault(param1: kotlin.String = throw NotImplementedError("Stub!")) {
         }
 
-        public inline fun `inline`(crossinline param1: () -> kotlin.String): kotlin.Unit {
+        public inline fun `inline`(crossinline param1: () -> kotlin.String) {
         }
 
         public inline fun `noinline`(noinline param1: () -> kotlin.String): kotlin.String = throw NotImplementedError("Stub!")
@@ -328,13 +328,13 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     assertThat(typeSpec.trimmedToString()).isEqualTo(
       """
       public class LambdaReceiver() {
-        public fun lambdaReceiver(block: kotlin.String.() -> kotlin.Unit): kotlin.Unit {
+        public fun lambdaReceiver(block: kotlin.String.() -> kotlin.Unit) {
         }
 
-        public fun lambdaReceiver2(block: kotlin.String.(kotlin.Int) -> kotlin.Unit): kotlin.Unit {
+        public fun lambdaReceiver2(block: kotlin.String.(kotlin.Int) -> kotlin.Unit) {
         }
 
-        public fun lambdaReceiver3(block: kotlin.String.(kotlin.Int, kotlin.String) -> kotlin.Unit): kotlin.Unit {
+        public fun lambdaReceiver3(block: kotlin.String.(kotlin.Int, kotlin.String) -> kotlin.Unit) {
         }
       }
       """.trimIndent(),
@@ -406,7 +406,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     assertThat(typeSpec.trimmedToString()).isEqualTo(
       """
       public class FunctionsReferencingTypeParameters<T>() {
-        public fun test(`param`: T): kotlin.Unit {
+        public fun test(`param`: T) {
         }
       }
       """.trimIndent(),
@@ -430,10 +430,10 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
 
         override var openPropInterface: kotlin.String = throw NotImplementedError("Stub!")
 
-        override fun openFunction(): kotlin.Unit {
+        override fun openFunction() {
         }
 
-        override fun openFunctionInterface(): kotlin.Unit {
+        override fun openFunctionInterface() {
         }
       }
       """.trimIndent(),
@@ -661,7 +661,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
       public interface TestInterface {
         public fun complex(input: kotlin.String, input2: kotlin.String = throw NotImplementedError("Stub!")): kotlin.String = throw NotImplementedError("Stub!")
 
-        public fun hasDefault(): kotlin.Unit {
+        public fun hasDefault() {
         }
 
         public fun hasDefaultMultiParam(input: kotlin.String, input2: kotlin.String): kotlin.String = throw NotImplementedError("Stub!")
@@ -669,14 +669,14 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         public fun hasDefaultSingleParam(input: kotlin.String): kotlin.String = throw NotImplementedError("Stub!")
 
         @kotlin.jvm.JvmDefault
-        public fun hasJvmDefault(): kotlin.Unit {
+        public fun hasJvmDefault() {
         }
 
-        public fun noDefault(): kotlin.Unit
+        public fun noDefault()
 
-        public fun noDefaultWithInput(input: kotlin.String): kotlin.Unit
+        public fun noDefaultWithInput(input: kotlin.String)
 
-        public fun noDefaultWithInputDefault(input: kotlin.String = throw NotImplementedError("Stub!")): kotlin.Unit
+        public fun noDefaultWithInputDefault(input: kotlin.String = throw NotImplementedError("Stub!"))
       }
       """.trimIndent(),
     )
@@ -687,14 +687,14 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     assertThat(subInterfaceSpec.trimmedToString()).isEqualTo(
       """
       public interface SubInterface : com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.TestInterface {
-        override fun hasDefault(): kotlin.Unit {
+        override fun hasDefault() {
         }
 
         @kotlin.jvm.JvmDefault
-        override fun hasJvmDefault(): kotlin.Unit {
+        override fun hasJvmDefault() {
         }
 
-        public fun subInterfaceFunction(): kotlin.Unit {
+        public fun subInterfaceFunction() {
         }
       }
       """.trimIndent(),
@@ -706,13 +706,13 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     assertThat(implSpec.trimmedToString()).isEqualTo(
       """
       public class TestSubInterfaceImpl() : com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.SubInterface {
-        override fun noDefault(): kotlin.Unit {
+        override fun noDefault() {
         }
 
-        override fun noDefaultWithInput(input: kotlin.String): kotlin.Unit {
+        override fun noDefaultWithInput(input: kotlin.String) {
         }
 
-        override fun noDefaultWithInputDefault(input: kotlin.String): kotlin.Unit {
+        override fun noDefaultWithInputDefault(input: kotlin.String) {
         }
       }
       """.trimIndent(),
@@ -838,19 +838,19 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     assertThat(typeSpec.trimmedToString()).isEqualTo(
       """
       public class GenericClass<T>() {
-        public fun <T> functionAlsoWithT(`param`: T): kotlin.Unit {
+        public fun <T> functionAlsoWithT(`param`: T) {
         }
 
-        public fun <R> functionWithADifferentType(`param`: R): kotlin.Unit {
+        public fun <R> functionWithADifferentType(`param`: R) {
         }
 
-        public fun functionWithT(`param`: T): kotlin.Unit {
+        public fun functionWithT(`param`: T) {
         }
 
         /**
          * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
          */
-        public inline fun <reified T> `reified`(`param`: T): kotlin.Unit {
+        public inline fun <reified T> `reified`(`param`: T) {
         }
       }
       """.trimIndent(),
@@ -925,7 +925,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         public constructor(`value`: kotlin.String)
 
         @com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.FunctionAnnotation
-        public fun function(): kotlin.Unit {
+        public fun function() {
         }
       }
       """.trimIndent(),
@@ -1226,7 +1226,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         public var volatileProp: kotlin.String? = null
 
         @kotlin.jvm.Synchronized
-        public fun synchronizedFun(): kotlin.Unit {
+        public fun synchronizedFun() {
         }
       }
       """.trimIndent(),
@@ -1239,10 +1239,10 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
       """
       public interface JvmAnnotationsInterface {
         @kotlin.jvm.JvmDefault
-        public fun defaultMethod(): kotlin.Unit {
+        public fun defaultMethod() {
         }
 
-        public fun notDefaultMethod(): kotlin.Unit
+        public fun notDefaultMethod()
       }
       """.trimIndent(),
     )
@@ -1317,7 +1317,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         public var propertySet: kotlin.String? = null
 
         @kotlin.jvm.JvmName(name = "jvmFunction")
-        public fun function(): kotlin.Unit {
+        public fun function() {
         }
 
         public interface InterfaceWithJvmName {
@@ -1328,7 +1328,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
 
             @kotlin.jvm.JvmName(name = "jvmStaticFunction")
             @kotlin.jvm.JvmStatic
-            public fun staticFunction(): kotlin.Unit {
+            public fun staticFunction() {
             }
           }
         }
@@ -1364,7 +1364,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         public var propertySet: kotlin.String? = null
 
         @kotlin.jvm.JvmName(name = "jvmFunction")
-        public fun function(): kotlin.Unit {
+        public fun function() {
         }
 
         public interface InterfaceWithJvmName {
@@ -1375,7 +1375,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
 
             @kotlin.jvm.JvmName(name = "jvmStaticFunction")
             @kotlin.jvm.JvmStatic
-            public fun staticFunction(): kotlin.Unit {
+            public fun staticFunction() {
             }
           }
         }
@@ -1439,7 +1439,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
           param1: kotlin.String,
           optionalParam2: kotlin.String = throw NotImplementedError("Stub!"),
           nullableParam3: kotlin.String? = throw NotImplementedError("Stub!"),
-        ): kotlin.Unit {
+        ) {
         }
       }
       """.trimIndent(),
@@ -1573,7 +1573,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
          * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
          */
         @kotlin.jvm.JvmSynthetic
-        public fun function(): kotlin.Unit {
+        public fun function() {
         }
 
         public interface InterfaceWithJvmName {
@@ -1581,7 +1581,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
            * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
            */
           @kotlin.jvm.JvmSynthetic
-          public fun interfaceFunction(): kotlin.Unit
+          public fun interfaceFunction()
 
           public companion object {
             @get:kotlin.jvm.JvmSynthetic
@@ -1593,7 +1593,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
              */
             @kotlin.jvm.JvmStatic
             @kotlin.jvm.JvmSynthetic
-            public fun staticFunction(): kotlin.Unit {
+            public fun staticFunction() {
             }
           }
         }
@@ -1638,7 +1638,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
          * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
          */
         @kotlin.jvm.JvmSynthetic
-        public fun function(): kotlin.Unit {
+        public fun function() {
         }
 
         public interface InterfaceWithJvmName {
@@ -1646,7 +1646,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
            * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
            */
           @kotlin.jvm.JvmSynthetic
-          public fun interfaceFunction(): kotlin.Unit
+          public fun interfaceFunction()
 
           public companion object {
             @get:kotlin.jvm.JvmSynthetic
@@ -1657,7 +1657,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
              * Note: Since this is a synthetic function, some JVM information (annotations, modifiers) may be missing.
              */
             @kotlin.jvm.JvmSynthetic
-            public fun staticFunction(): kotlin.Unit {
+            public fun staticFunction() {
             }
           }
         }
@@ -1728,7 +1728,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         public var setterThrows: kotlin.String? = null
 
         @kotlin.jvm.Throws(exceptionClasses = [java.lang.IllegalStateException::class])
-        public fun testFunction(): kotlin.Unit {
+        public fun testFunction() {
         }
       }
       """.trimIndent(),
@@ -1884,7 +1884,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         @com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "2")
         param2: kotlin.String,
       ) {
-        public fun function(@com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "woo") param1: kotlin.String): kotlin.Unit {
+        public fun function(@com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "woo") param1: kotlin.String) {
         }
       }
       """.trimIndent(),
@@ -1908,7 +1908,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         @com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "2")
         param2: kotlin.String,
       ) {
-        public fun function(@com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "woo") param1: kotlin.String): kotlin.Unit {
+        public fun function(@com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.CustomAnnotation(name = "woo") param1: kotlin.String) {
         }
       }
       """.trimIndent(),
@@ -1983,7 +1983,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
       public class TypeAnnotations() {
         public val foo: kotlin.collections.List<@com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.String> = throw NotImplementedError("Stub!")
 
-        public fun <T> bar(input: @com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.String, input2: @com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.TypeAnnotation (@com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.Int) -> @com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.String): kotlin.Unit {
+        public fun <T> bar(input: @com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.String, input2: @com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.TypeAnnotation (@com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.Int) -> @com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.TypeAnnotation kotlin.String) {
         }
       }
       """.trimIndent(),
@@ -2011,7 +2011,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     assertThat(typeSpec.trimmedToString()).isEqualTo(
       """
       public class Asset<A : com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.Asset<A>>() {
-        public fun <D : com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.Asset<D>, C : com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.Asset<A>> function(): kotlin.Unit {
+        public fun <D : com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.Asset<D>, C : com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.Asset<A>> function() {
         }
 
         public class AssetIn<in C : com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.Asset.AssetIn<C>>()
@@ -2043,11 +2043,11 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
 
         public abstract val foo: kotlin.String
 
-        public abstract fun bar(): kotlin.Unit
+        public abstract fun bar()
 
         public abstract fun barWithReturn(): kotlin.String
 
-        public fun fuz(): kotlin.Unit {
+        public fun fuz() {
         }
 
         public fun fuzWithReturn(): kotlin.String = throw NotImplementedError("Stub!")
@@ -2104,13 +2104,13 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
 
         public open val openProp: kotlin.String? = null
 
-        public fun implicitFinalFun(): kotlin.Unit {
+        public fun implicitFinalFun() {
         }
 
-        override fun interfaceFun(): kotlin.Unit {
+        override fun interfaceFun() {
         }
 
-        public open fun openFun(): kotlin.Unit {
+        public open fun openFun() {
         }
       }
       """.trimIndent(),
@@ -2124,7 +2124,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
       public abstract class FinalAbstractModalities() : com.squareup.kotlinpoet.metadata.specs.KotlinPoetMetadataSpecsTest.ModalitiesInterface {
         final override val interfaceProp: kotlin.String? = null
 
-        final override fun interfaceFun(): kotlin.Unit {
+        final override fun interfaceFun() {
         }
       }
       """.trimIndent(),
@@ -2140,10 +2140,10 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
 
         override val openProp: kotlin.String? = null
 
-        override fun interfaceFun(): kotlin.Unit {
+        override fun interfaceFun() {
         }
 
-        override fun openFun(): kotlin.Unit {
+        override fun openFun() {
         }
       }
       """.trimIndent(),
@@ -2188,7 +2188,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
     assertThat(funInterface.trimmedToString()).isEqualTo(
       """
       public fun interface FunInterface {
-        public fun example(): kotlin.Unit
+        public fun example()
       }
       """.trimIndent(),
     )

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -160,7 +160,6 @@ class TestProcessorTest {
       import kotlin.Int
       import kotlin.IntArray
       import kotlin.String
-      import kotlin.Unit
       import kotlin.collections.List
       import kotlin.collections.Map
       import kotlin.collections.MutableList
@@ -225,7 +224,7 @@ class TestProcessorTest {
           param1: Function0<String>,
           param2: Function1<String, String>,
           param3: Function1<String, String>,
-        ): Unit {
+        ) {
         }
 
         public fun wildTypes(
@@ -252,7 +251,7 @@ class TestProcessorTest {
           genericAlias: GenericTypeAlias,
           parameterizedTypeAlias: ParameterizedTypeAlias<String>,
           nestedArray: Array<Map<String, Any>>?,
-        ): Unit {
+        ) {
         }
       }
 
@@ -302,7 +301,6 @@ class TestProcessorTest {
 
       import kotlin.Int
       import kotlin.String
-      import kotlin.Unit
       import kotlin.collections.List
       import kotlin.collections.Map
 
@@ -313,7 +311,7 @@ class TestProcessorTest {
           genericMapAlias: Map<Int, String>,
           t1Unused: Map<Int, String>,
           a1: Map<String, Int>,
-        ): Unit {
+        ) {
         }
       }
 
@@ -431,10 +429,9 @@ class TestProcessorTest {
     package test
 
     import kotlin.Int
-    import kotlin.Unit
 
     public class TransitiveAliases {
-      public fun <T : Alias41<Alias23, out Alias77<Alias73<Int>>>> bar(arg1: T): Unit {
+      public fun <T : Alias41<Alias23, out Alias77<Alias73<Int>>>> bar(arg1: T) {
       }
     }
 
@@ -471,11 +468,10 @@ class TestProcessorTest {
       """
     package test
 
-    import kotlin.Unit
     import kotlin.collections.List
 
     public class AliasAsTypeArgument {
-      public fun bar(arg1: List<Alias997>): Unit {
+      public fun bar(arg1: List<Alias997>) {
       }
     }
 

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FunSpec.kt
@@ -48,7 +48,7 @@ public class FunSpec private constructor(
   public val typeVariables: List<TypeVariableName> = builder.typeVariables.toImmutableList()
   public val receiverType: TypeName? = builder.receiverType
 
-  public val returnType: TypeName? = builder.returnType
+  public val returnType: TypeName = builder.returnType
   public val parameters: List<ParameterSpec> = builder.parameters.toImmutableList()
   public val delegateConstructor: String? = builder.delegateConstructor
   public val delegateConstructorArguments: List<CodeBlock> =
@@ -165,10 +165,8 @@ public class FunSpec private constructor(
       }
     }
 
-    if (returnType != null) {
+    if (returnType != UNIT || emitUnitReturnType()) {
       codeWriter.emitCode(": %T", returnType)
-    } else if (emitUnitReturnType()) {
-      codeWriter.emitCode(": %T", UNIT)
     }
 
     if (delegateConstructor != null) {
@@ -217,10 +215,7 @@ public class FunSpec private constructor(
   /**
    * Returns whether [Unit] should be emitted as the return type.
    *
-   * [Unit] is emitted as return type on a function unless:
-   *   - It's a constructor
-   *   - It's a getter/setter on a property
-   *   - It's an expression body
+   * [Unit] is emitted as return type on a function only if it is an expression body.
    */
   private fun emitUnitReturnType(): Boolean {
     if (isConstructor) {
@@ -231,7 +226,7 @@ public class FunSpec private constructor(
       return false
     }
 
-    return body.asExpressionBody() == null
+    return body.asExpressionBody() != null
   }
 
   private fun CodeBlock.asExpressionBody(): CodeBlock? {
@@ -309,7 +304,7 @@ public class FunSpec private constructor(
     internal var returnKdoc = CodeBlock.EMPTY
     internal var receiverKdoc = CodeBlock.EMPTY
     internal var receiverType: TypeName? = null
-    internal var returnType: TypeName? = null
+    internal var returnType: TypeName = UNIT
     internal var delegateConstructor: String? = null
     internal var delegateConstructorArguments = listOf<CodeBlock>()
     internal val body = CodeBlock.builder()

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/AnnotationSpecTest.kt
@@ -318,9 +318,8 @@ class AnnotationSpecTest {
       |package test
       |
       |import kotlin.Suppress
-      |import kotlin.Unit
       |
-      |public fun test(): Unit {
+      |public fun test() {
       |  @Suppress("Things")
       |  val annotatedString = "AnnotatedString"
       |}
@@ -339,7 +338,7 @@ class AnnotationSpecTest {
 
     assertThat(funSpec.toString().trim()).isEqualTo(
       """
-      |public fun operation(): kotlin.Unit {
+      |public fun operation() {
       |  @Suppress("UNCHECKED_CAST")
       |}
       """.trimMargin(),
@@ -474,6 +473,7 @@ class AnnotationSpecTest {
         FunSpec.builder("create")
           .addModifiers(OVERRIDE)
           .addParameter("parcel", parcel)
+          .returns(externalClass)
           .addStatement("return %T(parcel.readInt())", externalClass)
           .build(),
       )
@@ -558,16 +558,15 @@ class AnnotationSpecTest {
       package com.squareup.parceler
 
       import kotlin.Int
-      import kotlin.Unit
 
       public class ExternalClass(
         public val `value`: Int,
       )
 
       public object ExternalClassParceler : Parceler<ExternalClass> {
-        override fun create(parcel: Parcel) = ExternalClass(parcel.readInt())
+        override fun create(parcel: Parcel): ExternalClass = ExternalClass(parcel.readInt())
 
-        override fun ExternalClass.write(parcel: Parcel, flags: Int): Unit {
+        override fun ExternalClass.write(parcel: Parcel, flags: Int) {
           parcel.writeInt(value)
         }
       }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
@@ -208,9 +208,8 @@ class ClassNameTest {
       |package com.squareup.tacos
       |
       |import com.squareup.`taco factory`.`Taco Factory`
-      |import kotlin.Unit
       |
-      |public fun main(): Unit {
+      |public fun main() {
       |  println(`Taco Factory`.produceTacos())
       |}
       |""".trimMargin()

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/CodeBlockTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/CodeBlockTest.kt
@@ -517,9 +517,7 @@ class CodeBlockTest {
       """
       |package com.squareup.tacos
       |
-      |import kotlin.Unit
-      |
-      |public fun test(): Unit {
+      |public fun test() {
       |  if ("Very long string that would wrap the line " ==
       |      "Very long string that would wrap the line ") {
       |  } else if ("Long string that would wrap the line 2 " ==

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/CrossplatformTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/CrossplatformTest.kt
@@ -72,7 +72,6 @@ class CrossplatformTest {
       """
       |import java.util.concurrent.atomic.AtomicReference
       |import kotlin.Boolean
-      |import kotlin.Unit
       |
       |internal expect class AtomicRef<V>(
       |  `value`: V,
@@ -81,7 +80,7 @@ class CrossplatformTest {
       |
       |  public fun `get`(): V
       |
-      |  public fun `set`(`value`: V): Unit
+      |  public fun `set`(`value`: V)
       |
       |  public fun getAndSet(`value`: V): V
       |
@@ -157,6 +156,7 @@ class CrossplatformTest {
       .addFunction(
         FunSpec.builder("f1")
           .addModifiers(KModifier.ACTUAL)
+          .returns(INT)
           .addStatement("return 1")
           .build(),
       )
@@ -168,7 +168,7 @@ class CrossplatformTest {
       |
       |public expect fun f1(): Int
       |
-      |public actual fun f1() = 1
+      |public actual fun f1(): Int = 1
       |
       """.trimMargin(),
     )

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ExpectDeclarationsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ExpectDeclarationsTest.kt
@@ -26,7 +26,7 @@ class ExpectDeclarationsTest {
 
     assertThat(methodSpec.toString()).isEqualTo(
       """
-      |public expect fun function(): kotlin.Unit
+      |public expect fun function()
       |
       """.trimMargin(),
     )
@@ -42,7 +42,7 @@ class ExpectDeclarationsTest {
     assertThat(builder.build().toString()).isEqualTo(
       """
         |public expect class Test {
-        |  public fun function(): kotlin.Unit
+        |  public fun function()
         |}
         |
       """.trimMargin(),

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ExternalDeclarationsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ExternalDeclarationsTest.kt
@@ -26,7 +26,7 @@ class ExternalDeclarationsTest {
 
     assertThat(methodSpec.toString()).isEqualTo(
       """
-      |public external fun function(): kotlin.Unit
+      |public external fun function()
       |
       """.trimMargin(),
     )
@@ -35,12 +35,13 @@ class ExternalDeclarationsTest {
   @Test fun externalFunDeclarationWithDefinedExternally() {
     val methodSpec = FunSpec.builder("function")
       .addModifiers(KModifier.EXTERNAL)
+      .returns(STRING)
       .addCode("return kotlin.js.definedExternally")
       .build()
 
     assertThat(methodSpec.toString()).isEqualTo(
       """
-      |public external fun function() = kotlin.js.definedExternally
+      |public external fun function(): kotlin.String = kotlin.js.definedExternally
       |
       """.trimMargin(),
     )
@@ -54,7 +55,7 @@ class ExternalDeclarationsTest {
 
     assertThat(methodSpec.toString()).isEqualTo(
       """
-      |public external fun function(): kotlin.Unit {
+      |public external fun function() {
       |  kotlin.js.definedExternally
       |}
       |
@@ -72,7 +73,7 @@ class ExternalDeclarationsTest {
     assertThat(builder.build().toString()).isEqualTo(
       """
         |public external class Test {
-        |  public fun function(): kotlin.Unit
+        |  public fun function()
         |}
         |
       """.trimMargin(),
@@ -83,6 +84,7 @@ class ExternalDeclarationsTest {
     val builder = TypeSpec.classBuilder("Test")
       .addModifiers(KModifier.EXTERNAL)
     val methodSpec = FunSpec.builder("function")
+      .returns(STRING)
       .addCode("return kotlin.js.definedExternally")
       .build()
     builder.addFunction(methodSpec)
@@ -90,7 +92,7 @@ class ExternalDeclarationsTest {
     assertThat(builder.build().toString()).isEqualTo(
       """
         |public external class Test {
-        |  public fun function() = kotlin.js.definedExternally
+        |  public fun function(): kotlin.String = kotlin.js.definedExternally
         |}
         |
       """.trimMargin(),
@@ -109,7 +111,7 @@ class ExternalDeclarationsTest {
     assertThat(builder.build().toString()).isEqualTo(
       """
         |public external class Test {
-        |  public fun function(): kotlin.Unit {
+        |  public fun function() {
         |    kotlin.js.definedExternally
         |  }
         |}

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -413,9 +413,8 @@ class FileSpecTest {
       |package com.example
       |
       |import com.squareup.`taco factory`.TacoFactory
-      |import kotlin.Unit
       |
-      |public fun main(): Unit {
+      |public fun main() {
       |  println(TacoFactory.produceTacos())
       |}
       |
@@ -437,10 +436,9 @@ class FileSpecTest {
       """
       |package com.example
       |
-      |import kotlin.Unit
       |import com.squareup.`taco factory`.TacoFactory as `La Taqueria`
       |
-      |public fun main(): Unit {
+      |public fun main() {
       |  println(`La Taqueria`.produceTacos())
       |}
       |
@@ -492,10 +490,9 @@ class FileSpecTest {
       """
       |package com.squareup.tacos
       |
-      |import kotlin.Unit
       |import java.util.concurrent.TimeUnit.MINUTES as MINS
       |
-      |public fun sleepForFiveMins(): Unit {
+      |public fun sleepForFiveMins() {
       |  MINS.sleep(5)
       |}
       |
@@ -726,10 +723,9 @@ class FileSpecTest {
         |import java.lang.System
         |import kotlin.Array
         |import kotlin.String
-        |import kotlin.Unit
         |
         |public class HelloWorld {
-        |  public fun main(args: Array<String>): Unit {
+        |  public fun main(args: Array<String>) {
         |    System.out.println("Hello World!");
         |  }
         |}
@@ -1041,9 +1037,7 @@ class FileSpecTest {
       """
       |package com.squareup.taco.enchilada.quesadillas.tamales.burritos.`super`.burritos.trying.to.`get`.a.really.large.packagename
       |
-      |import kotlin.Unit
-      |
-      |public fun foo(): Unit {
+      |public fun foo() {
       |}
       |
       """.trimMargin(),
@@ -1123,16 +1117,15 @@ class FileSpecTest {
       |
       |import com.squareup.kotlinpoet.FileSpecTest
       |import kotlin.String
-      |import kotlin.Unit
       |import kotlin.collections.Collection
       |import kotlin.collections.List
       |import kotlin.collections.Map
       |
-      |public fun f1(): Unit {
+      |public fun f1() {
       |  // this is a long line with a possibly long parameterized type with annotation: List<Map<in String, Collection<Map<FileSpecTest.WackyKey, out FileSpecTest.OhNoThisDoesNotCompile>>>>
       |}
       |
-      |public fun f2(): Unit {
+      |public fun f2() {
       |  // this is a very very very very very very very very very very long line with a very long lambda type: suspend String.(foo: List<Map<in String, Collection<Map<FileSpecTest.WackyKey, out FileSpecTest.OhNoThisDoesNotCompile>>>>) -> String
       |}
       |
@@ -1158,13 +1151,12 @@ class FileSpecTest {
     assertThat(spec.toString()).isEqualTo(
       """
       |import kotlin.String
-      |import kotlin.Unit
       |
       |val prop: String = "hi"
       |
       |println("hello!")
       |
-      |public fun localFun(): Unit {
+      |public fun localFun() {
       |}
       |
       |public class Yay

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileWritingTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileWritingTest.kt
@@ -260,12 +260,11 @@ class FileWritingTest {
         |import java.lang.System
         |import java.util.Date
         |import kotlin.Array
-        |import kotlin.Unit
         |
         |public class Test {
         |${"\t"}public val madeFreshDate: Date
         |
-        |${"\t"}public fun main(args: Array<String>): Unit {
+        |${"\t"}public fun main(args: Array<String>) {
         |${"\t\t"}System.out.println("Hello World!");
         |${"\t"}}
         |}

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -168,7 +168,7 @@ class FunSpecTest {
       .build()
     assertThat(funSpec.toString()).isEqualTo(
       """
-      |public fun foo(string: kotlin.String?): kotlin.Unit {
+      |public fun foo(string: kotlin.String?) {
       |}
       |
       """.trimMargin(),
@@ -195,7 +195,7 @@ class FunSpecTest {
 
     assertThat(funSpec.toString()).isEqualTo(
       """
-      |public fun foo(): kotlin.Unit {
+      |public fun foo() {
       |}
       |
       """.trimMargin(),
@@ -272,7 +272,7 @@ class FunSpecTest {
       |  string: kotlin.String,
       |  number: kotlin.Int,
       |  nodoc: kotlin.Boolean,
-      |): kotlin.Unit {
+      |) {
       |}
       |
       """.trimMargin(),
@@ -295,7 +295,7 @@ class FunSpecTest {
       |/**
       | * @param string A string parameter. This is non null
       | */
-      |public fun foo(string: kotlin.String): kotlin.Unit {
+      |public fun foo(string: kotlin.String) {
       |}
       |
       """.trimMargin(),
@@ -378,7 +378,7 @@ class FunSpecTest {
 
     assertThat(funSpec.toString()).isEqualTo(
       """
-      |public fun foo(): kotlin.Unit {
+      |public fun foo() {
       |  throwOrDoSomethingElse()
       |}
       |
@@ -388,12 +388,13 @@ class FunSpecTest {
 
   @Test fun expressionBodyIsDetectedReturnWithNonBreakingSpace() {
     val funSpec = FunSpec.builder("foo")
+      .returns(INT)
       .addStatement("return·1")
       .build()
 
     assertThat(funSpec.toString()).isEqualTo(
       """
-      |public fun foo() = 1
+      |public fun foo(): kotlin.Int = 1
       |
       """.trimMargin(),
     )
@@ -493,7 +494,7 @@ class FunSpecTest {
     assertThat(funSpec.toString()).isEqualTo(
       """
       |context(kotlin.String)
-      |public fun foo(): kotlin.Unit {
+      |public fun foo() {
       |}
       |
       """.trimMargin(),
@@ -511,7 +512,7 @@ class FunSpecTest {
     assertThat(funSpec.toString()).isEqualTo(
       """
       |context(kotlin.String, kotlin.Int, kotlin.Boolean)
-      |public fun foo(): kotlin.Unit {
+      |public fun foo() {
       |}
       |
       """.trimMargin(),
@@ -528,7 +529,7 @@ class FunSpecTest {
     assertThat(funSpec.toString()).isEqualTo(
       """
       |context(T)
-      |public fun <T> foo(): kotlin.Unit {
+      |public fun <T> foo() {
       |}
       |
       """.trimMargin(),
@@ -545,7 +546,7 @@ class FunSpecTest {
       """
       |context(kotlin.String)
       |@com.squareup.kotlinpoet.FunSpecTest.TestAnnotation
-      |public fun foo(): kotlin.Unit {
+      |public fun foo() {
       |}
       |
       """.trimMargin(),
@@ -561,7 +562,7 @@ class FunSpecTest {
     assertThat(funSpec.toString()).isEqualTo(
       """
       |context(@com.squareup.kotlinpoet.FunSpecTest.TestAnnotation kotlin.String)
-      |public fun foo(): kotlin.Unit {
+      |public fun foo() {
       |}
       |
       """.trimMargin(),
@@ -715,7 +716,7 @@ class FunSpecTest {
 
     assertThat(funSpec.toString()).isEqualTo(
       """
-      |public private internal fun myMethod(): kotlin.Unit {
+      |public private internal fun myMethod() {
       |}
       |
       """.trimMargin(),
@@ -730,7 +731,7 @@ class FunSpecTest {
 
     assertThat(funSpec.toString()).isEqualTo(
       """
-      |public fun myMethod(): kotlin.Unit {
+      |public fun myMethod() {
       |}
       |
       """.trimMargin(),
@@ -847,7 +848,7 @@ class FunSpecTest {
 
     assertThat(funSpec.toString()).isEqualTo(
       """
-      |public fun `if`(): kotlin.Unit {
+      |public fun `if`() {
       |}
       |
       """.trimMargin(),
@@ -860,7 +861,7 @@ class FunSpecTest {
 
     assertThat(funSpec.toString()).isEqualTo(
       """
-      |public fun `with-hyphen`(): kotlin.Unit {
+      |public fun `with-hyphen`() {
       |}
       |
       """.trimMargin(),
@@ -1044,7 +1045,7 @@ class FunSpecTest {
     assertThat(builder.build().toString()).isEqualTo(
       """
       |@kotlin.jvm.JvmStatic
-      |internal fun staticMethod(): kotlin.Unit {
+      |internal fun staticMethod() {
       |}
       |
       """.trimMargin(),
@@ -1057,7 +1058,7 @@ class FunSpecTest {
 
     assertThat(builder.build().toString()).isEqualTo(
       """
-      |internal final fun finalMethod(): kotlin.Unit {
+      |internal final fun finalMethod() {
       |}
       |
       """.trimMargin(),
@@ -1071,7 +1072,7 @@ class FunSpecTest {
     assertThat(builder.build().toString()).isEqualTo(
       """
       |@kotlin.jvm.Synchronized
-      |internal fun synchronizedMethod(): kotlin.Unit {
+      |internal fun synchronizedMethod() {
       |}
       |
       """.trimMargin(),
@@ -1085,7 +1086,7 @@ class FunSpecTest {
 
     assertThat(methodSpec.toString()).isEqualTo(
       """
-      |public fun function(): kotlin.Unit {
+      |public fun function() {
       |  codeWithNoNewline()
       |}
       |
@@ -1101,7 +1102,7 @@ class FunSpecTest {
 
     assertThat(methodSpec.toString()).isEqualTo(
       """
-      |public fun function(): kotlin.Unit {
+      |public fun function() {
       |  codeWithNoNewline()
       |}
       |
@@ -1112,12 +1113,13 @@ class FunSpecTest {
   // https://github.com/square/kotlinpoet/issues/947
   @Test fun ensureTrailingNewlineWithExpressionBody() {
     val methodSpec = FunSpec.builder("function")
+      .returns(STRING)
       .addCode("return codeWithNoNewline()")
       .build()
 
     assertThat(methodSpec.toString()).isEqualTo(
       """
-      |public fun function() = codeWithNoNewline()
+      |public fun function(): kotlin.String = codeWithNoNewline()
       |
       """.trimMargin(),
     )
@@ -1125,12 +1127,13 @@ class FunSpecTest {
 
   @Test fun ensureTrailingNewlineWithExpressionBodyAndExistingNewline() {
     val methodSpec = FunSpec.builder("function")
+      .returns(STRING)
       .addCode("return codeWithNoNewline()\n") // Have a newline already, so ensure we're not adding one
       .build()
 
     assertThat(methodSpec.toString()).isEqualTo(
       """
-      |public fun function() = codeWithNoNewline()
+      |public fun function(): kotlin.String = codeWithNoNewline()
       |
       """.trimMargin(),
     )
@@ -1146,7 +1149,7 @@ class FunSpecTest {
       |/**
       | * This is a comment with no initial newline
       | */
-      |public fun function(): kotlin.Unit {
+      |public fun function() {
       |}
       |
       """.trimMargin(),
@@ -1164,7 +1167,7 @@ class FunSpecTest {
       |/**
       | * This is a comment with an initial newline
       | */
-      |public fun function(): kotlin.Unit {
+      |public fun function() {
       |}
       |
       """.trimMargin(),
@@ -1187,7 +1190,7 @@ class FunSpecTest {
       |
       |import kotlin.Unit
       |
-      |public fun (@Annotation () -> Unit).foo(): Unit {
+      |public fun (@Annotation () -> Unit).foo() {
       |}
       |
       """.trimMargin(),

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -47,16 +47,15 @@ class KotlinPoetTest {
         |package com.squareup.tacos
         |
         |import kotlin.String
-        |import kotlin.Unit
         |
-        |public fun a(): Unit {
+        |public fun a() {
         |}
         |
         |public class B
         |
         |public val c: String = "C"
         |
-        |public fun d(): Unit {
+        |public fun d() {
         |}
         |
         |public class E
@@ -224,19 +223,17 @@ class KotlinPoetTest {
       """
         |package com.squareup.tacos
         |
-        |import kotlin.Unit
-        |
         |public class Taco {
-        |  public fun a(): Unit {
+        |  public fun a() {
         |  }
         |
-        |  protected fun b(): Unit {
+        |  protected fun b() {
         |  }
         |
-        |  internal fun c(): Unit {
+        |  internal fun c() {
         |  }
         |
-        |  private fun d(): Unit {
+        |  private fun d() {
         |  }
         |}
         |
@@ -260,10 +257,8 @@ class KotlinPoetTest {
       "" +
         "package com.squareup.tacos\n" +
         "\n" +
-        "import kotlin.Unit\n" +
-        "\n" +
         "public class Taco {\n" +
-        "  public fun strings(): Unit {\n" +
+        "  public fun strings() {\n" +
         "    val a = \"basic string\"\n" +
         "    val b = \"string with a \${\'\$\'} dollar sign\"\n" +
         "  }\n" +
@@ -305,10 +300,8 @@ class KotlinPoetTest {
       "" +
         "package com.squareup.tacos\n" +
         "\n" +
-        "import kotlin.Unit\n" +
-        "\n" +
         "public class Taco {\n" +
-        "  public fun strings(): Unit {\n" +
+        "  public fun strings() {\n" +
         "    val a = \"\"\"\n" +
         "        |\"\n" +
         "        |\"\"\".trimMargin()\n" +
@@ -351,10 +344,8 @@ class KotlinPoetTest {
       "" +
         "package com.squareup.tacos\n" +
         "\n" +
-        "import kotlin.Unit\n" +
-        "\n" +
         "public class Taco {\n" +
-        "  public fun strings(): Unit {\n" +
+        "  public fun strings() {\n" +
         "    val a = \"\"\"\n" +
         "        |\n" +
         "        |\"\"\".trimMargin()\n" +
@@ -387,10 +378,9 @@ class KotlinPoetTest {
         |package com.squareup.tacos
         |
         |import kotlin.String
-        |import kotlin.Unit
         |
         |public class Taco {
-        |  public fun addCheese(kind: String = "monterey jack"): Unit {
+        |  public fun addCheese(kind: String = "monterey jack") {
         |  }
         |}
         |
@@ -792,13 +782,11 @@ class KotlinPoetTest {
       """
       |package com.squareup.tacos
       |
-      |import kotlin.Unit
-      |
       |public var bar: suspend (Foo) -> Bar = { Bar() }
       |
       |public var nullBar: (suspend (Foo) -> Bar)? = null
       |
-      |public fun foo(bar: suspend (Foo) -> Bar): Unit {
+      |public fun foo(bar: suspend (Foo) -> Bar) {
       |}
       |
       """.trimMargin(),
@@ -825,9 +813,8 @@ class KotlinPoetTest {
       |
       |import java.util.concurrent.TimeUnit
       |import kotlin.Long
-      |import kotlin.Unit
       |
-      |public fun timeout(duration: Long, timeUnit: TimeUnit = TimeUnit.MILLISECONDS): Unit {
+      |public fun timeout(duration: Long, timeUnit: TimeUnit = TimeUnit.MILLISECONDS) {
       |  this.timeout = timeUnit.toMillis(duration)
       |}
       |
@@ -864,9 +851,7 @@ class KotlinPoetTest {
       """
       |package com.squareup.tacos
       |
-      |import kotlin.Unit
-      |
-      |public fun dynamicTest(): Unit {
+      |public fun dynamicTest() {
       |  val d1: dynamic = "Taco"
       |  val d2: dynamic = 1f
       |  // dynamics are dangerous!
@@ -929,11 +914,10 @@ class KotlinPoetTest {
       |package com.squareup.tacos
       |
       |import kotlin.Int
-      |import kotlin.Unit
       |import kotlin.collections.List
       |import kotlin.jvm.JvmSuppressWildcards
       |
-      |public fun foo(a: List<@JvmSuppressWildcards Int>): Unit {
+      |public fun foo(a: List<@JvmSuppressWildcards Int>) {
       |}
       |
       """.trimMargin(),
@@ -1031,11 +1015,9 @@ class KotlinPoetTest {
       |package com.squareup.tacos
       |
       |import kotlin.String
-      |import kotlin.Unit
       |
       |public
-      |    fun functionWithAPrettyLongNameThatWouldCauseWrapping(parameterWithALongNameThatWouldAlsoCauseWrapping: String):
-      |    Unit {
+      |    fun functionWithAPrettyLongNameThatWouldCauseWrapping(parameterWithALongNameThatWouldAlsoCauseWrapping: String) {
       |}
       |
       """.trimMargin(),
@@ -1154,9 +1136,8 @@ class KotlinPoetTest {
       |package com.squareup.example
       |
       |import com.squareup.tacos.Taco
-      |import kotlin.Unit
       |
-      |public fun main(): Unit {
+      |public fun main() {
       |  println(${'"'}""Here's a taco: ${'$'}{Taco()}""${'"'})
       |}
       |
@@ -1179,10 +1160,9 @@ class KotlinPoetTest {
       """
       |package com.squareup.example
       |
-      |import kotlin.Unit
       |import kotlin.collections.contentToString
       |
-      |public fun main(): Unit {
+      |public fun main() {
       |  val ints = arrayOf(1, 2, 3)
       |  println(${'"'}""${'$'}{ints.contentToString()}""${'"'})
       |}
@@ -1217,7 +1197,7 @@ class KotlinPoetTest {
       | * @param a Progress in %
       | * @param b Some other parameter with %
       | */
-      |public fun test(a: kotlin.Int, b: kotlin.Int): kotlin.Unit {
+      |public fun test(a: kotlin.Int, b: kotlin.Int) {
       |}
       |
       """.trimMargin(),
@@ -1248,10 +1228,8 @@ class KotlinPoetTest {
       """
       |package test
       |
-      |import kotlin.Unit
-      |
       |public class Exception : kotlin.Exception() {
-      |  public fun test(e: Exception): Unit {
+      |  public fun test(e: Exception) {
       |  }
       |}
       |
@@ -1316,13 +1294,12 @@ class KotlinPoetTest {
       """
       |package com.example
       |
-      |import kotlin.Unit
       |import com.squareup.cash.util.isNullOrEmpty as utilIsNullOrEmpty
       |import com.squareup.tacos.Taco as SquareupTacosTaco
       |import kotlin.text.isNullOrEmpty as textIsNullOrEmpty
       |import xyz.block.tacos.Taco as BlockTacosTaco
       |
-      |public fun main(): Unit {
+      |public fun main() {
       |  val squareTaco = ::SquareupTacosTaco
       |  val blockTaco = ::BlockTacosTaco
       |  val isSquareTacoNull = "Taco".textIsNullOrEmpty()
@@ -1355,11 +1332,10 @@ class KotlinPoetTest {
       """
       |package com.example
       |
-      |import kotlin.Unit
       |import androidx.compose.ui.graphics.StrokeCap.Companion.Round as strokeCapRound
       |import androidx.compose.ui.graphics.StrokeJoin.Companion.Round as strokeJoinRound
       |
-      |public fun main(): Unit {
+      |public fun main() {
       |  val strokeCapRound = strokeCapRound()
       |  val strokeJoinRound = strokeJoinRound()
       |}
@@ -1391,13 +1367,12 @@ class KotlinPoetTest {
       """
       |package com.example
       |
-      |import kotlin.Unit
       |import com.squareup.cash.util.isNullOrEmpty as cashIsNullOrEmpty
       |import com.squareup.tacos.Taco as SquareTaco
       |import kotlin.text.isNullOrEmpty as kotlinIsNullOrEmpty
       |import xyz.block.tacos.Taco as BlockTaco
       |
-      |public fun main(): Unit {
+      |public fun main() {
       |  val squareTaco = ::SquareTaco
       |  val blockTaco = ::BlockTaco
       |  val isSquareTacoNull = "Taco".kotlinIsNullOrEmpty()

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/LineWrappingTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/LineWrappingTest.kt
@@ -21,6 +21,7 @@ import org.junit.Test
 class LineWrappingTest {
   @Test fun codeSpacesWrap() {
     val wrapMe = FunSpec.builder("wrapMe")
+      .returns(STRING)
       .addStatement(
         "return %L * %L * %L * %L * %L * %L * %L * %L * %L * %L * %L * %L",
         10000000000, 20000000000, 30000000000, 40000000000, 50000000000, 60000000000,
@@ -31,7 +32,9 @@ class LineWrappingTest {
       """
         |package com.squareup.tacos
         |
-        |public fun wrapMe() = 10_000_000_000 * 20_000_000_000 * 30_000_000_000 * 40_000_000_000 *
+        |import kotlin.String
+        |
+        |public fun wrapMe(): String = 10_000_000_000 * 20_000_000_000 * 30_000_000_000 * 40_000_000_000 *
         |    50_000_000_000 * 60_000_000_000 * 70_000_000_000 * 80_000_000_000 * 90_000_000_000 *
         |    10_000_000_000 * 20_000_000_000 * 30_000_000_000
         |
@@ -41,6 +44,7 @@ class LineWrappingTest {
 
   @Test fun stringSpacesDoNotWrap() {
     val wrapMe = FunSpec.builder("wrapMe")
+      .returns(STRING)
       .addStatement(
         "return %S+%S+%S+%S+%S+%S+%S+%S+%S+%S+%S+%S",
         "Aaaa Aaaa", "Bbbb Bbbb", "Cccc Cccc", "Dddd Dddd", "Eeee Eeee", "Ffff Ffff",
@@ -51,7 +55,9 @@ class LineWrappingTest {
       """
         |package com.squareup.tacos
         |
-        |public fun wrapMe() =
+        |import kotlin.String
+        |
+        |public fun wrapMe(): String =
         |    "Aaaa Aaaa"+"Bbbb Bbbb"+"Cccc Cccc"+"Dddd Dddd"+"Eeee Eeee"+"Ffff Ffff"+"Gggg Gggg"+"Hhhh Hhhh"+"Iiii Iiii"+"Jjjj Jjjj"+"Kkkk Kkkk"+"Llll Llll"
         |
       """.trimMargin(),
@@ -60,6 +66,7 @@ class LineWrappingTest {
 
   @Test fun nonwrappingWhitespaceDoesNotWrap() {
     val wrapMe = FunSpec.builder("wrapMe")
+      .returns(STRING)
       .addStatement(
         "return %L·*·%L·*·%L·*·%L·*·%L·*·%L·*·%L·*·%L·*·%L·*·%L·*·%L·*·%L",
         10000000000, 20000000000, 30000000000, 40000000000, 50000000000, 60000000000,
@@ -70,7 +77,9 @@ class LineWrappingTest {
       """
         |package com.squareup.tacos
         |
-        |public fun wrapMe() =
+        |import kotlin.String
+        |
+        |public fun wrapMe(): String =
         |    10_000_000_000 * 20_000_000_000 * 30_000_000_000 * 40_000_000_000 * 50_000_000_000 * 60_000_000_000 * 70_000_000_000 * 80_000_000_000 * 90_000_000_000 * 10_000_000_000 * 20_000_000_000 * 30_000_000_000
         |
       """.trimMargin(),
@@ -79,13 +88,16 @@ class LineWrappingTest {
 
   @Test fun nonwrappingWhitespaceIsRetainedInStrings() {
     val wrapMe = FunSpec.builder("wrapMe")
+      .returns(STRING)
       .addStatement("return %S", "a·b")
       .build()
     assertThat(toString(wrapMe)).isEqualTo(
       """
         |package com.squareup.tacos
         |
-        |public fun wrapMe() = "a·b"
+        |import kotlin.String
+        |
+        |public fun wrapMe(): String = "a·b"
         |
       """.trimMargin(),
     )
@@ -102,9 +114,7 @@ class LineWrappingTest {
       """
         |package com.squareup.tacos
         |
-        |import kotlin.Unit
-        |
-        |public fun wrapMe(): Unit {
+        |public fun wrapMe() {
         |  val a =    8
         |  val b =   64
         |  val c =  512
@@ -126,9 +136,7 @@ class LineWrappingTest {
       """
         |package com.squareup.tacos
         |
-        |import kotlin.Unit
-        |
-        |public fun wrapMe(): Unit {
+        |public fun wrapMe() {
         |  val aaaaaa = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" +1
         |  val bbbbbb =
         |      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" +1
@@ -159,7 +167,6 @@ class LineWrappingTest {
         |package com.squareup.tacos
         |
         |import kotlin.String
-        |import kotlin.Unit
         |
         |public class Taco {
         |  public fun call(
@@ -195,7 +202,7 @@ class LineWrappingTest {
         |    s29: String,
         |    s30: String,
         |    s31: String,
-        |  ): Unit {
+        |  ) {
         |    call("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16",
         |        "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31")
         |  }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/MemberNameTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/MemberNameTest.kt
@@ -39,9 +39,8 @@ class MemberNameTest {
       |
       |import com.squareup.tacos.bestTacoEver
       |import com.squareup.tacos.randomTaco
-      |import kotlin.Unit
       |
-      |public fun makeTastyTacos(): Unit {
+      |public fun makeTastyTacos() {
       |  val randomTaco = randomTaco()
       |  val bestTaco = bestTacoEver
       |}
@@ -65,9 +64,8 @@ class MemberNameTest {
       |package com.example
       |
       |import com.squareup.tacos.Taco.Companion.createTaco
-      |import kotlin.Unit
       |
-      |public fun makeTastyTacos(): Unit {
+      |public fun makeTastyTacos() {
       |  createTaco()
       |}
       |
@@ -88,9 +86,7 @@ class MemberNameTest {
       """
       |package com.squareup.tacos
       |
-      |import kotlin.Unit
-      |
-      |public fun makeTastyTacos(): Unit {
+      |public fun makeTastyTacos() {
       |  createTaco()
       |}
       |
@@ -115,9 +111,8 @@ class MemberNameTest {
       |package com.squareup.tacos
       |
       |import com.squareup.tacos.Town.createTaco
-      |import kotlin.Unit
       |
-      |public fun makeTastyTacos(): Unit {
+      |public fun makeTastyTacos() {
       |  createTaco()
       |}
       |
@@ -140,11 +135,10 @@ class MemberNameTest {
       """
       |package com.example
       |
-      |import kotlin.Unit
       |import com.squareup.tacos.createTaco as squareupTacosCreateTaco
       |import com.twitter.tacos.createTaco as twitterTacosCreateTaco
       |
-      |public fun makeTastyTacos(): Unit {
+      |public fun makeTastyTacos() {
       |  squareupTacosCreateTaco()
       |  twitterTacosCreateTaco()
       |}
@@ -170,11 +164,10 @@ class MemberNameTest {
       """
       |package com.example
       |
-      |import kotlin.Unit
       |import com.squareup.tacos.SquareTacos.Companion.createTaco as squareTacosCreateTaco
       |import com.twitter.tacos.TwitterTacos.Companion.createTaco as twitterTacosCreateTaco
       |
-      |public fun makeTastyTacos(): Unit {
+      |public fun makeTastyTacos() {
       |  squareTacosCreateTaco()
       |  twitterTacosCreateTaco()
       |}
@@ -199,9 +192,8 @@ class MemberNameTest {
       |package com.example
       |
       |import com.squareup.tacos.SquareTacos
-      |import kotlin.Unit
       |
-      |public fun makeTastyTacos(): Unit {
+      |public fun makeTastyTacos() {
       |  val tacos = SquareTacos()
       |  com.squareup.tacos.math.SquareTacos(tacos)
       |}
@@ -232,14 +224,12 @@ class MemberNameTest {
       """
       |package com.squareup.tacos
       |
-      |import kotlin.Unit
-      |
       |public class TacoTest {
-      |  public fun test(): Unit {
+      |  public fun test() {
       |    kotlin.error("errorText")
       |  }
       |
-      |  public fun error(): Unit {
+      |  public fun error() {
       |  }
       |}
       |
@@ -274,14 +264,12 @@ class MemberNameTest {
       """
       |package com.squareup.tacos
       |
-      |import kotlin.Unit
-      |
       |public class Test {
-      |  public fun error(): Unit {
+      |  public fun error() {
       |  }
       |
       |  public inner class TacoTest {
-      |    public fun test(): Unit {
+      |    public fun test() {
       |      kotlin.error("errorText")
       |    }
       |  }
@@ -317,15 +305,14 @@ class MemberNameTest {
       """
       |package com.squareup.tacos
       |
-      |import kotlin.Unit
       |import kotlin.error
       |
       |public class Test {
-      |  public fun error(): Unit {
+      |  public fun error() {
       |  }
       |
       |  public class TacoTest {
-      |    public fun test(): Unit {
+      |    public fun test() {
       |      error("errorText")
       |    }
       |  }
@@ -352,11 +339,10 @@ class MemberNameTest {
       """
       |package com.example
       |
-      |import kotlin.Unit
       |import com.squareup.tacos.createTaco as createSquareTaco
       |import com.twitter.tacos.createTaco as createTwitterTaco
       |
-      |public fun makeTastyTacos(): Unit {
+      |public fun makeTastyTacos() {
       |  createSquareTaco()
       |  createTwitterTaco()
       |}
@@ -383,13 +369,12 @@ class MemberNameTest {
       """
       |package com.squareup.tacos
       |
-      |import kotlin.Unit
       |import org.junit.Before
       |import org.mockito.`when`
       |
       |public class TacoTest {
       |  @Before
-      |  public fun setUp(): Unit {
+      |  public fun setUp() {
       |    `when`(tacoService.createTaco()).thenReturn(tastyTaco())
       |  }
       |}
@@ -415,11 +400,10 @@ class MemberNameTest {
       """
       |package com.example
       |
-      |import kotlin.Unit
       |import com.squareup.tacos.SquareTacos.Companion.`when` as squareTacosWhen
       |import com.twitter.tacos.TwitterTacos.Companion.`when` as twitterTacosWhen
       |
-      |public fun whenTastyTacos(): Unit {
+      |public fun whenTastyTacos() {
       |  squareTacosWhen()
       |  twitterTacosWhen()
       |}
@@ -445,9 +429,8 @@ class MemberNameTest {
       |
       |import com.squareup.tacos.TacoTruck
       |import com.squareup.tacos.randomTaco
-      |import kotlin.Unit
       |
-      |public fun makeTastyTacos(): Unit {
+      |public fun makeTastyTacos() {
       |  val randomTacoFactory = ::randomTaco
       |  val bestTacoFactory = TacoTruck::bestTacoEver
       |}
@@ -470,9 +453,8 @@ class MemberNameTest {
       |package com.squareup.tacos
       |
       |import com.squareup.`taco factory`.`produce tacos`
-      |import kotlin.Unit
       |
-      |public fun main(): Unit {
+      |public fun main() {
       |  println(`produce tacos`())
       |}
       |
@@ -514,10 +496,9 @@ class MemberNameTest {
       |
       |import com.squareup.tacos.Taco
       |import com.squareup.tacos.TacoPackager
-      |import kotlin.Unit
       |import kotlin.collections.List
       |
-      |public fun packageTacos(tacos: List<Taco>, packager: TacoPackager): Unit {
+      |public fun packageTacos(tacos: List<Taco>, packager: TacoPackager) {
       |  packager.`package`(tacos)
       |}
       |
@@ -549,9 +530,8 @@ class MemberNameTest {
       |import com.squareup.tacos.`internal`.iterator
       |import com.squareup.tacos.`internal`.minusAssign
       |import com.squareup.tacos.ingredient.Meat
-      |import kotlin.Unit
       |
-      |public fun makeTacoHealthy(taco: Taco): Unit {
+      |public fun makeTacoHealthy(taco: Taco) {
       |  for (ingredient in taco) {
       |    if (ingredient is Meat) taco -= ingredient
       |  }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ParameterSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ParameterSpecTest.kt
@@ -127,7 +127,7 @@ class ParameterSpecTest {
       |
       |import kotlin.Unit
       |
-      |public fun foo(bar: @Annotation () -> Unit): Unit {
+      |public fun foo(bar: @Annotation () -> Unit) {
       |}
       |
       """.trimMargin(),

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/StringsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/StringsTest.kt
@@ -22,19 +22,21 @@ class StringsTest {
   @Test fun singleLineStringWithDollarSymbols() {
     val stringWithTemplate = "$" + "annoyingUser" + " is annoying."
     val funSpec = FunSpec.builder("getString")
+      .returns(STRING)
       .addStatement("return %S", stringWithTemplate)
       .build()
     assertThat(funSpec.toString())
-      .isEqualTo("public fun getString() = \"\${\'\$\'}annoyingUser is annoying.\"\n")
+      .isEqualTo("public fun getString(): kotlin.String = \"\${\'\$\'}annoyingUser is annoying.\"\n")
   }
 
   @Test fun multilineStringWithDollarSymbols() {
     val stringWithTemplate = "Some string\n" + "$" + "annoyingUser" + " is annoying."
     val funSpec = FunSpec.builder("getString")
+      .returns(STRING)
       .addStatement("return %S", stringWithTemplate)
       .build()
     assertThat(funSpec.toString()).isEqualTo(
-      "public fun getString() = \"\"\"\n" +
+      "public fun getString(): kotlin.String = \"\"\"\n" +
         "|Some string\n" +
         "|\${\'\$\'}annoyingUser is annoying.\n" +
         "\"\"\".trimMargin()\n",
@@ -44,19 +46,21 @@ class StringsTest {
   @Test fun singleLineStringTemplate() {
     val stringWithTemplate = "$" + "annoyingUser" + " is annoying."
     val funSpec = FunSpec.builder("getString")
+      .returns(STRING)
       .addStatement("return %P", stringWithTemplate)
       .build()
     assertThat(funSpec.toString())
-      .isEqualTo("public fun getString() = \"\"\"\$annoyingUser is annoying.\"\"\"\n")
+      .isEqualTo("public fun getString(): kotlin.String = \"\"\"\$annoyingUser is annoying.\"\"\"\n")
   }
 
   @Test fun multilineStringTemplate() {
     val stringWithTemplate = "Some string\n" + "$" + "annoyingUser" + " is annoying."
     val funSpec = FunSpec.builder("getString")
+      .returns(STRING)
       .addStatement("return %P", stringWithTemplate)
       .build()
     assertThat(funSpec.toString()).isEqualTo(
-      "public fun getString() = \"\"\"\n" +
+      "public fun getString(): kotlin.String = \"\"\"\n" +
         "|Some string\n" +
         "|\$annoyingUser is annoying.\n" +
         "\"\"\".trimMargin()\n",
@@ -67,9 +71,10 @@ class StringsTest {
   @Test fun templateStringWithStringLiteralReference() {
     val string = "SELECT * FROM socialFeedItem WHERE message IS NOT NULL AND userId \${ if (userId == null) \"IS\" else \"=\" } ?1 ORDER BY datetime(creation_time) DESC"
     val funSpec = FunSpec.builder("getString")
+      .returns(STRING)
       .addStatement("return %P", string)
       .build()
     assertThat(funSpec.toString())
-      .isEqualTo("public fun getString() = \"\"\"SELECT * FROM socialFeedItem WHERE message IS NOT NULL AND userId \${ if (userId == null) \"IS\" else \"=\" } ?1 ORDER BY datetime(creation_time) DESC\"\"\"\n")
+      .isEqualTo("public fun getString(): kotlin.String = \"\"\"SELECT * FROM socialFeedItem WHERE message IS NOT NULL AND userId \${ if (userId == null) \"IS\" else \"=\" } ?1 ORDER BY datetime(creation_time) DESC\"\"\"\n")
   }
 }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -169,13 +169,11 @@ class TypeSpecTest {
       """
         |package com.squareup.tacos
         |
-        |import kotlin.Unit
-        |
         |public class Taco {
         |  public val NAME: Thing.Thang<Foo, Bar> = object : Thing.Thang<Foo, Bar>() {
         |    public override fun call(thung: Thung<in Foo>): Thung<in Bar> = object : SimpleThung<Bar>(thung)
         |        {
-        |      public override fun doSomething(bar: Bar): Unit {
+        |      public override fun doSomething(bar: Bar) {
         |        /* code snippets */
         |      }
         |    }
@@ -240,11 +238,10 @@ class TypeSpecTest {
         |
         |import com.squareup.wire.Message
         |import java.lang.Runnable
-        |import kotlin.Unit
         |
         |public class Taco {
         |  public val NAME: Runnable = object : Message(), Runnable {
-        |    public override fun run(): Unit {
+        |    public override fun run() {
         |      /* code snippets */
         |    }
         |  }
@@ -622,16 +619,14 @@ class TypeSpecTest {
       """
         |package com.squareup.tacos
         |
-        |import kotlin.Unit
-        |
         |public enum class Tortilla {
         |  CORN {
-        |    public override fun fold(): Unit {
+        |    public override fun fold() {
         |    }
         |  },
         |  ;
         |
-        |  public abstract fun fold(): Unit
+        |  public abstract fun fold()
         |}
         |
       """.trimMargin(),
@@ -701,12 +696,11 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import kotlin.String
-        |import kotlin.Unit
         |
         |public sealed class Sealed {
         |  public abstract val name: String
         |
-        |  public abstract fun fold(): Unit
+        |  public abstract fun fold()
         |}
         |
       """.trimMargin(),
@@ -926,26 +920,25 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import java.io.IOException
-        |import kotlin.Unit
         |import kotlin.jvm.Throws
         |
         |public abstract class Taco {
         |  @Throws(IOException::class)
-        |  public fun throwOne(): Unit {
+        |  public fun throwOne() {
         |  }
         |
         |  @Throws(
         |    IOException::class,
         |    SourCreamException::class,
         |  )
-        |  public fun throwTwo(): Unit {
+        |  public fun throwTwo() {
         |  }
         |
         |  @Throws(IOException::class)
-        |  public abstract fun abstractThrow(): Unit
+        |  public abstract fun abstractThrow()
         |
         |  @Throws(IOException::class)
-        |  public external fun nativeThrow(): Unit
+        |  public external fun nativeThrow()
         |}
         |
       """.trimMargin(),
@@ -1208,12 +1201,10 @@ class TypeSpecTest {
       """
         |package com.squareup.tacos
         |
-        |import kotlin.Unit
-        |
         |public fun interface Taco {
-        |  public fun sam(): Unit
+        |  public fun sam()
         |
-        |  public fun notSam(): Unit {
+        |  public fun notSam() {
         |  }
         |}
         |
@@ -1489,7 +1480,7 @@ class TypeSpecTest {
     assertThat(classA.toString()).isEqualTo(
       """
       |public expect class ClassA {
-      |  public fun test(): kotlin.Unit
+      |  public fun test()
       |}
       |
       """.trimMargin(),
@@ -1512,7 +1503,7 @@ class TypeSpecTest {
       """
       |public expect class ClassA {
       |  public companion object {
-      |    public fun test(): kotlin.Unit
+      |    public fun test()
       |  }
       |}
       |
@@ -1536,7 +1527,7 @@ class TypeSpecTest {
       """
       |public expect class ClassA {
       |  public class ClassB {
-      |    public fun test(): kotlin.Unit
+      |    public fun test()
       |  }
       |}
       |
@@ -1565,7 +1556,7 @@ class TypeSpecTest {
       |public expect class ClassA {
       |  public class ClassB {
       |    public class ClassC {
-      |      public fun test(): kotlin.Unit
+      |      public fun test()
       |    }
       |  }
       |}
@@ -1600,7 +1591,7 @@ class TypeSpecTest {
       |  public class ClassB {
       |    public class ClassC {
       |      public class ClassD {
-      |        public fun test(): kotlin.Unit
+      |        public fun test()
       |      }
       |    }
       |  }
@@ -1695,15 +1686,13 @@ class TypeSpecTest {
       """
         |package com.squareup.tacos
         |
-        |import kotlin.Unit
-        |
         |public interface Taco {
-        |  public fun aMethod(): Unit
+        |  public fun aMethod()
         |
-        |  public fun aDefaultMethod(): Unit {
+        |  public fun aDefaultMethod() {
         |  }
         |
-        |  private fun aPrivateMethod(): Unit {
+        |  private fun aPrivateMethod() {
         |  }
         |}
         |
@@ -1891,7 +1880,6 @@ class TypeSpecTest {
         |
         |import java.util.Locale
         |import kotlin.Boolean
-        |import kotlin.Unit
         |
         |/**
         | * A hard or soft tortilla, loosely folded and filled with whatever
@@ -1909,7 +1897,7 @@ class TypeSpecTest {
         |   *
         |   * For [Locale#KOREAN], the front may also be folded.
         |   */
-        |  public fun refold(locale: Locale): Unit {
+        |  public fun refold(locale: Locale) {
         |  }
         |}
         |
@@ -2056,10 +2044,9 @@ class TypeSpecTest {
         |
         |import java.lang.Runnable
         |import kotlin.Int
-        |import kotlin.Unit
         |
         |public class Taqueria {
-        |  public fun prepare(workers: Int, vararg jobs: Runnable): Unit {
+        |  public fun prepare(workers: Int, vararg jobs: Runnable) {
         |  }
         |}
         |
@@ -2084,14 +2071,13 @@ class TypeSpecTest {
         |import java.lang.Runnable
         |import kotlin.Boolean
         |import kotlin.Int
-        |import kotlin.Unit
         |
         |public class Taqueria {
         |  public fun prepare(
         |    workers: Int,
         |    vararg jobs: Runnable,
         |    start: Boolean,
-        |  ): Unit {
+        |  ) {
         |  }
         |}
         |
@@ -2193,10 +2179,9 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import java.lang.System
-        |import kotlin.Unit
         |
         |public class Taco {
-        |  public fun choices(): Unit {
+        |  public fun choices() {
         |    if (taco != null || taco == otherTaco) {
         |      System.out.println("only one taco? NOO!")
         |    } else if (taco.isSupreme() && otherTaco.isSupreme()) {
@@ -2226,10 +2211,9 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import java.lang.System
-        |import kotlin.Unit
         |
         |public class Taco {
-        |  public fun choices(): Unit {
+        |  public fun choices() {
         |    if (5 < 4)  {
         |      System.out.println("wat")
         |    } else if (5 < 6) {
@@ -2255,10 +2239,9 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import java.lang.System
-        |import kotlin.Unit
         |
         |public class Taco {
-        |  public fun inlineIndent(): Unit {
+        |  public fun inlineIndent() {
         |    if (3 < 4) {
         |      System.out.println("hello");
         |    }
@@ -2333,7 +2316,6 @@ class TypeSpecTest {
         |import kotlin.Int
         |import kotlin.Long
         |import kotlin.String
-        |import kotlin.Unit
         |
         |public class Members {
         |  public val W: String
@@ -2344,16 +2326,16 @@ class TypeSpecTest {
         |
         |  public constructor(o: Long)
         |
-        |  public fun T(): Unit {
+        |  public fun T() {
         |  }
         |
-        |  public fun S(): Unit {
+        |  public fun S() {
         |  }
         |
-        |  public fun R(): Unit {
+        |  public fun R() {
         |  }
         |
-        |  public fun Q(): Unit {
+        |  public fun Q() {
         |  }
         |
         |  public class Z
@@ -2486,7 +2468,7 @@ class TypeSpecTest {
     assertThat(type.toString()).isEqualTo(
       """
         |object : java.lang.Runnable {
-        |  public override fun run(): kotlin.Unit {
+        |  public override fun run() {
         |  }
         |}
       """.trimMargin(),
@@ -2599,7 +2581,6 @@ class TypeSpecTest {
         |import java.util.Comparator
         |import kotlin.Int
         |import kotlin.String
-        |import kotlin.Unit
         |import kotlin.collections.List
         |
         |public class Taco {
@@ -2614,7 +2595,7 @@ class TypeSpecTest {
         |    }
         |  }
         |
-        |  public fun sortPrefix(list: List<String>, length: Int): Unit {
+        |  public fun sortPrefix(list: List<String>, length: Int) {
         |    Collections.sort(
         |        list,
         |        object : Comparator<String> {
@@ -2832,10 +2813,8 @@ class TypeSpecTest {
       """
         |package com.squareup.tacos
         |
-        |import kotlin.Unit
-        |
         |public class Taco {
-        |  public fun addTopping(topping: Topping): Unit {
+        |  public fun addTopping(topping: Topping) {
         |    try {
         |      /* do something tricky with the topping */
         |    } catch (e: IllegalToppingException) {
@@ -2887,6 +2866,7 @@ class TypeSpecTest {
       .addFunction(
         FunSpec.builder("toppingPrice")
           .addParameter("topping", String::class)
+          .returns(INT)
           .beginControlFlow("return when(topping)")
           .addStatement("%S -> 1", "beef")
           .addStatement("%S -> 2", "lettuce")
@@ -2900,10 +2880,11 @@ class TypeSpecTest {
       """
         |package com.squareup.tacos
         |
+        |import kotlin.Int
         |import kotlin.String
         |
         |public class Taco {
-        |  public fun toppingPrice(topping: String) = when(topping) {
+        |  public fun toppingPrice(topping: String): Int = when(topping) {
         |    "beef" -> 1
         |    "lettuce" -> 2
         |    "cheese" -> 3
@@ -3383,7 +3364,6 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import kotlin.Int
-        |import kotlin.Unit
         |
         |public object MyObject {
         |  public val tacos: Int
@@ -3391,7 +3371,7 @@ class TypeSpecTest {
         |  init {
         |  }
         |
-        |  public fun test(): Unit {
+        |  public fun test() {
         |  }
         |}
         |
@@ -3417,13 +3397,12 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import com.squareup.wire.Message
-        |import kotlin.Unit
         |
         |public object MyObject : Message() {
         |  init {
         |  }
         |
-        |  public fun test(): Unit {
+        |  public fun test() {
         |  }
         |}
         |
@@ -3455,13 +3434,12 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import kotlin.Int
-        |import kotlin.Unit
         |
         |public class MyClass {
         |  public companion object {
         |    public val tacos: Int = 42
         |
-        |    public fun test(): Unit {
+        |    public fun test() {
         |    }
         |  }
         |}
@@ -3523,11 +3501,9 @@ class TypeSpecTest {
       """
         |package com.squareup.tacos
         |
-        |import kotlin.Unit
-        |
         |public class MyClass {
         |  public companion object Factory {
-        |    public fun tacos(): Unit {
+        |    public fun tacos() {
         |    }
         |  }
         |}
@@ -3554,11 +3530,9 @@ class TypeSpecTest {
       """
         |package com.squareup.tacos
         |
-        |import kotlin.Unit
-        |
         |public interface MyInterface {
         |  public companion object {
-        |    public fun test(): Unit {
+        |    public fun test() {
         |    }
         |  }
         |}
@@ -3587,15 +3561,13 @@ class TypeSpecTest {
       """
         |package com.squareup.tacos
         |
-        |import kotlin.Unit
-        |
         |public enum class MyEnum {
         |  FOO,
         |  BAR,
         |  ;
         |
         |  public companion object {
-        |    public fun test(): Unit {
+        |    public fun test() {
         |    }
         |  }
         |}
@@ -3643,11 +3615,10 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import com.squareup.wire.Message
-        |import kotlin.Unit
         |
         |public class MyClass {
         |  public companion object : Message() {
-        |    public fun test(): Unit {
+        |    public fun test() {
         |    }
         |  }
         |}
@@ -4248,10 +4219,9 @@ class TypeSpecTest {
         |package com.squareup.tacos
         |
         |import kotlin.String
-        |import kotlin.Unit
         |
         |public class Taco {
-        |  public fun shell(): Unit {
+        |  public fun shell() {
         |    val taco1: String = "Taco!"
         |    val taco2: String? = null
         |    lateinit var taco3: String
@@ -4453,10 +4423,8 @@ class TypeSpecTest {
       """
       |package com.squareup.tacos
       |
-      |import kotlin.Unit
-      |
       |public external class Foo {
-      |  public fun bar(): Unit
+      |  public fun bar()
       |}
       |
       """.trimMargin(),
@@ -4475,12 +4443,11 @@ class TypeSpecTest {
       |package com.squareup.tacos
       |
       |import kotlin.String
-      |import kotlin.Unit
       |
       |public external interface Foo {
       |  public val baz: String
       |
-      |  public fun bar(): Unit
+      |  public fun bar()
       |}
       |
       """.trimMargin(),
@@ -4499,12 +4466,11 @@ class TypeSpecTest {
       |package com.squareup.tacos
       |
       |import kotlin.String
-      |import kotlin.Unit
       |
       |public external object Foo {
       |  public val baz: String
       |
-      |  public fun bar(): Unit
+      |  public fun bar()
       |}
       |
       """.trimMargin(),
@@ -4538,19 +4504,17 @@ class TypeSpecTest {
       """
       |package com.squareup.tacos
       |
-      |import kotlin.Unit
-      |
       |public external class Foo {
       |  public class Nested1 {
-      |    public fun baz(): Unit
+      |    public fun baz()
       |
       |    public object Nested2 {
-      |      public fun bar(): Unit
+      |      public fun bar()
       |    }
       |  }
       |
       |  public companion object {
-      |    public fun qux(): Unit
+      |    public fun qux()
       |  }
       |}
       |
@@ -5168,7 +5132,7 @@ class TypeSpecTest {
       .build()
     assertThat(funSpec.toString()).isEqualTo(
       """
-      |public fun printTaco(taco: com.squareup.tacos.Taco.`object`): kotlin.Unit {
+      |public fun printTaco(taco: com.squareup.tacos.Taco.`object`) {
       |  print(taco)
       |}
       |
@@ -5212,7 +5176,6 @@ class TypeSpecTest {
       package com.squareup.tacos
 
       import kotlin.String
-      import kotlin.Unit
 
       public interface Taco {
         public val foo: String
@@ -5221,7 +5184,7 @@ class TypeSpecTest {
 
         public fun bar(): String
 
-        public fun barWithDefault(): Unit {
+        public fun barWithDefault() {
         }
       }
 
@@ -5379,7 +5342,7 @@ class TypeSpecTest {
     assertThat(baseClass.toString()).isEqualTo(
       """
       |public abstract class Base {
-      |  internal abstract fun foo(): kotlin.Unit
+      |  internal abstract fun foo()
       |}
       |
       """.trimMargin(),
@@ -5397,7 +5360,7 @@ class TypeSpecTest {
     assertThat(exampleClass.toString()).isEqualTo(
       """
       |public class Example : Base() {
-      |  override fun foo(): kotlin.Unit {
+      |  override fun foo() {
       |  }
       |}
       |
@@ -5417,7 +5380,7 @@ class TypeSpecTest {
     assertThat(example2Class.toString()).isEqualTo(
       """
       |public class Example2 : Base() {
-      |  public override fun foo(): kotlin.Unit {
+      |  public override fun foo() {
       |  }
       |}
       |
@@ -5437,7 +5400,7 @@ class TypeSpecTest {
     assertThat(example3Class.toString()).isEqualTo(
       """
       |internal class Example3 : Base() {
-      |  public override fun foo(): kotlin.Unit {
+      |  public override fun foo() {
       |  }
       |}
       |

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeVariableNameTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeVariableNameTest.kt
@@ -176,7 +176,7 @@ class TypeVariableNameTest {
       .build()
     assertThat(funSpec.toString()).isEqualTo(
       """
-      |public inline fun <reified T> printMembers(): kotlin.Unit {
+      |public inline fun <reified T> printMembers() {
       |  println(T::class.members)
       |}
       |

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/UtilTest.kt
@@ -124,9 +124,8 @@ class UtilTest {
       import kotlin.Function1
       import kotlin.Int
       import kotlin.String
-      import kotlin.Unit
 
-      public fun foo(`aaa bbb`: Function1<Int, String>): Unit {
+      public fun foo(`aaa bbb`: Function1<Int, String>) {
         `aaa bbb`(0) + `aaa bbb`(1) + `aaa bbb`(2) + `aaa bbb`(3) + `aaa bbb`(4) + `aaa bbb`(5) +
             `aaa bbb`(6) + `aaa bbb`(7) + `aaa bbb`(8) + `aaa bbb`(9) + `aaa bbb`(100)
       }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/jvm/JvmAnnotationsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/jvm/JvmAnnotationsTest.kt
@@ -271,14 +271,13 @@ class JvmAnnotationsTest {
       |
       |import java.io.IOException
       |import java.lang.IllegalArgumentException
-      |import kotlin.Unit
       |import kotlin.jvm.Throws
       |
       |@Throws(
       |  IOException::class,
       |  IllegalArgumentException::class,
       |)
-      |public fun foo(): Unit {
+      |public fun foo() {
       |}
       |
       """.trimMargin(),
@@ -297,11 +296,10 @@ class JvmAnnotationsTest {
       """
       |package com.squareup.tacos
       |
-      |import kotlin.Unit
       |import kotlin.jvm.Throws
       |
       |@Throws(IllegalTacoException::class)
-      |public fun foo(): Unit {
+      |public fun foo() {
       |}
       |
       """.trimMargin(),
@@ -419,11 +417,10 @@ class JvmAnnotationsTest {
       |
       |import kotlin.Int
       |import kotlin.String
-      |import kotlin.Unit
       |import kotlin.jvm.JvmOverloads
       |
       |@JvmOverloads
-      |public fun foo(bar: Int, baz: String = "baz"): Unit {
+      |public fun foo(bar: Int, baz: String = "baz") {
       |}
       |
       """.trimMargin(),
@@ -515,11 +512,10 @@ class JvmAnnotationsTest {
       """
       |package com.squareup.tacos
       |
-      |import kotlin.Unit
       |import kotlin.jvm.JvmName
       |
       |@JvmName("getFoo")
-      |public fun foo(): Unit {
+      |public fun foo() {
       |}
       |
       """.trimMargin(),
@@ -649,11 +645,10 @@ class JvmAnnotationsTest {
       """
       |package com.squareup.tacos
       |
-      |import kotlin.Unit
       |import kotlin.jvm.JvmSuppressWildcards
       |
       |@JvmSuppressWildcards(suppress = false)
-      |public fun foo(): Unit {
+      |public fun foo() {
       |}
       |
       """.trimMargin(),
@@ -721,11 +716,10 @@ class JvmAnnotationsTest {
       |package com.squareup.tacos
       |
       |import kotlin.Int
-      |import kotlin.Unit
       |import kotlin.collections.List
       |import kotlin.jvm.JvmSuppressWildcards
       |
-      |public fun foo(a: List<@JvmSuppressWildcards Int>): Unit {
+      |public fun foo(a: List<@JvmSuppressWildcards Int>) {
       |}
       |
       """.trimMargin(),
@@ -749,11 +743,10 @@ class JvmAnnotationsTest {
       |package com.squareup.tacos
       |
       |import kotlin.Int
-      |import kotlin.Unit
       |import kotlin.collections.List
       |import kotlin.jvm.JvmWildcard
       |
-      |public fun foo(a: List<@JvmWildcard Int>): Unit {
+      |public fun foo(a: List<@JvmWildcard Int>) {
       |}
       |
       """.trimMargin(),
@@ -765,6 +758,7 @@ class JvmAnnotationsTest {
       .addFunction(
         FunSpec.builder("foo")
           .synchronized()
+          .returns(STRING)
           .addStatement("return %S", "foo")
           .build(),
       )
@@ -773,10 +767,11 @@ class JvmAnnotationsTest {
       """
       |package com.squareup.tacos
       |
+      |import kotlin.String
       |import kotlin.jvm.Synchronized
       |
       |@Synchronized
-      |public fun foo() = "foo"
+      |public fun foo(): String = "foo"
       |
       """.trimMargin(),
     )
@@ -986,11 +981,10 @@ class JvmAnnotationsTest {
       """
       |package com.squareup.tacos
       |
-      |import kotlin.Unit
       |import kotlin.jvm.Strictfp
       |
       |@Strictfp
-      |public fun foo(): Unit {
+      |public fun foo() {
       |}
       |
       """.trimMargin(),


### PR DESCRIPTION
The only time it needs produced is when the function body is an expression in a non-ctor/getter/setter.

This contains a behavior change which explicitly makes the default return type `Unit`. This was somewhat the case before, except when you emitted a function body which could be turned into an expression. In this case you were able to get an implicit (i.e., unspecified) return type as none was declared. This would violate usages in explicit API contexts. A function with an omitted return type and a body which can be turned into an expression will now see an explicit `Unit` return type emitted. The fix is to declare the proper return type or remove the use of `return`.

Closes #1540