### PR TITLE
Un-pin Markdown version

### DIFF
--- a/.github/workflows/mkdocs-requirements.txt
+++ b/.github/workflows/mkdocs-requirements.txt
@@ -3,7 +3,6 @@ future==0.18.3
 Jinja2==3.1.2
 livereload==2.6.3
 lunr==0.7.0.post1
-Markdown==3.3.7 # See https://github.com/mkdocs/mkdocs/issues/2892.
 MarkupSafe==2.1.3
 mkdocs==1.5.2
 mkdocs-macros-plugin==1.0.4


### PR DESCRIPTION
It was previously pinned by mkdocs (https://github.com/mkdocs/mkdocs/issues/2892), but was unpinned in https://github.com/mkdocs/mkdocs/commit/562d5e14c1d2c914d42942ab2385822c04d5bc7b. Don't think we're using it directly, so deleting it altogether.