### PR TITLE
Prevent name clashes between a function in class and a function call in current scope.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@ Change Log
 
 ## Unreleased
 
+* Fix: Prevent name clashes between a function in class and a function call in current scope (#1850).
 * Fix: Fix extension function imports (#1814).
 * Fix: Omit implicit modifiers on FileSpec.scriptBuilder (#1813).
 * Fix: Fix trailing newline in PropertySpec (#1827).

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/CodeWriter.kt
@@ -464,11 +464,14 @@ internal class CodeWriter constructor(
     val simpleName = imports[memberName.canonicalName]?.alias ?: memberName.simpleName
     // Match an imported member.
     val importedMember = importedMembers[simpleName]
-    if (importedMember == memberName) {
+    val found = importedMember == memberName
+    if (found && !isMethodNameUsedInCurrentContext(simpleName)) {
       return simpleName
     } else if (importedMember != null && memberName.enclosingClassName != null) {
       val enclosingClassName = lookupName(memberName.enclosingClassName)
       return "$enclosingClassName.$simpleName"
+    } else if (found) {
+      return simpleName
     }
 
     // If the member is in the same package, we're done.


### PR DESCRIPTION
This pull request aims to fix clashes name between a function in class and a function call. We have below generate code, which contains function in class and call another function with same name.

Actual:
```kotlin
      package com.squareup.tacos
      
      import com.squareup.Fridge.meat
      
      public class DeliciousTaco {
        public fun build(): Taco = Taco(deliciousMeat = meat { })
      
        public fun deliciousMeat() {
        }
      }
      
      public class TastelessTaco {
        public fun build(): Taco = Taco(meat = meat { }) // <----
      
        public fun meat() { // <----
        }
      }
      
```

Expected:
```kotlin
      package com.squareup.tacos
      
      import com.squareup.Fridge.meat
      
      public class DeliciousTaco {
        public fun build(): Taco = Taco(deliciousMeat = meat { })
      
        public fun deliciousMeat() {
        }
      }
      
      public class TastelessTaco {
        public fun build(): Taco = Taco(meat = com.squareup.Fridge.meat { }) // <----
      
        public fun meat() { // <----
        }
      }
      
```
