### PR TITLE
Ksp opt in workaround

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,7 @@ Change Log
 * Fix: Omit implicit modifiers on FileSpec.scriptBuilder (#1813).
 * Fix: Fix trailing newline in PropertySpec (#1827).
 Change: kotlinx-metadata 0.9.0. Note that the `KotlinClassMetadata .read` is deprecated in 0.9.0 and replaced with `readStrict` (#1830).
-* Fix: `KSAnnotation.toAnnotationSpec` writes varargs in place instead of making them an array to work around a kotlin
+* Fix: `KSAnnotation.toAnnotationSpec` writes varargs in place instead of making them an array to work around a Kotlin
   issue with `OptIn` annotations (#1831).
 
 ## Version 1.16.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ Change Log
 * Fix: Omit implicit modifiers on FileSpec.scriptBuilder (#1813).
 * Fix: Fix trailing newline in PropertySpec (#1827).
 Change: kotlinx-metadata 0.9.0. Note that the `KotlinClassMetadata .read` is deprecated in 0.9.0 and replaced with `readStrict` (#1830).
+* Fix: `KSAnnotation.toAnnotationSpec` writes varargs in place instead of making them an array to work around a kotlin
+  issue with `OptIn` annotations (#1831).
 
 ## Version 1.16.0
 

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/Annotations.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/Annotations.kt
@@ -53,7 +53,7 @@ public fun KSAnnotation.toAnnotationSpec(omitDefaultValues: Boolean = false): An
       if (isDefaultValue(value, defaultValue)) { continue }
     }
     if (type?.isVararg == true) {
-      // wait to add varargs to end
+      // Wait to add varargs to end.
       varargValues = value as List<*>
     } else {
       val member = CodeBlock.builder()
@@ -61,12 +61,12 @@ public fun KSAnnotation.toAnnotationSpec(omitDefaultValues: Boolean = false): An
       addValueToBlock(value, member, omitDefaultValues)
       builder.addMember(member.build())
     }
-    if (varargValues != null) {
-      for (item in varargValues) {
-        val member = CodeBlock.builder()
-        addValueToBlock(item!!, member, omitDefaultValues)
-        builder.addMember(member.build())
-      }
+  }
+  if (varargValues != null) {
+    for (item in varargValues) {
+      val member = CodeBlock.builder()
+      addValueToBlock(item!!, member, omitDefaultValues)
+      builder.addMember(member.build())
     }
   }
   return builder.build()

--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/exampleAnnotations.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/exampleAnnotations.kt
@@ -79,3 +79,5 @@ annotation class AnotherAnnotation(val input: String)
 enum class AnnotationEnumValue {
   ONE, TWO, THREE
 }
+
+annotation class AnnotationWithVararg(vararg val args: String)

--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/exampleAnnotations.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/exampleAnnotations.kt
@@ -80,4 +80,4 @@ enum class AnnotationEnumValue {
   ONE, TWO, THREE
 }
 
-annotation class AnnotationWithVararg(vararg val args: String)
+annotation class AnnotationWithVararg(val simpleArg: Int, vararg val args: String)

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -621,6 +621,51 @@ class TestProcessorTest {
   }
 
   @Test
+  fun varargArgument() {
+    val compilation = prepareCompilation(
+      kotlin(
+        "Example.kt",
+        """
+           package test
+
+           import com.squareup.kotlinpoet.ksp.test.processor.AnnotationWithVararg
+           import com.squareup.kotlinpoet.ksp.test.processor.ExampleAnnotation
+
+           @RequiresOptIn
+           annotation class MyOptIn
+
+           @ExampleAnnotation
+           @OptIn(MyOptIn::class)
+           @AnnotationWithVararg("one", "two")
+           interface Example
+        """.trimIndent()
+      )
+    )
+
+    val result = compilation.compile()
+    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    val generatedFileText = File(compilation.kspSourcesDir, "kotlin/test/TestExample.kt")
+      .readText()
+
+    assertThat(generatedFileText).isEqualTo(
+      """
+      package test
+
+      import com.squareup.kotlinpoet.ksp.test.processor.AnnotationWithVararg
+      import kotlin.OptIn
+
+      @OptIn(MyOptIn::class)
+      @AnnotationWithVararg(
+        "one",
+        "two",
+      )
+      public class TestExample
+
+      """.trimIndent()
+    )
+  }
+
+  @Test
   fun regression_1513() {
     val compilation = prepareCompilation(
       kotlin(

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -636,10 +636,10 @@ class TestProcessorTest {
 
            @ExampleAnnotation
            @OptIn(MyOptIn::class)
-           @AnnotationWithVararg("one", "two")
+           @AnnotationWithVararg(0, "one", "two")
            interface Example
-        """.trimIndent()
-      )
+        """.trimIndent(),
+      ),
     )
 
     val result = compilation.compile()
@@ -656,12 +656,13 @@ class TestProcessorTest {
 
       @OptIn(MyOptIn::class)
       @AnnotationWithVararg(
+        simpleArg = 0,
         "one",
         "two",
       )
       public class TestExample
 
-      """.trimIndent()
+      """.trimIndent(),
     )
   }
 


### PR DESCRIPTION
- [x] `docs/changelog.md` has been updated if applicable.

~Stacked on #1832.~ Closes #1831.