### PR TITLE
group Kotlin and Renovate updates together in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,13 @@
     {
       "matchManagers": ["pip_requirements"],
       "automerge": true
+    },
+    {
+      "matchPackagePatterns": [
+        "^org\\.jetbrains\\.kotlin:(?:[\\w-]+)$",
+        "^com\\.google\\.devtools\\.ksp:(?:[\\w-]+)$"
+      ],
+      "groupName": "Kotlin and KSP"
     }
   ]
 }


### PR DESCRIPTION
fixes #1496

This is lifted from our config in [Workflow-kotlin](https://github.com/square/workflow-kotlin/blob/main/renovate.json).  [This PR](https://github.com/square/workflow-kotlin/pull/948) is grouped because of that package rule.