### PR TITLE
Fix trailing newline in PropertySpec

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ Change Log
 
 * Fix: Fix extension function imports (#1814).
 * Fix: Omit implicit modifiers on FileSpec.scriptBuilder (#1813).
+* Fix: Fix trailing newline in PropertySpec (#1827).
 
 ## Version 1.16.0
 

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/PropertySpec.kt
@@ -100,7 +100,7 @@ public class PropertySpec private constructor(
       }
       val initializerFormat = if (initializer.hasStatements()) "%L" else "«%L»"
       codeWriter.emitCode(
-        codeBlock = CodeBlock.of(initializerFormat, initializer),
+        codeBlock = CodeBlock.of(initializerFormat, initializer.trimTrailingNewLine()),
         isConstantContext = KModifier.CONST in modifiers,
       )
     }

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Util.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Util.kt
@@ -138,7 +138,9 @@ internal fun stringLiteralWithQuotes(
   }
 }
 
-internal fun CodeBlock.ensureEndsWithNewLine() = if (isEmpty()) {
+internal fun CodeBlock.ensureEndsWithNewLine() = trimTrailingNewLine('\n')
+
+internal fun CodeBlock.trimTrailingNewLine(replaceWith: Char? = null) = if (isEmpty()) {
   this
 } else {
   with(toBuilder()) {
@@ -146,11 +148,18 @@ internal fun CodeBlock.ensureEndsWithNewLine() = if (isEmpty()) {
     if (lastFormatPart.isPlaceholder && args.isNotEmpty()) {
       val lastArg = args.last()
       if (lastArg is String) {
-        args[args.size - 1] = lastArg.trimEnd('\n') + '\n'
+        val trimmedArg = lastArg.trimEnd('\n')
+        args[args.size - 1] = if (replaceWith != null) {
+          trimmedArg + replaceWith
+        } else {
+          trimmedArg
+        }
       }
     } else {
       formatParts[formatParts.lastIndexOf(lastFormatPart)] = lastFormatPart.trimEnd('\n')
-      formatParts += "\n"
+      if (replaceWith != null) {
+        formatParts += "$replaceWith"
+      }
     }
     return@with build()
   }

--- a/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -1242,4 +1242,35 @@ class FileSpecTest {
     assertThat(spec.packageName).isEqualTo(memberName.packageName)
     assertThat(spec.name).isEqualTo(memberName.simpleName)
   }
+
+  @Test fun topLevelPropertyWithControlFlow() {
+    val spec = FileSpec.builder("com.example.foo", "Test")
+      .addProperty(
+        PropertySpec.builder("MyProperty", String::class.java)
+          .initializer(
+            CodeBlock.builder()
+              .beginControlFlow("if (1 + 1 == 2)")
+              .addStatement("Expected")
+              .nextControlFlow("else")
+              .addStatement("Unexpected")
+              .endControlFlow()
+              .build(),
+          ).build(),
+      ).build()
+
+    assertThat(spec.toString()).isEqualTo(
+      """
+      |package com.example.foo
+      |
+      |import java.lang.String
+      |
+      |public val MyProperty: String = if (1 + 1 == 2) {
+      |  Expected
+      |} else {
+      |  Unexpected
+      |}
+      |
+      """.trimMargin(),
+    )
+  }
 }

--- a/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -500,7 +500,6 @@ class PropertySpecTest {
       |  println("arg=${'$'}arg")
       |}
       |
-      |
       """.trimMargin(),
     )
   }

--- a/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -2638,7 +2638,7 @@ class TypeSpecTest {
         |      |beef
         |      |lettuce
         |      |cheese
-        |      |${"\"\"\""}.trimMargin()
+        |      ${"\"\"\""}.trimMargin()
         |}
         |
       """.trimMargin(),


### PR DESCRIPTION
This happens because things like `.endControlFlow` adds `\n`. This removes any trailing newline before emitting the `initializer`.

Closes #941


- [x] `docs/changelog.md` has been updated if applicable.
