### PR TITLE
fix nullability of lambdas in KSTypeReference.toTypeName

### DIFF
--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KsTypes.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KsTypes.kt
@@ -188,7 +188,7 @@ public fun KSTypeReference.toTypeName(
         receiver = elem.receiverType?.toTypeName(typeParamResolver),
         parameters = elem.functionParameters.map { ParameterSpec.unnamed(it.type.toTypeName(typeParamResolver)) },
         returnType = elem.returnType.toTypeName(typeParamResolver),
-      )
+      ).copy(nullable = resolve().isMarkedNullable)
     }
     else -> resolve().toTypeName(typeParamResolver, element?.typeArguments.orEmpty())
   }

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -133,6 +133,7 @@ class TestProcessorTest {
                param4: Function0<String>,
                param5: Function1<String, String>,
                param6: (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) -> Unit,
+               param7: ((String) -> String)?,
              ) {
              }
 
@@ -296,6 +297,7 @@ class TestProcessorTest {
             Int,
             Int,
           ) -> Unit,
+          param7: ((String) -> String)?,
         ) {
         }
 


### PR DESCRIPTION
With the change of how lambdas are converted to `TypeName` in 1.15.2 the nullability of the converted reference is lost. This fixes it and makes the behavior match the `else` case (`KSType.toTypeName`) which also preserves nullability.