### PR TITLE
fix: make specs, builders and spec args serializable

### DIFF
--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -11,7 +11,7 @@ public abstract interface class com/squareup/kotlinpoet/Annotatable$Builder {
 	public abstract fun getAnnotations ()Ljava/util/List;
 }
 
-public final class com/squareup/kotlinpoet/AnnotationSpec : com/squareup/kotlinpoet/Taggable {
+public final class com/squareup/kotlinpoet/AnnotationSpec : com/squareup/kotlinpoet/Taggable, java/io/Serializable {
 	public static final field Companion Lcom/squareup/kotlinpoet/AnnotationSpec$Companion;
 	public static final fun builder (Lcom/squareup/kotlinpoet/ClassName;)Lcom/squareup/kotlinpoet/AnnotationSpec$Builder;
 	public static final fun builder (Lcom/squareup/kotlinpoet/ParameterizedTypeName;)Lcom/squareup/kotlinpoet/AnnotationSpec$Builder;
@@ -33,7 +33,7 @@ public final class com/squareup/kotlinpoet/AnnotationSpec : com/squareup/kotlinp
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/squareup/kotlinpoet/AnnotationSpec$Builder : com/squareup/kotlinpoet/Taggable$Builder {
+public final class com/squareup/kotlinpoet/AnnotationSpec$Builder : com/squareup/kotlinpoet/Taggable$Builder, java/io/Serializable {
 	public static final field Companion Lcom/squareup/kotlinpoet/AnnotationSpec$Builder$Companion;
 	public final fun addMember (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/AnnotationSpec$Builder;
 	public final fun addMember (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/AnnotationSpec$Builder;
@@ -107,7 +107,7 @@ public final class com/squareup/kotlinpoet/ClassNames {
 	public static final fun get (Lkotlin/reflect/KClass;)Lcom/squareup/kotlinpoet/ClassName;
 }
 
-public final class com/squareup/kotlinpoet/CodeBlock {
+public final class com/squareup/kotlinpoet/CodeBlock : java/io/Serializable {
 	public static final field Companion Lcom/squareup/kotlinpoet/CodeBlock$Companion;
 	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun builder ()Lcom/squareup/kotlinpoet/CodeBlock$Builder;
@@ -181,7 +181,7 @@ public final class com/squareup/kotlinpoet/Dynamic : com/squareup/kotlinpoet/Typ
 public abstract interface annotation class com/squareup/kotlinpoet/ExperimentalKotlinPoetApi : java/lang/annotation/Annotation {
 }
 
-public final class com/squareup/kotlinpoet/FileSpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/Taggable, com/squareup/kotlinpoet/TypeSpecHolder {
+public final class com/squareup/kotlinpoet/FileSpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/Taggable, com/squareup/kotlinpoet/TypeSpecHolder, java/io/Serializable {
 	public static final field Companion Lcom/squareup/kotlinpoet/FileSpec$Companion;
 	public static final fun builder (Lcom/squareup/kotlinpoet/ClassName;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public static final fun builder (Lcom/squareup/kotlinpoet/MemberName;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
@@ -217,7 +217,7 @@ public final class com/squareup/kotlinpoet/FileSpec : com/squareup/kotlinpoet/An
 	public final fun writeTo (Ljavax/annotation/processing/Filer;)V
 }
 
-public final class com/squareup/kotlinpoet/FileSpec$Builder : com/squareup/kotlinpoet/Annotatable$Builder, com/squareup/kotlinpoet/Taggable$Builder, com/squareup/kotlinpoet/TypeSpecHolder$Builder {
+public final class com/squareup/kotlinpoet/FileSpec$Builder : com/squareup/kotlinpoet/Annotatable$Builder, com/squareup/kotlinpoet/Taggable$Builder, com/squareup/kotlinpoet/TypeSpecHolder$Builder, java/io/Serializable {
 	public final fun addAliasedImport (Lcom/squareup/kotlinpoet/ClassName;Ljava/lang/String;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun addAliasedImport (Lcom/squareup/kotlinpoet/ClassName;Ljava/lang/String;Ljava/lang/String;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun addAliasedImport (Lcom/squareup/kotlinpoet/MemberName;Ljava/lang/String;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
@@ -287,7 +287,7 @@ public final class com/squareup/kotlinpoet/FileSpec$Companion {
 	public static synthetic fun scriptBuilder$default (Lcom/squareup/kotlinpoet/FileSpec$Companion;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 }
 
-public final class com/squareup/kotlinpoet/FunSpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/ContextReceivable, com/squareup/kotlinpoet/Documentable, com/squareup/kotlinpoet/OriginatingElementsHolder, com/squareup/kotlinpoet/Taggable {
+public final class com/squareup/kotlinpoet/FunSpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/ContextReceivable, com/squareup/kotlinpoet/Documentable, com/squareup/kotlinpoet/OriginatingElementsHolder, com/squareup/kotlinpoet/Taggable, java/io/Serializable {
 	public static final field Companion Lcom/squareup/kotlinpoet/FunSpec$Companion;
 	public static final fun builder (Lcom/squareup/kotlinpoet/MemberName;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public static final fun builder (Ljava/lang/String;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
@@ -324,7 +324,7 @@ public final class com/squareup/kotlinpoet/FunSpec : com/squareup/kotlinpoet/Ann
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/squareup/kotlinpoet/FunSpec$Builder : com/squareup/kotlinpoet/Annotatable$Builder, com/squareup/kotlinpoet/ContextReceivable$Builder, com/squareup/kotlinpoet/Documentable$Builder, com/squareup/kotlinpoet/OriginatingElementsHolder$Builder, com/squareup/kotlinpoet/Taggable$Builder {
+public final class com/squareup/kotlinpoet/FunSpec$Builder : com/squareup/kotlinpoet/Annotatable$Builder, com/squareup/kotlinpoet/ContextReceivable$Builder, com/squareup/kotlinpoet/Documentable$Builder, com/squareup/kotlinpoet/OriginatingElementsHolder$Builder, com/squareup/kotlinpoet/Taggable$Builder, java/io/Serializable {
 	public synthetic fun addAnnotation (Lcom/squareup/kotlinpoet/AnnotationSpec;)Lcom/squareup/kotlinpoet/Annotatable$Builder;
 	public fun addAnnotation (Lcom/squareup/kotlinpoet/AnnotationSpec;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public synthetic fun addAnnotation (Lcom/squareup/kotlinpoet/ClassName;)Lcom/squareup/kotlinpoet/Annotatable$Builder;
@@ -414,7 +414,7 @@ public final class com/squareup/kotlinpoet/FunSpec$Companion {
 	public final fun setterBuilder ()Lcom/squareup/kotlinpoet/FunSpec$Builder;
 }
 
-public final class com/squareup/kotlinpoet/Import : java/lang/Comparable {
+public final class com/squareup/kotlinpoet/Import : java/io/Serializable, java/lang/Comparable {
 	public fun compareTo (Lcom/squareup/kotlinpoet/Import;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public final fun component1 ()Ljava/lang/String;
@@ -428,7 +428,7 @@ public final class com/squareup/kotlinpoet/Import : java/lang/Comparable {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/squareup/kotlinpoet/KModifier : java/lang/Enum {
+public final class com/squareup/kotlinpoet/KModifier : java/lang/Enum, java/io/Serializable {
 	public static final field ABSTRACT Lcom/squareup/kotlinpoet/KModifier;
 	public static final field ACTUAL Lcom/squareup/kotlinpoet/KModifier;
 	public static final field ANNOTATION Lcom/squareup/kotlinpoet/KModifier;
@@ -466,7 +466,7 @@ public final class com/squareup/kotlinpoet/KModifier : java/lang/Enum {
 	public static fun values ()[Lcom/squareup/kotlinpoet/KModifier;
 }
 
-public final class com/squareup/kotlinpoet/KOperator : java/lang/Enum {
+public final class com/squareup/kotlinpoet/KOperator : java/lang/Enum, java/io/Serializable {
 	public static final field CONTAINS Lcom/squareup/kotlinpoet/KOperator;
 	public static final field DEC Lcom/squareup/kotlinpoet/KOperator;
 	public static final field DIV Lcom/squareup/kotlinpoet/KOperator;
@@ -523,7 +523,7 @@ public final class com/squareup/kotlinpoet/LambdaTypeName$Companion {
 	public static synthetic fun get$default (Lcom/squareup/kotlinpoet/LambdaTypeName$Companion;Lcom/squareup/kotlinpoet/TypeName;[Lcom/squareup/kotlinpoet/TypeName;Lcom/squareup/kotlinpoet/TypeName;ILjava/lang/Object;)Lcom/squareup/kotlinpoet/LambdaTypeName;
 }
 
-public final class com/squareup/kotlinpoet/MemberName {
+public final class com/squareup/kotlinpoet/MemberName : java/io/Serializable {
 	public static final field Companion Lcom/squareup/kotlinpoet/MemberName$Companion;
 	public fun <init> (Lcom/squareup/kotlinpoet/ClassName;Lcom/squareup/kotlinpoet/KOperator;)V
 	public fun <init> (Lcom/squareup/kotlinpoet/ClassName;Ljava/lang/String;)V
@@ -582,7 +582,7 @@ public final class com/squareup/kotlinpoet/OriginatingElementsHolder$Builder$Def
 	public static fun addOriginatingElement (Lcom/squareup/kotlinpoet/OriginatingElementsHolder$Builder;Ljavax/lang/model/element/Element;)Lcom/squareup/kotlinpoet/OriginatingElementsHolder$Builder;
 }
 
-public final class com/squareup/kotlinpoet/ParameterSpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/Documentable, com/squareup/kotlinpoet/Taggable {
+public final class com/squareup/kotlinpoet/ParameterSpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/Documentable, com/squareup/kotlinpoet/Taggable, java/io/Serializable {
 	public static final field Companion Lcom/squareup/kotlinpoet/ParameterSpec$Companion;
 	public fun <init> (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Ljava/lang/Iterable;)V
 	public fun <init> (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;[Lcom/squareup/kotlinpoet/KModifier;)V
@@ -613,7 +613,7 @@ public final class com/squareup/kotlinpoet/ParameterSpec : com/squareup/kotlinpo
 	public static final fun unnamed (Lkotlin/reflect/KClass;)Lcom/squareup/kotlinpoet/ParameterSpec;
 }
 
-public final class com/squareup/kotlinpoet/ParameterSpec$Builder : com/squareup/kotlinpoet/Annotatable$Builder, com/squareup/kotlinpoet/Documentable$Builder, com/squareup/kotlinpoet/Taggable$Builder {
+public final class com/squareup/kotlinpoet/ParameterSpec$Builder : com/squareup/kotlinpoet/Annotatable$Builder, com/squareup/kotlinpoet/Documentable$Builder, com/squareup/kotlinpoet/Taggable$Builder, java/io/Serializable {
 	public synthetic fun addAnnotation (Lcom/squareup/kotlinpoet/AnnotationSpec;)Lcom/squareup/kotlinpoet/Annotatable$Builder;
 	public fun addAnnotation (Lcom/squareup/kotlinpoet/AnnotationSpec;)Lcom/squareup/kotlinpoet/ParameterSpec$Builder;
 	public synthetic fun addAnnotation (Lcom/squareup/kotlinpoet/ClassName;)Lcom/squareup/kotlinpoet/Annotatable$Builder;
@@ -696,7 +696,7 @@ public final class com/squareup/kotlinpoet/ParameterizedTypeNames {
 	public static final fun get (Ljava/lang/reflect/ParameterizedType;)Lcom/squareup/kotlinpoet/ParameterizedTypeName;
 }
 
-public final class com/squareup/kotlinpoet/PropertySpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/ContextReceivable, com/squareup/kotlinpoet/Documentable, com/squareup/kotlinpoet/OriginatingElementsHolder, com/squareup/kotlinpoet/Taggable {
+public final class com/squareup/kotlinpoet/PropertySpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/ContextReceivable, com/squareup/kotlinpoet/Documentable, com/squareup/kotlinpoet/OriginatingElementsHolder, com/squareup/kotlinpoet/Taggable, java/io/Serializable {
 	public static final field Companion Lcom/squareup/kotlinpoet/PropertySpec$Companion;
 	public static final fun builder (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
 	public static final fun builder (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;[Lcom/squareup/kotlinpoet/KModifier;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
@@ -730,7 +730,7 @@ public final class com/squareup/kotlinpoet/PropertySpec : com/squareup/kotlinpoe
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/squareup/kotlinpoet/PropertySpec$Builder : com/squareup/kotlinpoet/Annotatable$Builder, com/squareup/kotlinpoet/ContextReceivable$Builder, com/squareup/kotlinpoet/Documentable$Builder, com/squareup/kotlinpoet/OriginatingElementsHolder$Builder, com/squareup/kotlinpoet/Taggable$Builder {
+public final class com/squareup/kotlinpoet/PropertySpec$Builder : com/squareup/kotlinpoet/Annotatable$Builder, com/squareup/kotlinpoet/ContextReceivable$Builder, com/squareup/kotlinpoet/Documentable$Builder, com/squareup/kotlinpoet/OriginatingElementsHolder$Builder, com/squareup/kotlinpoet/Taggable$Builder, java/io/Serializable {
 	public synthetic fun addAnnotation (Lcom/squareup/kotlinpoet/AnnotationSpec;)Lcom/squareup/kotlinpoet/Annotatable$Builder;
 	public fun addAnnotation (Lcom/squareup/kotlinpoet/AnnotationSpec;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
 	public synthetic fun addAnnotation (Lcom/squareup/kotlinpoet/ClassName;)Lcom/squareup/kotlinpoet/Annotatable$Builder;
@@ -801,7 +801,7 @@ public final class com/squareup/kotlinpoet/Taggable$DefaultImpls {
 	public static fun tag (Lcom/squareup/kotlinpoet/Taggable;Lkotlin/reflect/KClass;)Ljava/lang/Object;
 }
 
-public final class com/squareup/kotlinpoet/TypeAliasSpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/Documentable, com/squareup/kotlinpoet/Taggable {
+public final class com/squareup/kotlinpoet/TypeAliasSpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/Documentable, com/squareup/kotlinpoet/Taggable, java/io/Serializable {
 	public static final field Companion Lcom/squareup/kotlinpoet/TypeAliasSpec$Companion;
 	public static final fun builder (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;)Lcom/squareup/kotlinpoet/TypeAliasSpec$Builder;
 	public static final fun builder (Ljava/lang/String;Ljava/lang/reflect/Type;)Lcom/squareup/kotlinpoet/TypeAliasSpec$Builder;
@@ -824,7 +824,7 @@ public final class com/squareup/kotlinpoet/TypeAliasSpec : com/squareup/kotlinpo
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/squareup/kotlinpoet/TypeAliasSpec$Builder : com/squareup/kotlinpoet/Annotatable$Builder, com/squareup/kotlinpoet/Documentable$Builder, com/squareup/kotlinpoet/Taggable$Builder {
+public final class com/squareup/kotlinpoet/TypeAliasSpec$Builder : com/squareup/kotlinpoet/Annotatable$Builder, com/squareup/kotlinpoet/Documentable$Builder, com/squareup/kotlinpoet/Taggable$Builder, java/io/Serializable {
 	public synthetic fun addAnnotation (Lcom/squareup/kotlinpoet/AnnotationSpec;)Lcom/squareup/kotlinpoet/Annotatable$Builder;
 	public fun addAnnotation (Lcom/squareup/kotlinpoet/AnnotationSpec;)Lcom/squareup/kotlinpoet/TypeAliasSpec$Builder;
 	public synthetic fun addAnnotation (Lcom/squareup/kotlinpoet/ClassName;)Lcom/squareup/kotlinpoet/Annotatable$Builder;
@@ -857,7 +857,7 @@ public final class com/squareup/kotlinpoet/TypeAliasSpec$Companion {
 	public final fun builder (Ljava/lang/String;Lkotlin/reflect/KClass;)Lcom/squareup/kotlinpoet/TypeAliasSpec$Builder;
 }
 
-public abstract class com/squareup/kotlinpoet/TypeName : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/Taggable {
+public abstract class com/squareup/kotlinpoet/TypeName : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/Taggable, java/io/Serializable {
 	public static final field Companion Lcom/squareup/kotlinpoet/TypeName$Companion;
 	public synthetic fun <init> (ZLjava/util/List;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun copy (ZLjava/util/List;)Lcom/squareup/kotlinpoet/TypeName;
@@ -933,7 +933,7 @@ public final class com/squareup/kotlinpoet/TypeNames {
 	public static final fun get (Lkotlin/reflect/KClass;)Lcom/squareup/kotlinpoet/ClassName;
 }
 
-public final class com/squareup/kotlinpoet/TypeSpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/ContextReceivable, com/squareup/kotlinpoet/Documentable, com/squareup/kotlinpoet/OriginatingElementsHolder, com/squareup/kotlinpoet/Taggable, com/squareup/kotlinpoet/TypeSpecHolder {
+public final class com/squareup/kotlinpoet/TypeSpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/ContextReceivable, com/squareup/kotlinpoet/Documentable, com/squareup/kotlinpoet/OriginatingElementsHolder, com/squareup/kotlinpoet/Taggable, com/squareup/kotlinpoet/TypeSpecHolder, java/io/Serializable {
 	public static final field Companion Lcom/squareup/kotlinpoet/TypeSpec$Companion;
 	public static final fun annotationBuilder (Lcom/squareup/kotlinpoet/ClassName;)Lcom/squareup/kotlinpoet/TypeSpec$Builder;
 	public static final fun annotationBuilder (Ljava/lang/String;)Lcom/squareup/kotlinpoet/TypeSpec$Builder;
@@ -989,7 +989,7 @@ public final class com/squareup/kotlinpoet/TypeSpec : com/squareup/kotlinpoet/An
 	public static final fun valueClassBuilder (Ljava/lang/String;)Lcom/squareup/kotlinpoet/TypeSpec$Builder;
 }
 
-public final class com/squareup/kotlinpoet/TypeSpec$Builder : com/squareup/kotlinpoet/Annotatable$Builder, com/squareup/kotlinpoet/ContextReceivable$Builder, com/squareup/kotlinpoet/Documentable$Builder, com/squareup/kotlinpoet/OriginatingElementsHolder$Builder, com/squareup/kotlinpoet/Taggable$Builder, com/squareup/kotlinpoet/TypeSpecHolder$Builder {
+public final class com/squareup/kotlinpoet/TypeSpec$Builder : com/squareup/kotlinpoet/Annotatable$Builder, com/squareup/kotlinpoet/ContextReceivable$Builder, com/squareup/kotlinpoet/Documentable$Builder, com/squareup/kotlinpoet/OriginatingElementsHolder$Builder, com/squareup/kotlinpoet/Taggable$Builder, com/squareup/kotlinpoet/TypeSpecHolder$Builder, java/io/Serializable {
 	public synthetic fun addAnnotation (Lcom/squareup/kotlinpoet/AnnotationSpec;)Lcom/squareup/kotlinpoet/Annotatable$Builder;
 	public fun addAnnotation (Lcom/squareup/kotlinpoet/AnnotationSpec;)Lcom/squareup/kotlinpoet/TypeSpec$Builder;
 	public synthetic fun addAnnotation (Lcom/squareup/kotlinpoet/ClassName;)Lcom/squareup/kotlinpoet/Annotatable$Builder;

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.kotlinpoet
 
+import java.io.Serializable
 import java.lang.reflect.Array
 import java.util.Objects
 import javax.lang.model.element.AnnotationMirror
@@ -30,7 +31,7 @@ import kotlin.reflect.KClass
 public class AnnotationSpec private constructor(
   builder: Builder,
   private val tagMap: TagMap = builder.buildTagMap(),
-) : Taggable by tagMap {
+) : Taggable by tagMap, Serializable {
   @Deprecated(
     message = "Use typeName instead. This property will be removed in KotlinPoet 2.0.",
     replaceWith = ReplaceWith("typeName"),
@@ -120,7 +121,7 @@ public class AnnotationSpec private constructor(
 
   public class Builder internal constructor(
     internal val typeName: TypeName,
-  ) : Taggable.Builder<Builder> {
+  ) : Taggable.Builder<Builder>, Serializable {
     internal var useSiteTarget: UseSiteTarget? = null
 
     public val members: MutableList<CodeBlock> = mutableListOf()

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/CodeBlock.kt
@@ -17,6 +17,7 @@
 
 package com.squareup.kotlinpoet
 
+import java.io.Serializable
 import java.lang.reflect.Type
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
@@ -61,7 +62,7 @@ import kotlin.reflect.KClass
 public class CodeBlock private constructor(
   internal val formatParts: List<String>,
   internal val args: List<Any?>,
-) {
+) : Serializable {
   /** A heterogeneous list containing string literals and value placeholders.  */
 
   public fun isEmpty(): Boolean = formatParts.isEmpty()

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
+import java.io.Serializable
 import java.net.URI
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Path
@@ -49,7 +50,7 @@ import kotlin.reflect.KClass
 public class FileSpec private constructor(
   builder: Builder,
   private val tagMap: TagMap = builder.buildTagMap(),
-) : Taggable by tagMap, Annotatable, TypeSpecHolder {
+) : Taggable by tagMap, Annotatable, TypeSpecHolder, Serializable {
   override val annotations: List<AnnotationSpec> = builder.annotations.toImmutableList()
   override val typeSpecs: List<TypeSpec> = builder.members.filterIsInstance<TypeSpec>().toImmutableList()
   public val comment: CodeBlock = builder.comment.build()
@@ -253,7 +254,7 @@ public class FileSpec private constructor(
     public val packageName: String,
     public val name: String,
     public val isScript: Boolean,
-  ) : Taggable.Builder<Builder>, Annotatable.Builder<Builder>, TypeSpecHolder.Builder<Builder> {
+  ) : Taggable.Builder<Builder>, Annotatable.Builder<Builder>, TypeSpecHolder.Builder<Builder>, Serializable {
     override val annotations: MutableList<AnnotationSpec> = mutableListOf()
     internal val comment = CodeBlock.builder()
     internal val memberImports = sortedSetOf<Import>()

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
@@ -20,6 +20,7 @@ import com.squareup.kotlinpoet.KModifier.EXPECT
 import com.squareup.kotlinpoet.KModifier.EXTERNAL
 import com.squareup.kotlinpoet.KModifier.INLINE
 import com.squareup.kotlinpoet.KModifier.VARARG
+import java.io.Serializable
 import java.lang.reflect.Type
 import javax.lang.model.element.Element
 import javax.lang.model.element.ExecutableElement
@@ -42,7 +43,8 @@ public class FunSpec private constructor(
   OriginatingElementsHolder by delegateOriginatingElementsHolder,
   ContextReceivable by contextReceivers,
   Annotatable,
-  Documentable {
+  Documentable,
+  Serializable {
   public val name: String = builder.name
   override val kdoc: CodeBlock = builder.kdoc.build()
   public val returnKdoc: CodeBlock = builder.returnKdoc
@@ -307,7 +309,8 @@ public class FunSpec private constructor(
     OriginatingElementsHolder.Builder<Builder>,
     ContextReceivable.Builder<Builder>,
     Annotatable.Builder<Builder>,
-    Documentable.Builder<Builder> {
+    Documentable.Builder<Builder>,
+    Serializable {
     internal var returnKdoc = CodeBlock.EMPTY
     internal var receiverKdoc = CodeBlock.EMPTY
     internal var receiverType: TypeName? = null

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Import.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Import.kt
@@ -15,10 +15,12 @@
  */
 package com.squareup.kotlinpoet
 
+import java.io.Serializable
+
 public data class Import internal constructor(
   val qualifiedName: String,
   val alias: String? = null,
-) : Comparable<Import> {
+) : Comparable<Import>, Serializable {
 
   private val importString = buildString {
     append(qualifiedName.escapeSegmentsIfNecessary())

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/KModifier.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/KModifier.kt
@@ -19,12 +19,13 @@ import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.KModifier.PROTECTED
 import com.squareup.kotlinpoet.KModifier.PUBLIC
+import java.io.Serializable
 import java.util.EnumSet
 
 public enum class KModifier(
   internal val keyword: String,
   private vararg val targets: Target,
-) {
+) : Serializable {
   // Modifier order defined here:
   // https://kotlinlang.org/docs/reference/coding-conventions.html#modifiers
 

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/KOperator.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/KOperator.kt
@@ -15,10 +15,12 @@
  */
 package com.squareup.kotlinpoet
 
+import java.io.Serializable
+
 public enum class KOperator(
   internal val operator: String,
   internal val functionName: String,
-) {
+) : Serializable {
   UNARY_PLUS("+", "unaryPlus"),
   PLUS("+", "plus"),
   UNARY_MINUS("-", "unaryMinus"),

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/MemberName.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/MemberName.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.kotlinpoet
 
+import java.io.Serializable
 import kotlin.reflect.KClass
 
 /**
@@ -73,7 +74,7 @@ public data class MemberName internal constructor(
   public val simpleName: String,
   public val operator: KOperator? = null,
   public val isExtension: Boolean = false,
-) {
+) : Serializable {
   // TODO(egorand): Reduce the number of overloaded constructors in KotlinPoet 2.0.
 
   public constructor(

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/ParameterSpec.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/ParameterSpec.kt
@@ -18,6 +18,7 @@ package com.squareup.kotlinpoet
 import com.squareup.kotlinpoet.KModifier.CROSSINLINE
 import com.squareup.kotlinpoet.KModifier.NOINLINE
 import com.squareup.kotlinpoet.KModifier.VARARG
+import java.io.Serializable
 import java.lang.reflect.Type
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.Modifier
@@ -29,7 +30,7 @@ import kotlin.reflect.KClass
 public class ParameterSpec private constructor(
   builder: Builder,
   private val tagMap: TagMap = builder.buildTagMap(),
-) : Taggable by tagMap, Annotatable, Documentable {
+) : Taggable by tagMap, Annotatable, Documentable, Serializable {
   public val name: String = builder.name
   override val kdoc: CodeBlock = builder.kdoc.build()
   override val annotations: List<AnnotationSpec> = builder.annotations.toImmutableList()
@@ -94,7 +95,7 @@ public class ParameterSpec private constructor(
   public class Builder internal constructor(
     internal val name: String,
     internal val type: TypeName,
-  ) : Taggable.Builder<Builder>, Annotatable.Builder<Builder>, Documentable.Builder<Builder> {
+  ) : Taggable.Builder<Builder>, Annotatable.Builder<Builder>, Documentable.Builder<Builder>, Serializable {
     internal var defaultValue: CodeBlock? = null
 
     public val modifiers: MutableList<KModifier> = mutableListOf()

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/PropertySpec.kt
@@ -18,6 +18,7 @@ package com.squareup.kotlinpoet
 import com.squareup.kotlinpoet.FunSpec.Companion.GETTER
 import com.squareup.kotlinpoet.FunSpec.Companion.SETTER
 import com.squareup.kotlinpoet.KModifier.Target.PROPERTY
+import java.io.Serializable
 import java.lang.reflect.Type
 import java.util.EnumSet
 import javax.lang.model.element.Element
@@ -34,7 +35,8 @@ public class PropertySpec private constructor(
   OriginatingElementsHolder by delegateOriginatingElementsHolder,
   ContextReceivable by contextReceivers,
   Annotatable,
-  Documentable {
+  Documentable,
+  Serializable {
   public val mutable: Boolean = builder.mutable
   public val name: String = builder.name
   public val type: TypeName = builder.type
@@ -176,7 +178,8 @@ public class PropertySpec private constructor(
     OriginatingElementsHolder.Builder<Builder>,
     ContextReceivable.Builder<Builder>,
     Annotatable.Builder<Builder>,
-    Documentable.Builder<Builder> {
+    Documentable.Builder<Builder>,
+    Serializable {
     internal var isPrimaryConstructorParameter = false
     internal var mutable = false
     internal var initializer: CodeBlock? = null

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Taggable.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Taggable.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.kotlinpoet
 
+import java.io.Serializable
 import kotlin.reflect.KClass
 
 /** A type that can be tagged with extra metadata of the user's choice. */
@@ -153,7 +154,7 @@ public inline fun <reified T : Any> TypeSpec.Builder.tag(tag: T?): TypeSpec.Buil
 internal fun Taggable.Builder<*>.buildTagMap(): TagMap = TagMap(tags)
 
 @JvmInline
-internal value class TagMap private constructor(override val tags: Map<KClass<*>, Any>) : Taggable {
+internal value class TagMap private constructor(override val tags: Map<KClass<*>, Any>) : Taggable, Serializable {
   companion object {
     operator fun invoke(tags: Map<KClass<*>, Any>): TagMap = TagMap(tags.toImmutableMap())
   }

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/TypeAliasSpec.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/TypeAliasSpec.kt
@@ -19,6 +19,7 @@ import com.squareup.kotlinpoet.KModifier.ACTUAL
 import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.KModifier.PUBLIC
+import java.io.Serializable
 import java.lang.reflect.Type
 import kotlin.reflect.KClass
 
@@ -26,7 +27,7 @@ import kotlin.reflect.KClass
 public class TypeAliasSpec private constructor(
   builder: Builder,
   private val tagMap: TagMap = builder.buildTagMap(),
-) : Taggable by tagMap, Annotatable, Documentable {
+) : Taggable by tagMap, Annotatable, Documentable, Serializable {
   public val name: String = builder.name
   public val type: TypeName = builder.type
   public val modifiers: Set<KModifier> = builder.modifiers.toImmutableSet()
@@ -69,7 +70,7 @@ public class TypeAliasSpec private constructor(
   public class Builder internal constructor(
     internal val name: String,
     internal val type: TypeName,
-  ) : Taggable.Builder<Builder>, Annotatable.Builder<Builder>, Documentable.Builder<Builder> {
+  ) : Taggable.Builder<Builder>, Annotatable.Builder<Builder>, Documentable.Builder<Builder>, Serializable {
     public val modifiers: MutableSet<KModifier> = mutableSetOf()
     public val typeVariables: MutableSet<TypeVariableName> = mutableSetOf()
     override val tags: MutableMap<KClass<*>, Any> = mutableMapOf()

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/TypeName.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/TypeName.kt
@@ -18,6 +18,7 @@
 package com.squareup.kotlinpoet
 
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import java.io.Serializable
 import java.lang.reflect.GenericArrayType
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
@@ -66,7 +67,7 @@ public sealed class TypeName constructor(
   public val isNullable: Boolean,
   annotations: List<AnnotationSpec>,
   internal val tagMap: TagMap,
-) : Taggable by tagMap, Annotatable {
+) : Taggable by tagMap, Annotatable, Serializable {
   override val annotations: List<AnnotationSpec> = annotations.toImmutableList()
 
   /** Lazily-initialized toString of this type name.  */

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/TypeSpec.kt
@@ -29,6 +29,7 @@ import com.squareup.kotlinpoet.KModifier.PROTECTED
 import com.squareup.kotlinpoet.KModifier.PUBLIC
 import com.squareup.kotlinpoet.KModifier.SEALED
 import com.squareup.kotlinpoet.KModifier.VALUE
+import java.io.Serializable
 import java.lang.reflect.Type
 import javax.lang.model.element.Element
 import kotlin.DeprecationLevel.ERROR
@@ -48,7 +49,8 @@ public class TypeSpec private constructor(
   ContextReceivable by contextReceivers,
   Annotatable,
   Documentable,
-  TypeSpecHolder {
+  TypeSpecHolder,
+  Serializable {
   public val kind: Kind = builder.kind
   public val name: String? = builder.name
   override val kdoc: CodeBlock = builder.kdoc.build()
@@ -471,7 +473,8 @@ public class TypeSpec private constructor(
     ContextReceivable.Builder<Builder>,
     Annotatable.Builder<Builder>,
     Documentable.Builder<Builder>,
-    TypeSpecHolder.Builder<Builder> {
+    TypeSpecHolder.Builder<Builder>,
+    Serializable {
     internal var primaryConstructor: FunSpec? = null
     internal var superclass: TypeName = ANY
     internal val initializerBlock = CodeBlock.builder()


### PR DESCRIPTION
This change makes spec classes (and their builders, and typical arg classes) serializable.

Use case:
I use `kotlinpoet` a lot with Gradle, have some code generation tasks there. Sometimes I want to use things like `ClassName` or `TypeSpec` as inputs to a Gradle task, but the problem is that Gradle task inputs have to be serializable. So every time I need that, I have to come up with workarounds: either using my own data classes leading to code duplication, or using serializable functions. While both options kinda work, I'd really love to ditch them and simply use `kotlinpoet` classes.