### PR TITLE
Remove default compatibility from unstable types

### DIFF
--- a/interop/kotlinx-metadata/api/kotlinx-metadata.api
+++ b/interop/kotlinx-metadata/api/kotlinx-metadata.api
@@ -290,10 +290,6 @@ public abstract interface class com/squareup/kotlinpoet/metadata/specs/JvmModifi
 	public fun annotationSpec ()Lcom/squareup/kotlinpoet/AnnotationSpec;
 }
 
-public final class com/squareup/kotlinpoet/metadata/specs/JvmModifier$DefaultImpls {
-	public static fun annotationSpec (Lcom/squareup/kotlinpoet/metadata/specs/JvmModifier;)Lcom/squareup/kotlinpoet/AnnotationSpec;
-}
-
 public final class com/squareup/kotlinpoet/metadata/specs/KmTypesKt {
 	public static final fun isExtensionType (Lkotlinx/metadata/KmType;)Z
 }

--- a/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/JvmModifier.kt
+++ b/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/JvmModifier.kt
@@ -26,7 +26,6 @@ import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
  * This API is considered read-only and should not be implemented outside of KotlinPoet.
  */
 @KotlinPoetMetadataPreview
-@JvmDefaultWithCompatibility
 public interface JvmModifier {
   public fun annotationSpec(): AnnotationSpec? {
     return null

--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -155,10 +155,6 @@ public abstract interface class com/squareup/kotlinpoet/ContextReceivable {
 }
 
 public abstract interface class com/squareup/kotlinpoet/ContextReceivable$Builder {
-	public abstract fun getContextReceiverTypes ()Ljava/util/List;
-}
-
-public final class com/squareup/kotlinpoet/ContextReceivable$Builder$DefaultImpls {
 }
 
 public abstract interface annotation class com/squareup/kotlinpoet/DelicateKotlinPoetApi : java/lang/annotation/Annotation {

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ContextReceivable.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ContextReceivable.kt
@@ -23,7 +23,6 @@ public interface ContextReceivable {
   public val contextReceiverTypes: List<TypeName>
 
   /** The builder analogue to [ContextReceivable] types. */
-  @JvmDefaultWithCompatibility
   public interface Builder<out T : Builder<T>> {
 
     /** Mutable map of the current originating elements this builder contains. */


### PR DESCRIPTION
It was used to give one minor version to migrate to in the chance compiled libraries were using the otherwise-unstable API.

Closes #1570