### PR TITLE
ksp: more accurately represent function types

### DIFF
--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
@@ -171,7 +171,7 @@ class TestProcessor(private val env: SymbolProcessorEnvironment) : SymbolProcess
           )
           .addParameters(
             function.parameters.map { parameter ->
-              // function references can't be obtained from a resolved KSType because it resolves to FunctionN<> which
+              // Function references can't be obtained from a resolved KSType because it resolves to FunctionN<> which
               // loses the necessary context, skip validation in these cases as we know they won't match.
               val typeName = if (parameter.type.resolve().isFunctionType) {
                 parameter.type.toTypeName(functionTypeParams)

--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
@@ -171,7 +171,14 @@ class TestProcessor(private val env: SymbolProcessorEnvironment) : SymbolProcess
           )
           .addParameters(
             function.parameters.map { parameter ->
-              val parameterType = parameter.type.toValidatedTypeName(functionTypeParams).let {
+              // function references can't be obtained from a resolved KSType because it resolves to FunctionN<> which
+              // loses the necessary context, skip validation in these cases as we know they won't match.
+              val typeName = if (parameter.type.resolve().isFunctionType) {
+                parameter.type.toTypeName(functionTypeParams)
+              } else {
+                parameter.type.toValidatedTypeName(functionTypeParams)
+              }
+              val parameterType = typeName.let {
                 if (unwrapTypeAliases) {
                   it.unwrapTypeAlias()
                 } else {

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -131,7 +131,8 @@ class TestProcessorTest {
                param2: (String) -> String,
                param3: String.() -> String,
                param4: Function0<String>,
-               param5: Function1<String, String>
+               param5: Function1<String, String>,
+               param6: (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) -> Unit,
              ) {
              }
 
@@ -190,6 +191,7 @@ class TestProcessorTest {
       import kotlin.Int
       import kotlin.IntArray
       import kotlin.String
+      import kotlin.Unit
       import kotlin.collections.List
       import kotlin.collections.Map
       import kotlin.collections.MutableList
@@ -268,6 +270,32 @@ class TestProcessorTest {
           param3: String.() -> String,
           param4: Function0<String>,
           param5: Function1<String, String>,
+          param6: (
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+            Int,
+          ) -> Unit,
         ) {
         }
 

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -129,7 +129,9 @@ class TestProcessorTest {
              suspend fun functionD(
                param1: () -> String,
                param2: (String) -> String,
-               param3: String.() -> String
+               param3: String.() -> String,
+               param4: Function0<String>,
+               param5: Function1<String, String>
              ) {
              }
 
@@ -183,6 +185,8 @@ class TestProcessorTest {
       import kotlin.Boolean
       import kotlin.Enum
       import kotlin.Float
+      import kotlin.Function0
+      import kotlin.Function1
       import kotlin.Int
       import kotlin.IntArray
       import kotlin.String
@@ -262,6 +266,8 @@ class TestProcessorTest {
           param1: () -> String,
           param2: (String) -> String,
           param3: String.() -> String,
+          param4: Function0<String>,
+          param5: Function1<String, String>,
         ) {
         }
 

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -183,8 +183,6 @@ class TestProcessorTest {
       import kotlin.Boolean
       import kotlin.Enum
       import kotlin.Float
-      import kotlin.Function0
-      import kotlin.Function1
       import kotlin.Int
       import kotlin.IntArray
       import kotlin.String
@@ -261,9 +259,9 @@ class TestProcessorTest {
         }
 
         public suspend fun functionD(
-          param1: Function0<String>,
-          param2: Function1<String, String>,
-          param3: Function1<String, String>,
+          param1: () -> String,
+          param2: (String) -> String,
+          param3: String.() -> String,
         ) {
         }
 


### PR DESCRIPTION
When converting a KSTypeReference, represent a function type with LambdaTypeName. The better matches the source code and allows for receiver types (ex: String.() -> Unit) to be represented correctly.