### PR TITLE
Corrected javapoet's GitHub repository

### DIFF
--- a/docs/interop-javapoet.md
+++ b/docs/interop-javapoet.md
@@ -1,7 +1,7 @@
 JavaPoet Extensions for KotlinPoet
 ==================================
 
-`interop:javapoet` is an interop API for converting [JavaPoet](https://github.com/squareup/javapoet)
+`interop:javapoet` is an interop API for converting [JavaPoet](https://github.com/square/javapoet)
 types to KotlinPoet types. This is particularly useful for projects that support code gen in
 multiple languages and want to easily be able to jump between.
 


### PR DESCRIPTION
- [X] `docs/changelog.md` has been updated if applicable.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.

<img width="60%" alt="image" src="https://github.com/square/kotlinpoet/assets/40740128/c5b41b1d-1070-4df8-9925-95cfd177e663">

> There is no squareup/javapoet

<br/>

javapoet's GitHub repository has been moved from squareup to square.
