### PR TITLE
fix #1919 Small double values are set to zero in %L translation

### DIFF
--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/CodeBlock.kt
@@ -22,6 +22,7 @@ import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import javax.lang.model.element.Element
 import javax.lang.model.type.TypeMirror
+import kotlin.math.max
 import kotlin.reflect.KClass
 
 /**
@@ -374,7 +375,11 @@ public class CodeBlock private constructor(
         minusSign = '-'
       }
 
-      val precision = if (o is Float || o is Double) o.toString().split(".").last().length else 0
+      val precision = when(o) {
+        is Float -> max(o.toBigDecimal().stripTrailingZeros().scale(), 1)
+        is Double -> max(o.toBigDecimal().stripTrailingZeros().scale(), 1)
+        else -> 0
+      }
 
       val pattern = when (o) {
         is Float, is Double -> "###,##0.0" + "#".repeat(precision - 1)

--- a/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/CodeBlockTest.kt
+++ b/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/CodeBlockTest.kt
@@ -37,6 +37,43 @@ class CodeBlockTest {
     assertThat(a.toString()).isEqualTo("delicious taco")
   }
 
+  @Test fun doublePrecision() {
+    val doubles = listOf(
+      12345678900000.0 to "12_345_678_900_000.0",
+      12345678900000.07 to "12_345_678_900_000.07",
+      123456.0 to "123_456.0",
+      1234.5678 to "1_234.5678",
+      12.345678 to "12.345678",
+      0.12345678 to "0.12345678",
+      0.0001 to "0.0001",
+      0.00001 to "0.00001",
+      0.000001 to "0.000001",
+      0.0000001 to "0.0000001",
+    )
+    for((d, expected) in doubles) {
+      val a = CodeBlock.of("number %L", d)
+      assertThat(a.toString()).isEqualTo("number $expected")
+    }
+  }
+
+  @Test fun floatPrecision() {
+    val floats = listOf(
+      12345678.0f to "12_345_678.0",
+      123456.0f to "123_456.0",
+      1234.567f to "1_234.567",
+      12.34567f to "12.34567",
+      0.1234567f to "0.1234567",
+      0.0001f to "0.0001",
+      0.00001f to "0.00001",
+      0.000001f to "0.000001",
+      0.0000001f to "0.0000001",
+    )
+    for((f, expected) in floats) {
+      val a = CodeBlock.of("number %L", f)
+      assertThat(a.toString()).isEqualTo("number $expected")
+    }
+  }
+
   @Test fun percentEscapeCannotBeIndexed() {
     assertThrows<IllegalArgumentException> {
       CodeBlock.builder().add("%1%", "taco").build()


### PR DESCRIPTION
- [X ] `docs/changelog.md` has been updated if applicable.
- [X] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
