### PR TITLE
added a new format specifier (%U) for literals that should never wrap

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ Change: kotlinx-metadata 0.9.0. Note that the `KotlinClassMetadata .read` is dep
   issue with `OptIn` annotations (#1831).
 * Fix: `MemberName`s without a package are now correctly imported (#1841)
 * Fix: Throw if primary constructor delegates to other constructors (#1859).
+* New: `%U` format specifier for literals that should never have line breaks added (#????)
 
 ## Version 1.16.0
 

--- a/docs/l-for-literals.md
+++ b/docs/l-for-literals.md
@@ -20,6 +20,7 @@ private fun computeRange(name: String, from: Int, to: Int, op: String): FunSpec 
 ```
 
 Literals are emitted directly to the output code with no escaping. Arguments for literals may be
-strings, primitives, and a few KotlinPoet types described below.
+strings, primitives, and a few KotlinPoet types described below. Literals will have line breaks
+added if the literal is over 100 characters and has whitespace.
 
  [formatter]: https://developer.android.com/reference/java/util/Formatter.html

--- a/docs/u-for-unbroken-literals.md
+++ b/docs/u-for-unbroken-literals.md
@@ -1,0 +1,46 @@
+%U for Unbroken Literals
+===============
+
+Although the string specifier (`%S`) and literal specifier (`%L`) work in the vast majority of
+cases, sometimes escaping and line breaks are unacceptable in the output. In these cases, `%U` is
+the right specifier. `%U` has identical behavior to `%L` with the exception that it will never
+insert line breaks.
+
+This format specifier is useful where unexpected line breaks may break the correctness of the
+output. A specific example is the case where a byte array serialized as a pre-escaped String. Using
+any of the other specifiers in cases like this may unintentionally modify the content and make the
+emitted code incorrect.
+
+With `%U`:
+
+```kotlin
+private fun findLongInString(): FunSpec {
+  val longPreQuotedString = "\"very long string very long string very long string very long string very long string very long string very long string\""
+  return FunSpec.builder("findLongInString")
+    .returns(Boolean::class)
+    .addStatement("val theString = %U", longPreQuotedString)
+    .addStatement("return theString.contains(\"long\".toRegex())")
+    .build()
+}
+```
+
+Produces (note lack of line break on long string):
+
+```kotlin
+public fun findLongInString(): Boolean {
+  val theString = "very long string very long string very long string very long string very long string very long string very long string"
+  return theString.contains("long".toRegex())
+}
+```
+
+Whereas using `%L` would have produced (note line break):
+
+```kotlin
+public fun findLongInString(): Boolean {
+  val theString = "very long string very long string very long string very long string very
+      long string very long string very long string"
+  return theString.contains("long".toRegex())
+}
+```
+
+Which wouldn't compile.

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/CodeBlock.kt
@@ -343,6 +343,7 @@ public class CodeBlock private constructor(
       when (c) {
         'N' -> this.args += argToName(arg).escapeIfNecessary()
         'L' -> this.args += argToLiteral(arg)
+        'U' -> this.args += argToLiteral(arg)
         'S' -> this.args += argToString(arg)
         'P' -> this.args += if (arg is CodeBlock) arg else argToString(arg)
         'T' -> this.args += argToType(arg)

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/CodeWriter.kt
@@ -247,6 +247,8 @@ internal class CodeWriter constructor(
       when (val part = partIterator.next()) {
         "%L" -> emitLiteral(codeBlock.args[a++], isConstantContext, omitImplicitModifiers)
 
+        "%U" -> emitLiteral(codeBlock.args[a++], isConstantContext, omitImplicitModifiers, true)
+
         "%N" -> emit(codeBlock.args[a++] as String)
 
         "%S" -> {
@@ -394,7 +396,7 @@ internal class CodeWriter constructor(
     return false
   }
 
-  private fun emitLiteral(o: Any?, isConstantContext: Boolean, omitImplicitModifiers: Boolean) {
+  private fun emitLiteral(o: Any?, isConstantContext: Boolean, omitImplicitModifiers: Boolean, nonWrapping: Boolean = false) {
     when (o) {
       is TypeSpec -> o.emit(this, null)
       is AnnotationSpec -> o.emit(this, inline = true, asParameter = isConstantContext)
@@ -407,7 +409,7 @@ internal class CodeWriter constructor(
       )
       is TypeAliasSpec -> o.emit(this)
       is CodeBlock -> emitCode(o, isConstantContext = isConstantContext)
-      else -> emit(o.toString())
+      else -> emit(o.toString(), nonWrapping)
     }
   }
 

--- a/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/LineWrappingTest.kt
+++ b/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/LineWrappingTest.kt
@@ -212,6 +212,52 @@ class LineWrappingTest {
       )
   }
 
+  @Test fun unbrokenLiteralsDoNotWrap() {
+    val wrapMe = FunSpec.builder("wrapMe")
+      .returns(STRING)
+      .addStatement(
+        "%U",
+        "very long string very long string very long string very long string very long string very long string very long string very long string very long string very long string very long string very long string",
+      )
+      .build()
+    assertThat(toString(wrapMe)).isEqualTo(
+      """
+        |package com.squareup.tacos
+        |
+        |import kotlin.String
+        |
+        |public fun wrapMe(): String {
+        |  very long string very long string very long string very long string very long string very long string very long string very long string very long string very long string very long string very long string
+        |}
+        |
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun literalsDoWrap() {
+    val wrapMe = FunSpec.builder("wrapMe")
+      .returns(STRING)
+      .addStatement(
+        "%L",
+        "very long string very long string very long string very long string very long string very long string very long string very long string very long string very long string very long string very long string",
+      )
+      .build()
+    assertThat(toString(wrapMe)).isEqualTo(
+      """
+        |package com.squareup.tacos
+        |
+        |import kotlin.String
+        |
+        |public fun wrapMe(): String {
+        |  very long string very long string very long string very long string very long string very long
+        |      string very long string very long string very long string very long string very long string
+        |      very long string
+        |}
+        |
+      """.trimMargin(),
+    )
+  }
+
   private fun toString(typeSpec: TypeSpec): String {
     return FileSpec.get("com.squareup.tacos", typeSpec).toString()
   }


### PR DESCRIPTION
Using KotlinPoet, we found that the existing format specifiers weren't _quite_ appropriate for our use case.

In some cases, we have to generate classes that have large byte arrays. Because of the way those are compiled later, they can't be simple bytes arrays (they get encoded as instructions rather than end up in the constant pool), and we often hit the large method limit. Instead, we encode them as strings. We take the responsibility of escaping characters, and we don't want any line wrapping to make decoding easier.

We tried to use `%S`, but the automatic escaping and using multiline strings made guaranteeing the correctness of later decoding difficult.

We tried to use `%L`, but the automatic line wrapping caused compilation failures and also introduces decoding risk for us.

We didn't want to change behavior of existing specifiers, so adding a new one for a literal without wrapping seemed like the right course. Locally testing, it appears to do exactly what we need and cause no regressions in other functionality. The new specifier is `%U` for "unbroken" literals.

- [~] `docs/changelog.md` has been updated if applicable.
- [X] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
