### PR TITLE
Allow properties with context receivers in interfaces to omit declaring accessors

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/PropertySpec.kt
@@ -56,12 +56,6 @@ public class PropertySpec private constructor(
     require(mutable || setter == null) {
       "only a mutable property can have a setter"
     }
-    if (contextReceiverTypes.isNotEmpty()) {
-      requireNotNull(getter) { "properties with context receivers require a $GETTER" }
-      if (mutable) {
-        requireNotNull(setter) { "mutable properties with context receivers require a $SETTER" }
-      }
-    }
   }
 
   internal fun emit(

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -789,6 +789,20 @@ public class TypeSpec private constructor(
         }
       }
 
+      for (propertySpec in propertySpecs) {
+        require(isAbstract || ABSTRACT !in propertySpec.modifiers) {
+          "non-abstract type $name cannot declare abstract property ${propertySpec.name}"
+        }
+        if (propertySpec.contextReceiverTypes.isNotEmpty()) {
+          if (ABSTRACT !in kind.implicitPropertyModifiers(modifiers) + propertySpec.modifiers) {
+            requireNotNull(propertySpec.getter) { "non-abstract properties with context receivers require a ${FunSpec.GETTER}" }
+            if (propertySpec.mutable) {
+              requireNotNull(propertySpec.setter) { "non-abstract mutable properties with context receivers require a ${FunSpec.SETTER}" }
+            }
+          }
+        }
+      }
+
       if (isAnnotation) {
         primaryConstructor?.let {
           requireNoneOf(it.modifiers, INTERNAL, PROTECTED, PRIVATE, ABSTRACT)

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -16,8 +16,6 @@
 package com.squareup.kotlinpoet
 
 import com.google.common.truth.Truth.assertThat
-import com.squareup.kotlinpoet.FunSpec.Companion.GETTER
-import com.squareup.kotlinpoet.FunSpec.Companion.SETTER
 import com.squareup.kotlinpoet.KModifier.EXTERNAL
 import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.KModifier.PUBLIC
@@ -648,44 +646,6 @@ class PropertySpecTest {
 
       """.trimIndent(),
     )
-  }
-
-  @Test fun varWithContextReceiverWithoutCustomAccessors() {
-    val mutablePropertySpecBuilder = {
-      PropertySpec.builder("foo", STRING)
-        .mutable()
-        .contextReceivers(INT)
-    }
-
-    assertThrows<IllegalArgumentException> {
-      mutablePropertySpecBuilder()
-        .getter(
-          FunSpec.getterBuilder()
-            .build(),
-        )
-        .build()
-    }.hasMessageThat()
-      .isEqualTo("mutable properties with context receivers require a $SETTER")
-
-    assertThrows<IllegalArgumentException> {
-      mutablePropertySpecBuilder()
-        .setter(
-          FunSpec.setterBuilder()
-            .build(),
-        )
-        .build()
-    }.hasMessageThat()
-      .isEqualTo("properties with context receivers require a $GETTER")
-  }
-
-  @Test fun valWithContextReceiverWithoutGetter() {
-    assertThrows<IllegalArgumentException> {
-      PropertySpec.builder("foo", STRING)
-        .mutable(false)
-        .contextReceivers(INT)
-        .build()
-    }.hasMessageThat()
-      .isEqualTo("properties with context receivers require a $GETTER")
   }
 
   @Test fun varWithContextReceiver() {


### PR DESCRIPTION
Closes #1525 

* Move check for getters and setters on properties with context receivers into `TypeSpec.kt`
* Disallow abstract properties in non-abstract types