### PR TITLE
Fix complex alias handling in KsTypes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ Change Log
 
 * **Fix**: Don't expand typealiases of function types to `LambdaTypeName`s in `KSTypeReference.toTypeName()`.
 * **Fix**: Small double and float values were set to 0.0 in %L translation (#1919)
+* **Fix**: Fix typealias type argument resolution in KSP2.
 * **Enhancement**: Make enum entry references in `KSAnnotation.toAnnotationSpec()` and `KSClassDeclaration.toClassName()` more robust.
 * Migrate `kotlinpoet-metadata` to stable `org.jetbrains.kotlin:kotlin-metadata-jvm` artifact for Metadata parsing.
 * Promote `kotlinpoet-metadata` out of preview to stable.

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KsTypes.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KsTypes.kt
@@ -199,6 +199,6 @@ public fun KSTypeReference.toTypeName(
       returnType = elem.returnType.toTypeName(typeParamResolver),
     ).copy(nullable = type.isMarkedNullable, suspending = type.isSuspendFunctionType)
   } else {
-    type.toTypeName(typeParamResolver, element?.typeArguments.orEmpty())
+    type.toTypeName(typeParamResolver, type.arguments)
   }
 }


### PR DESCRIPTION
We were using the wrong API for this before, and it no longer works in KSP2. This uses the correct arguments API and resolves it on both platforms