### PR TITLE
Fix issue with missing suspend modifier in KSTypeReference.toTypeName

### DIFF
--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KsTypes.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KsTypes.kt
@@ -182,14 +182,15 @@ public fun KSTypeArgument.toTypeName(
 public fun KSTypeReference.toTypeName(
   typeParamResolver: TypeParameterResolver = TypeParameterResolver.EMPTY,
 ): TypeName {
+  val type = resolve()
   return when (val elem = element) {
     is KSCallableReference -> {
       LambdaTypeName.get(
         receiver = elem.receiverType?.toTypeName(typeParamResolver),
         parameters = elem.functionParameters.map { ParameterSpec.unnamed(it.type.toTypeName(typeParamResolver)) },
         returnType = elem.returnType.toTypeName(typeParamResolver),
-      ).copy(nullable = resolve().isMarkedNullable)
+      ).copy(nullable = type.isMarkedNullable, suspending = type.isSuspendFunctionType)
     }
-    else -> resolve().toTypeName(typeParamResolver, element?.typeArguments.orEmpty())
+    else -> type.toTypeName(typeParamResolver, element?.typeArguments.orEmpty())
   }
 }

--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
@@ -173,7 +173,7 @@ class TestProcessor(private val env: SymbolProcessorEnvironment) : SymbolProcess
             function.parameters.map { parameter ->
               // Function references can't be obtained from a resolved KSType because it resolves to FunctionN<> which
               // loses the necessary context, skip validation in these cases as we know they won't match.
-              val typeName = if (parameter.type.resolve().isFunctionType) {
+              val typeName = if (parameter.type.resolve().run { isFunctionType || isSuspendFunctionType }) {
                 parameter.type.toTypeName(functionTypeParams)
               } else {
                 parameter.type.toValidatedTypeName(functionTypeParams)

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -134,6 +134,7 @@ class TestProcessorTest {
                param5: Function1<String, String>,
                param6: (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) -> Unit,
                param7: ((String) -> String)?,
+               param8: suspend () -> String,
              ) {
              }
 
@@ -298,6 +299,7 @@ class TestProcessorTest {
             Int,
           ) -> Unit,
           param7: ((String) -> String)?,
+          param8: suspend () -> String,
         ) {
         }
 


### PR DESCRIPTION
Since #1742 suspend lambdas are missing their suspend modifier:
```kotlin
param8: suspend () -> String,
```

[1.15.1](https://github.com/square/kotlinpoet/releases/tag/1.15.1):
```kotlin
param8: SuspendFunction0<String>,
```

[1.15.2](https://github.com/square/kotlinpoet/releases/tag/1.15.2):
```kotlin
param8: () -> String,
```
