### PR TITLE
Internalize non-KP-type-returning APIs in KM artifact

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ Change Log
 * Fix: Fix trailing newline in PropertySpec (#1827).
 * Change: kotlinx-metadata 0.9.0. Note that the `KotlinClassMetadata .read` is deprecated in 0.9.0 and replaced with `readStrict` (#1830).
   * Note: we now also `lenient` parameters to map to the underlying `readStrict()` and `readLenient()` calls (#1766).
+  * We have also removed various `Class`/`TypeElement`/`Metadata`-to-`KmClass` APIs from the public API, as these are trivial to write now with kotlinx-metadata's newer APIs and allows us to focus the API surface area of this artifact better (#1891).
 * Fix: `KSAnnotation.toAnnotationSpec` writes varargs in place instead of making them an array to work around a Kotlin
   issue with `OptIn` annotations (#1831).
 * Fix: `MemberName`s without a package are now correctly imported (#1841)

--- a/interop/kotlinx-metadata/api/kotlinx-metadata.api
+++ b/interop/kotlinx-metadata/api/kotlinx-metadata.api
@@ -1,11 +1,3 @@
-public final class com/squareup/kotlinpoet/metadata/KotlinPoetMetadata {
-	public static final fun readKotlinClassMetadata (Lkotlin/Metadata;Z)Lkotlinx/metadata/jvm/KotlinClassMetadata;
-	public static final fun toKmClass (Ljava/lang/Class;Z)Lkotlinx/metadata/KmClass;
-	public static final fun toKmClass (Ljavax/lang/model/element/TypeElement;Z)Lkotlinx/metadata/KmClass;
-	public static final fun toKmClass (Lkotlin/Metadata;Z)Lkotlinx/metadata/KmClass;
-	public static final fun toKmClass (Lkotlin/reflect/KClass;Z)Lkotlinx/metadata/KmClass;
-}
-
 public abstract interface annotation class com/squareup/kotlinpoet/metadata/KotlinPoetMetadataPreview : java/lang/annotation/Annotation {
 }
 

--- a/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/KotlinPoetMetadata.kt
+++ b/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/KotlinPoetMetadata.kt
@@ -24,7 +24,6 @@ import kotlin.annotation.AnnotationTarget.PROPERTY
 import kotlin.reflect.KClass
 import kotlinx.metadata.KmClass
 import kotlinx.metadata.jvm.KotlinClassMetadata
-import kotlinx.metadata.jvm.Metadata
 
 /**
  * Indicates that a given API is part of the experimental KotlinPoet metadata support. This exists
@@ -39,28 +38,24 @@ public annotation class KotlinPoetMetadataPreview
  * @param lenient see docs on [KotlinClassMetadata.readStrict] and [KotlinClassMetadata.readLenient] for more details.
  * @return a new [KmClass] representation of the Kotlin metadata for [this] class.
  */
-@KotlinPoetMetadataPreview
-public fun KClass<*>.toKmClass(lenient: Boolean): KmClass = java.toKmClass(lenient)
+internal fun KClass<*>.toKmClass(lenient: Boolean): KmClass = java.toKmClass(lenient)
 
 /**
  * @param lenient see docs on [KotlinClassMetadata.readStrict] and [KotlinClassMetadata.readLenient] for more details.
  * @return a new [KmClass] representation of the Kotlin metadata for [this] class.
  */
-@KotlinPoetMetadataPreview
-public fun Class<*>.toKmClass(lenient: Boolean): KmClass = readMetadata(::getAnnotation).toKmClass(lenient)
+internal fun Class<*>.toKmClass(lenient: Boolean): KmClass = readMetadata(::getAnnotation).toKmClass(lenient)
 
 /**
  * @param lenient see docs on [KotlinClassMetadata.readStrict] and [KotlinClassMetadata.readLenient] for more details.
  * @return a new [KmClass] representation of the Kotlin metadata for [this] type.
  */
-@KotlinPoetMetadataPreview
-public fun TypeElement.toKmClass(lenient: Boolean): KmClass = readMetadata(::getAnnotation).toKmClass(lenient)
+internal fun TypeElement.toKmClass(lenient: Boolean): KmClass = readMetadata(::getAnnotation).toKmClass(lenient)
 
 /**
  * @param lenient see docs on [KotlinClassMetadata.readStrict] and [KotlinClassMetadata.readLenient] for more details.
  */
-@KotlinPoetMetadataPreview
-public fun Metadata.toKmClass(lenient: Boolean): KmClass {
+internal fun Metadata.toKmClass(lenient: Boolean): KmClass {
   return toKotlinClassMetadata<KotlinClassMetadata.Class>(lenient)
     .kmClass
 }
@@ -68,8 +63,7 @@ public fun Metadata.toKmClass(lenient: Boolean): KmClass {
 /**
  * @param lenient see docs on [KotlinClassMetadata.readStrict] and [KotlinClassMetadata.readLenient] for more details.
  */
-@KotlinPoetMetadataPreview
-public inline fun <reified T : KotlinClassMetadata> Metadata.toKotlinClassMetadata(
+internal inline fun <reified T : KotlinClassMetadata> Metadata.toKotlinClassMetadata(
   lenient: Boolean,
 ): T {
   val expectedType = T::class
@@ -102,8 +96,7 @@ public inline fun <reified T : KotlinClassMetadata> Metadata.toKotlinClassMetada
  *
  * @param lenient see docs on [KotlinClassMetadata.readStrict] and [KotlinClassMetadata.readLenient] for more details.
  */
-@KotlinPoetMetadataPreview
-public fun Metadata.readKotlinClassMetadata(lenient: Boolean): KotlinClassMetadata {
+internal fun Metadata.readKotlinClassMetadata(lenient: Boolean): KotlinClassMetadata {
   return if (lenient) {
     KotlinClassMetadata.readLenient(this)
   } else {


### PR DESCRIPTION
These were useful in a time where kotlinx-metadata didn't offer easy entry point APIs for these, but it's come a long way now and we can better focus the artifact by only exposing kotlinpoet-specific APIs

Followup from https://github.com/square/kotlinpoet/pull/1766/#discussion_r1568840502