### PR TITLE
Update Kotlin Metadata to version 0.9.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,9 @@ Change Log
 * Fix: Fix extension function imports (#1814).
 * Fix: Omit implicit modifiers on FileSpec.scriptBuilder (#1813).
 * Fix: Fix trailing newline in PropertySpec (#1827).
+Change: kotlinx-metadata 0.9.0. This is a breaking change for users of the
+:kotlinpoet-metadata module, as `read` is deprecated in 0.9.0 and the
+replacement `readStrict` was introduced in 0.9.0 (#1830).
 
 ## Version 1.16.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,9 +6,7 @@ Change Log
 * Fix: Fix extension function imports (#1814).
 * Fix: Omit implicit modifiers on FileSpec.scriptBuilder (#1813).
 * Fix: Fix trailing newline in PropertySpec (#1827).
-Change: kotlinx-metadata 0.9.0. This is a breaking change for users of the
-:kotlinpoet-metadata module, as `read` is deprecated in 0.9.0 and the
-replacement `readStrict` was introduced in 0.9.0 (#1830).
+Change: kotlinx-metadata 0.9.0. Note that the `KotlinClassMetadata .read` is deprecated in 0.9.0 and replaced with `readStrict` (#1830).
 
 ## Version 1.16.0
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-emb
 kotlin-annotationProcessingEmbeddable = { module = "org.jetbrains.kotlin:kotlin-annotation-processing-embeddable", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
-kotlin-metadata = { module = "org.jetbrains.kotlinx:kotlinx-metadata-jvm", version = "0.8.0" }
+kotlin-metadata = { module = "org.jetbrains.kotlinx:kotlinx-metadata-jvm", version = "0.9.0" }
 
 ksp = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }

--- a/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/KotlinPoetMetadata.kt
+++ b/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/KotlinPoetMetadata.kt
@@ -85,7 +85,7 @@ public inline fun <reified T : KotlinClassMetadata> Metadata.toKotlinClassMetada
  */
 @KotlinPoetMetadataPreview
 public fun Metadata.readKotlinClassMetadata(): KotlinClassMetadata {
-  val metadata = KotlinClassMetadata.read(asClassHeader())
+  val metadata = KotlinClassMetadata.readStrict(asClassHeader())
   checkNotNull(metadata) {
     "Could not parse metadata! Try bumping kotlinpoet and/or kotlinx-metadata version."
   }

--- a/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -670,23 +670,21 @@ private fun KmProperty.toPropertySpec(
         }
       }
     }
-    if (setter != null) {
-      setterSignature?.let { setterSignature ->
-        if (containerData is ClassData &&
-          !containerData.declarationContainer.isAnnotation &&
-          !containerData.declarationContainer.isInterface &&
-          classInspector?.supportsNonRuntimeRetainedAnnotations == false &&
-          modality != Modality.OPEN && modality != Modality.ABSTRACT
-        ) {
-          // Infer if JvmName was used
-          // We skip annotation types for this because they can't have vars.
-          // We skip interface types or open/abstract properties because they can't have @JvmName.
-          setterSignature.jvmNameAnnotation(
-            metadataName = "set${name.safeCapitalize(Locale.US)}",
-            useSiteTarget = UseSiteTarget.SET,
-          )?.let { jvmNameAnnotation ->
-            mutableAnnotations += jvmNameAnnotation
-          }
+    setterSignature?.let { setterSignature ->
+      if (containerData is ClassData &&
+        !containerData.declarationContainer.isAnnotation &&
+        !containerData.declarationContainer.isInterface &&
+        classInspector?.supportsNonRuntimeRetainedAnnotations == false &&
+        modality != Modality.OPEN && modality != Modality.ABSTRACT
+      ) {
+        // Infer if JvmName was used
+        // We skip annotation types for this because they can't have vars.
+        // We skip interface types or open/abstract properties because they can't have @JvmName.
+        setterSignature.jvmNameAnnotation(
+          metadataName = "set${name.safeCapitalize(Locale.US)}",
+          useSiteTarget = UseSiteTarget.SET,
+        )?.let { jvmNameAnnotation ->
+          mutableAnnotations += jvmNameAnnotation
         }
       }
     }

--- a/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
+++ b/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt
@@ -93,8 +93,6 @@ import kotlinx.metadata.Modality
 import kotlinx.metadata.Visibility
 import kotlinx.metadata.declaresDefaultValue
 import kotlinx.metadata.hasAnnotations
-import kotlinx.metadata.hasGetter
-import kotlinx.metadata.hasSetter
 import kotlinx.metadata.isConst
 import kotlinx.metadata.isCrossinline
 import kotlinx.metadata.isData
@@ -673,7 +671,7 @@ private fun KmProperty.toPropertySpec(
       }
     }
     if (setter != null) {
-        setterSignature?.let { setterSignature ->
+      setterSignature?.let { setterSignature ->
         if (containerData is ClassData &&
           !containerData.declarationContainer.isAnnotation &&
           !containerData.declarationContainer.isInterface &&


### PR DESCRIPTION
Version 0.9.0 deprecates several APIs including `read` where the replacement `readStrict` was not introduced until version 0.9.0 [https://github.com/JetBrains/kotlin/blob/master/libraries/kotlinx-metadata/jvm/Migration.md](https://www.google.com/url?sa=D&q=https%3A%2F%2Fgithub.com%2FJetBrains%2Fkotlin%2Fblob%2Fmaster%2Flibraries%2Fkotlinx-metadata%2Fjvm%2FMigration.md)

- [ x] `docs/changelog.md`

