### PR TITLE
Group MkDocs upgrades to avoid version conflicts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,13 @@
         "^com\\.google\\.devtools\\.ksp:(?:[\\w-]+)$"
       ],
       "groupName": "Kotlin and KSP"
+    },
+    {
+      "matchManagers": ["pip_requirements"],
+      "matchPackagePrefixes": [
+        "mkdocs"
+      ],
+      "groupName": "MkDocs"
     }
   ]
 }


### PR DESCRIPTION
Resolves the deadlock between #1893 and #1894 which both depend on each other.