### PR TITLE
Fix #1952

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,8 @@ Change Log
 
 ## Unreleased
 
+* Fix: Enum classes that only have an init block now also generate the required semicolon (#1952)
+
 ## Version 1.18.1
 
 Thanks to [@mitasov-ra][mitasov-ra] for contributing to this release.

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/TypeSpec.kt
@@ -262,7 +262,7 @@ public class TypeSpec private constructor(
         if (!firstMember) {
           codeWriter.emit("\n")
         }
-        if (propertySpecs.isNotEmpty() || funSpecs.isNotEmpty() || typeSpecs.isNotEmpty()) {
+        if (propertySpecs.isNotEmpty() || funSpecs.isNotEmpty() || typeSpecs.isNotEmpty() || initializerBlock.isNotEmpty()) {
           codeWriter.emit(";\n")
         }
       }

--- a/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -5714,6 +5714,23 @@ class TypeSpecTest {
     )
   }
 
+  @Test fun enumClassWithOnlyInitializerBlock() {
+    val typeSpec = TypeSpec.enumBuilder("Foo")
+      .addInitializerBlock(CodeBlock.EMPTY)
+      .build()
+
+    assertThat(typeSpec.toString()).isEqualTo(
+      """
+      |public enum class Foo {
+      |  ;
+      |  init {
+      |  }
+      |}
+      |
+      """.trimMargin(),
+    )
+  }
+
   @Test fun classKdoc() {
     val type = TypeSpec.classBuilder("MyClass")
       .addKdoc("This is my class")


### PR DESCRIPTION
- [X] `docs/changelog.md` has been updated if applicable.
- [X] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
