### PR TITLE
Add `FileSpec.builder` convenience for `MemberName`

### DIFF
--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -187,6 +187,7 @@ public abstract interface annotation class com/squareup/kotlinpoet/ExperimentalK
 public final class com/squareup/kotlinpoet/FileSpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/Taggable {
 	public static final field Companion Lcom/squareup/kotlinpoet/FileSpec$Companion;
 	public static final fun builder (Lcom/squareup/kotlinpoet/ClassName;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
+	public static final fun builder (Lcom/squareup/kotlinpoet/MemberName;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public static final fun builder (Ljava/lang/String;Ljava/lang/String;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun get (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeSpec;)Lcom/squareup/kotlinpoet/FileSpec;
@@ -275,6 +276,7 @@ public final class com/squareup/kotlinpoet/FileSpec$Builder : com/squareup/kotli
 
 public final class com/squareup/kotlinpoet/FileSpec$Companion {
 	public final fun builder (Lcom/squareup/kotlinpoet/ClassName;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
+	public final fun builder (Lcom/squareup/kotlinpoet/MemberName;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun builder (Ljava/lang/String;Ljava/lang/String;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun get (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeSpec;)Lcom/squareup/kotlinpoet/FileSpec;
 	public final fun scriptBuilder (Ljava/lang/String;Ljava/lang/String;)Lcom/squareup/kotlinpoet/FileSpec$Builder;

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/FileSpec.kt
@@ -536,6 +536,10 @@ public class FileSpec private constructor(
       return builder(className.packageName, className.simpleName)
     }
 
+    @JvmStatic public fun builder(memberName: MemberName): Builder {
+      return builder(memberName.packageName, memberName.simpleName)
+    }
+
     @JvmStatic public fun builder(packageName: String, fileName: String): Builder =
       Builder(packageName, fileName, isScript = false)
 

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -1204,4 +1204,11 @@ class FileSpecTest {
       FileSpec.builder(className)
     }
   }
+
+  @Test fun memberNameFactory() {
+    val memberName = MemberName("com.example", "Example")
+    val spec = FileSpec.builder(memberName).build()
+    assertThat(spec.packageName).isEqualTo(memberName.packageName)
+    assertThat(spec.name).isEqualTo(memberName.simpleName)
+  }
 }


### PR DESCRIPTION
Same use case as when you use the `ClassName` factory.