### PR TITLE
Deprecate TypeSpec.expectClassBuilder() and TypeSpec.valueClassBuilder()

### DIFF
--- a/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -273,7 +273,7 @@ private fun KmClass.toTypeSpec(
     isAnnotation -> TypeSpec.annotationBuilder(simpleName)
     isCompanionObject -> TypeSpec.companionObjectBuilder(companionObjectName(simpleName))
     isEnum -> TypeSpec.enumBuilder(simpleName)
-    isExpect -> TypeSpec.expectClassBuilder(simpleName)
+    isExpect -> TypeSpec.classBuilder(simpleName).addModifiers(EXPECT)
     isObject -> TypeSpec.objectBuilder(simpleName)
     isInterface -> {
       if (classData?.declarationContainer?.isFun == true) {

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -886,14 +886,14 @@ public class TypeSpec private constructor(
     @JvmStatic public fun classBuilder(className: ClassName): Builder = classBuilder(className.simpleName)
 
     @Deprecated(
-      "Use classBuilder() instead. This function will be removed in KotlinPoet 2.0",
+      "Use classBuilder() instead. This function will be removed in KotlinPoet 2.0.",
       ReplaceWith("TypeSpec.classBuilder(name).addModifiers(KModifier.EXPECT)"),
     )
     @JvmStatic
     public fun expectClassBuilder(name: String): Builder = Builder(Kind.CLASS, name, EXPECT)
 
     @Deprecated(
-      "Use classBuilder() instead. This function will be removed in KotlinPoet 2.0",
+      "Use classBuilder() instead. This function will be removed in KotlinPoet 2.0.",
       ReplaceWith("TypeSpec.classBuilder(className).addModifiers(KModifier.EXPECT)"),
     )
     @JvmStatic

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -897,7 +897,7 @@ public class TypeSpec private constructor(
       ReplaceWith("TypeSpec.classBuilder(className).addModifiers(KModifier.EXPECT)"),
     )
     @JvmStatic
-    public fun expectClassBuilder(className: ClassName): Builder = expectClassBuilder(className.simpleName)
+    public fun expectClassBuilder(className: ClassName): Builder = classBuilder(className.simpleName).addModifiers(EXPECT)
 
     @JvmStatic public fun valueClassBuilder(name: String): Builder = Builder(Kind.CLASS, name, VALUE)
 

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -899,7 +899,12 @@ public class TypeSpec private constructor(
     @JvmStatic
     public fun expectClassBuilder(className: ClassName): Builder = classBuilder(className.simpleName).addModifiers(EXPECT)
 
-    @JvmStatic public fun valueClassBuilder(name: String): Builder = Builder(Kind.CLASS, name, VALUE)
+    @Deprecated(
+      "Use classBuilder() instead. This function will be removed in KotlinPoet 2.0.",
+      ReplaceWith("TypeSpec.classBuilder(name).addModifiers(KModifier.VALUE)"),
+    )
+    @JvmStatic
+    public fun valueClassBuilder(name: String): Builder = Builder(Kind.CLASS, name, VALUE)
 
     @JvmStatic public fun objectBuilder(name: String): Builder = Builder(Kind.OBJECT, name)
 

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeSpec.kt
@@ -883,22 +883,27 @@ public class TypeSpec private constructor(
   public companion object {
     @JvmStatic public fun classBuilder(name: String): Builder = Builder(Kind.CLASS, name)
 
-    @JvmStatic public fun classBuilder(className: ClassName): Builder =
-      classBuilder(className.simpleName)
+    @JvmStatic public fun classBuilder(className: ClassName): Builder = classBuilder(className.simpleName)
 
-    @JvmStatic public fun expectClassBuilder(name: String): Builder =
-      Builder(Kind.CLASS, name, EXPECT)
+    @Deprecated(
+      "Use classBuilder() instead. This function will be removed in KotlinPoet 2.0",
+      ReplaceWith("TypeSpec.classBuilder(name).addModifiers(KModifier.EXPECT)"),
+    )
+    @JvmStatic
+    public fun expectClassBuilder(name: String): Builder = Builder(Kind.CLASS, name, EXPECT)
 
-    @JvmStatic public fun expectClassBuilder(className: ClassName): Builder =
-      expectClassBuilder(className.simpleName)
+    @Deprecated(
+      "Use classBuilder() instead. This function will be removed in KotlinPoet 2.0",
+      ReplaceWith("TypeSpec.classBuilder(className).addModifiers(KModifier.EXPECT)"),
+    )
+    @JvmStatic
+    public fun expectClassBuilder(className: ClassName): Builder = expectClassBuilder(className.simpleName)
 
-    @JvmStatic public fun valueClassBuilder(name: String): Builder =
-      Builder(Kind.CLASS, name, VALUE)
+    @JvmStatic public fun valueClassBuilder(name: String): Builder = Builder(Kind.CLASS, name, VALUE)
 
     @JvmStatic public fun objectBuilder(name: String): Builder = Builder(Kind.OBJECT, name)
 
-    @JvmStatic public fun objectBuilder(className: ClassName): Builder =
-      objectBuilder(className.simpleName)
+    @JvmStatic public fun objectBuilder(className: ClassName): Builder = objectBuilder(className.simpleName)
 
     @JvmStatic @JvmOverloads
     public fun companionObjectBuilder(name: String? = null): Builder =

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/CrossplatformTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/CrossplatformTest.kt
@@ -25,9 +25,9 @@ class CrossplatformTest {
   @Test fun crossplatform() {
     val expectTypeParam = TypeVariableName("V")
     val expectType = "AtomicRef"
-    val expectSpec = TypeSpec.expectClassBuilder(expectType)
+    val expectSpec = TypeSpec.classBuilder(expectType)
       .addTypeVariable(expectTypeParam)
-      .addModifiers(KModifier.INTERNAL)
+      .addModifiers(KModifier.INTERNAL, KModifier.EXPECT)
       .primaryConstructor(
         FunSpec.constructorBuilder()
           .addParameter("value", expectTypeParam)
@@ -94,8 +94,8 @@ class CrossplatformTest {
   }
 
   @Test fun expectWithSecondaryConstructors() {
-    val expectSpec = TypeSpec.expectClassBuilder("IoException")
-      .addModifiers(KModifier.OPEN)
+    val expectSpec = TypeSpec.classBuilder("IoException")
+      .addModifiers(KModifier.EXPECT, KModifier.OPEN)
       .superclass(Exception::class)
       .addFunction(FunSpec.constructorBuilder().build())
       .addFunction(
@@ -176,14 +176,16 @@ class CrossplatformTest {
 
   @Test fun initBlockInExpectForbidden() {
     assertThrows<IllegalStateException> {
-      TypeSpec.expectClassBuilder("AtomicRef")
+      TypeSpec.classBuilder("AtomicRef")
+        .addModifiers(KModifier.EXPECT)
         .addInitializerBlock(CodeBlock.of("println()"))
     }.hasMessageThat().isEqualTo("expect CLASS can't have initializer blocks")
   }
 
   @Test fun expectFunctionBodyForbidden() {
     assertThrows<IllegalArgumentException> {
-      TypeSpec.expectClassBuilder("AtomicRef")
+      TypeSpec.classBuilder("AtomicRef")
+        .addModifiers(KModifier.EXPECT)
         .addFunction(
           FunSpec.builder("print")
             .addStatement("println()")
@@ -195,7 +197,8 @@ class CrossplatformTest {
 
   @Test fun expectPropertyInitializerForbidden() {
     assertThrows<IllegalArgumentException> {
-      TypeSpec.expectClassBuilder("AtomicRef")
+      TypeSpec.classBuilder("AtomicRef")
+        .addModifiers(KModifier.EXPECT)
         .addProperty(
           PropertySpec.builder("a", Boolean::class)
             .initializer("true")
@@ -206,7 +209,8 @@ class CrossplatformTest {
 
   @Test fun expectPropertyGetterForbidden() {
     assertThrows<IllegalArgumentException> {
-      TypeSpec.expectClassBuilder("AtomicRef")
+      TypeSpec.classBuilder("AtomicRef")
+        .addModifiers(KModifier.EXPECT)
         .addProperty(
           PropertySpec.builder("a", Boolean::class)
             .getter(
@@ -221,7 +225,8 @@ class CrossplatformTest {
 
   @Test fun expectPropertySetterForbidden() {
     assertThrows<IllegalArgumentException> {
-      TypeSpec.expectClassBuilder("AtomicRef")
+      TypeSpec.classBuilder("AtomicRef")
+        .addModifiers(KModifier.EXPECT)
         .addProperty(
           PropertySpec.builder("a", Boolean::class)
             .mutable()

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -1471,7 +1471,8 @@ class TypeSpecTest {
   }
 
   @Test fun expectClass() {
-    val classA = TypeSpec.expectClassBuilder("ClassA")
+    val classA = TypeSpec.classBuilder("ClassA")
+      .addModifiers(KModifier.EXPECT)
       .addFunction(
         FunSpec.builder("test")
           .build(),
@@ -1489,7 +1490,8 @@ class TypeSpecTest {
   }
 
   @Test fun nestedExpectCompanionObjectWithFunction() {
-    val classA = TypeSpec.expectClassBuilder("ClassA")
+    val classA = TypeSpec.classBuilder("ClassA")
+      .addModifiers(KModifier.EXPECT)
       .addType(
         TypeSpec.companionObjectBuilder()
           .addFunction(
@@ -1513,7 +1515,8 @@ class TypeSpecTest {
   }
 
   @Test fun nestedExpectClassWithFunction() {
-    val classA = TypeSpec.expectClassBuilder("ClassA")
+    val classA = TypeSpec.classBuilder("ClassA")
+      .addModifiers(KModifier.EXPECT)
       .addType(
         TypeSpec.classBuilder("ClassB")
           .addFunction(
@@ -1537,7 +1540,8 @@ class TypeSpecTest {
   }
 
   @Test fun deeplyNestedExpectClassWithFunction() {
-    val classA = TypeSpec.expectClassBuilder("ClassA")
+    val classA = TypeSpec.classBuilder("ClassA")
+      .addModifiers(KModifier.EXPECT)
       .addType(
         TypeSpec.classBuilder("ClassB")
           .addType(
@@ -1567,7 +1571,8 @@ class TypeSpecTest {
   }
 
   @Test fun veryDeeplyNestedExpectClassWithFunction() {
-    val classA = TypeSpec.expectClassBuilder("ClassA")
+    val classA = TypeSpec.classBuilder("ClassA")
+      .addModifiers(KModifier.EXPECT)
       .addType(
         TypeSpec.classBuilder("ClassB")
           .addType(
@@ -1603,7 +1608,8 @@ class TypeSpecTest {
   }
 
   @Test fun deeplyNestedExpectClassWithConstructor() {
-    val classA = TypeSpec.expectClassBuilder("ClassA")
+    val classA = TypeSpec.classBuilder("ClassA")
+      .addModifiers(KModifier.EXPECT)
       .addType(
         TypeSpec.classBuilder("ClassB")
           .addType(
@@ -1633,7 +1639,8 @@ class TypeSpecTest {
   }
 
   @Test fun veryDeeplyNestedExpectClassWithConstructor() {
-    val classA = TypeSpec.expectClassBuilder("ClassA")
+    val classA = TypeSpec.classBuilder("ClassA")
+      .addModifiers(KModifier.EXPECT)
       .addType(
         TypeSpec.classBuilder("ClassB")
           .addType(
@@ -3264,8 +3271,8 @@ class TypeSpecTest {
   }
 
   @Test fun generalExpectClassBuilderEqualityTest() {
-    val expectSpec = TypeSpec.expectClassBuilder("AtmoicRef")
-      .addModifiers(KModifier.INTERNAL)
+    val expectSpec = TypeSpec.classBuilder("AtmoicRef")
+      .addModifiers(KModifier.EXPECT, KModifier.INTERNAL)
       .primaryConstructor(
         FunSpec.constructorBuilder()
           .addParameter("value", Int::class)

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ValueTypeSpecTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ValueTypeSpecTest.kt
@@ -40,7 +40,8 @@ class ValueTypeSpecTest(private val useValue: Boolean) {
   private val modifierString = modifier.keyword
 
   private fun classBuilder() = if (useValue) {
-    TypeSpec.valueClassBuilder("Guacamole")
+    TypeSpec.classBuilder("Guacamole")
+      .addModifiers(KModifier.VALUE)
   } else {
     TypeSpec.classBuilder("Guacamole")
       .addModifiers(modifier)

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/jvm/JvmAnnotationsTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/jvm/JvmAnnotationsTest.kt
@@ -19,6 +19,7 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.KModifier.DATA
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -1141,7 +1142,8 @@ class JvmAnnotationsTest {
   @Test fun jvmInlineClass() {
     val file = FileSpec.builder("com.squareup.tacos", "Taco")
       .addType(
-        TypeSpec.valueClassBuilder("Taco")
+        TypeSpec.classBuilder("Taco")
+          .addModifiers(KModifier.VALUE)
           .jvmInline()
           .primaryConstructor(
             FunSpec.constructorBuilder()


### PR DESCRIPTION
Closes #1385