### PR TITLE
Add Maven Central repo URL to RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,4 +10,6 @@ Releasing
  7. `git push && git push --tags`.
 
 This will trigger a GitHub Action workflow which will create a GitHub release and upload the
-release artifacts to Maven Central.
+release artifacts to [Maven Central][maven-central].
+
+ [maven-central]: https://repo.maven.apache.org/maven2/com/squareup/kotlinpoet/


### PR DESCRIPTION
I always check this URL to see whether the release has been published, and always forget what the URL is, so putting it here.

Is this the best URL by the way?