### PR TITLE
Fix KT-18706 in CodeWriter.generateImports

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,18 @@ Change Log
 
 ## Unreleased
 
+ * Fix: Fix KT-18706: kotlinpoet now generates import aliases without backticks (#1920)
+   * For example:
+     ```kotlin
+     // before, doesn't compile due to KT-18706
+     import com.example.one.`$Foo` as `One$Foo`
+     import com.example.two.`$Foo` as `Two$Foo`
+
+     // now, compiles
+     import com.example.one.`$Foo` as One__Foo
+     import com.example.two.`$Foo` as Two__Foo
+     ```
+
 ## Version 1.18.0
 
 Thanks to [@DanielGronau][DanielGronau] for contributing to this release.

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/CodeWriter.kt
@@ -761,7 +761,8 @@ internal class CodeWriter(
           imported[simpleName] = qualifiedNames
         } else {
           generateImportAliases(simpleName, canonicalNamesToQualifiedNames, capitalizeAliases)
-            .onEach { (alias, qualifiedName) ->
+            .onEach { (a, qualifiedName) ->
+              val alias = a.escapeAsAlias()
               val canonicalName = qualifiedName.computeCanonicalName()
               generatedImports[canonicalName] = Import(canonicalName, alias)
 

--- a/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/UtilTest.kt
+++ b/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/UtilTest.kt
@@ -143,6 +143,52 @@ class UtilTest {
     assertThat("`A`".escapeIfNecessary()).isEqualTo("`A`")
   }
 
+  @Test
+  fun `escapeAsAlias all underscores`() {
+    val input = "____"
+    val expected = "____0"
+    assertThat(input.escapeAsAlias()).isEqualTo(expected)
+  }
+
+  @Test
+  fun `escapeAsAlias keyword`() {
+    val input = "if"
+    val expected = "__if"
+    assertThat(input.escapeAsAlias()).isEqualTo(expected)
+  }
+
+  @Test
+  fun `escapeAsAlias first character cannot be used as identifier start`() {
+    val input = "1abc"
+    val expected = "_1abc"
+    assertThat(input.escapeAsAlias()).isEqualTo(expected)
+  }
+
+  @Test
+  fun `escapeAsAlias dollar sign`() {
+    val input = "\$\$abc"
+    val expected = "____abc"
+    assertThat(input.escapeAsAlias()).isEqualTo(expected)
+  }
+
+  @Test
+  fun `escapeAsAlias characters that cannot be used as identifier part`() {
+    val input = "a b-c"
+    val expected = "a_U0020b_U002dc"
+    assertThat(input.escapeAsAlias()).isEqualTo(expected)
+  }
+
+  @Test
+  fun `escapeAsAlias double escape does nothing`() {
+    val input = "1SampleClass_\$Generated "
+    val expected = "_1SampleClass___Generated_U0020"
+
+    assertThat(input.escapeAsAlias())
+      .isEqualTo(expected)
+    assertThat(input.escapeAsAlias().escapeAsAlias())
+      .isEqualTo(expected)
+  }
+
   private fun stringLiteral(string: String) = stringLiteral(string, string)
 
   private fun stringLiteral(expected: String, value: String) =


### PR DESCRIPTION
- [x] `docs/changelog.md` has been updated if applicable.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.

Because of [KT-18706](https://youtrack.jetbrains.com/issue/KT-18706)
bug all aliases escaped with backticks are not resolved by the Kotlin compiler.

So I've added a new function to Utils - `String.escapeAsAlias`, which converts aliases to Java identifiers, so that backticks are no longer needed.

I tried to make a more "global" fix by adding `escapeAsAlias` to the `Import` constructor, but since `Import` is a `data class` the "easy way" is not possible. `Import` should be converted to `class` to do this.

So I've decided just to fix the `generateImports` function, so that aliases, generated by kotlinpoet itself, would work. This small fix helps a lot with code generation tools.