### PR TITLE
Wrap supertypes if primary constructor wraps

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@ Change Log
 
 ## Unreleased
 
+* New: Supertype list wraps to one-per-line if the primary constructor spans multiple lines (#1866).
 * Fix: Prevent name clashes between a function in class and a function call in current scope (#1850).
 * Fix: Fix extension function imports (#1814).
 * Fix: Omit implicit modifiers on FileSpec.scriptBuilder (#1813).

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/TypeSpec.kt
@@ -178,6 +178,7 @@ public class TypeSpec private constructor(
         }
         codeWriter.emitTypeVariables(typeVariables)
 
+        var wrapSupertypes = false
         primaryConstructor?.let {
           codeWriter.pushType(this) // avoid name collisions when emitting primary constructor
           val emittedAnnotations = it.annotations.isNotEmpty()
@@ -198,6 +199,8 @@ public class TypeSpec private constructor(
           }
 
           it.parameters.emit(codeWriter, forceNewLines = true) { param ->
+            wrapSupertypes = true
+
             val property = constructorProperties[param.name]
             if (property != null) {
               property.emit(
@@ -232,7 +235,8 @@ public class TypeSpec private constructor(
         }
 
         if (superTypes.isNotEmpty()) {
-          codeWriter.emitCode(superTypes.joinToCode(separator = ", ", prefix = " : "))
+          val separator = if (wrapSupertypes) ",\n    " else ", "
+          codeWriter.emitCode(superTypes.joinToCode(separator = separator, prefix = " : "))
         }
 
         codeWriter.emitWhereBlock(typeVariables)


### PR DESCRIPTION
This means there's always a ") : " on a line which prefixes the supertypes, so force them to also wrap to multiple lines.

I decided to take a more opinionated approach that wasn't based on count, but instead is based on whether the primary constructor wraps to multiple lines. Closes #1865.

- [x] `docs/changelog.md` has been updated if applicable.
- [ ] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
