### PR TITLE
Support generating a single import for overloaded MemberNames

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@ Change Log
 * Fix: Throw if primary constructor delegates to other constructors (#1859).
 * Fix: Aliased imports with nested class (#1876).
 * Fix: Check for error types in `KSType.toClassName()` (#1890).
+* Fix: Support generating a single import for overloaded `MemberName`s (#1909).
 
 ## Version 1.16.0
 

--- a/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/MemberNameTest.kt
+++ b/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/MemberNameTest.kt
@@ -657,4 +657,29 @@ class MemberNameTest {
       """.trimIndent(),
     )
   }
+
+  // https://github.com/square/kotlinpoet/issues/1907
+  @Test fun `extension and non-extension MemberName clash`() {
+    val file = FileSpec.builder("com.squareup.tacos", "Tacos")
+      .addFunction(
+        FunSpec.builder("main")
+          .addStatement("println(%M(Taco()))", MemberName("com.squareup.wrappers", "wrap"))
+          .addStatement("println(Taco().%M())", MemberName("com.squareup.wrappers", "wrap", isExtension = true))
+          .build(),
+      )
+      .build()
+    assertThat(file.toString()).isEqualTo(
+      """
+      package com.squareup.tacos
+
+      import com.squareup.wrappers.wrap
+
+      public fun main() {
+        println(wrap(Taco()))
+        println(Taco().wrap())
+      }
+
+      """.trimIndent(),
+    )
+  }
 }


### PR DESCRIPTION
Fixes #1907.

MemberName imports were modeled after TypeName imports, where an import can only represent a single fully-qualified name. However with MemberNames, a single import can represent multiple overloaded members that share a fully-qualified name. While overloaded members can be represented with a single MemberName, we distinguish between extension and non-extension members, and their MemberNames are not equal. We'll currently try to generate import aliases in this case, which is incorrect, and actually impossible, since they have the exact same fully-qualified name (see #1907). This change handles this scenario and adds support for having a single import generated for multiple MemberNames.

- [x] `docs/changelog.md` has been updated if applicable.