### PR TITLE
Add FileSpec.Builder.relativePath()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ Change Log
 * Fix: Preserve nullability in `KSType.toClassName()`. (#1956)
 * New: Add `KSTypeAlias.toClassName()`. (#1956)
 * New: Add `KSType.toClassNameOrNull()`. (#1956)
+* New: Add `FileSpec.Builder.relativePath()`. (#1976)
 
 ## Version 1.18.1
 

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
@@ -265,7 +265,7 @@ public class FileSpec private constructor(
     internal val memberImports = sortedSetOf<Import>()
     internal var indent = DEFAULT_INDENT
     override val tags: MutableMap<KClass<*>, Any> = mutableMapOf()
-    internal var relativePath :String? = null
+    internal var relativePath: String? = null
 
     public val defaultImports: MutableSet<String> = mutableSetOf()
     public val imports: List<Import> get() = memberImports.toList()

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
@@ -69,7 +69,7 @@ public class FileSpec private constructor(
    * The relative path of the file which would be produced by a call to [writeTo].
    * This value always uses unix-style path separators (`/`).
    */
-  public val relativePath: String = buildString {
+  public val relativePath: String = builder.relativePath ?: buildString {
     for (packageComponent in packageName.split('.').dropLastWhile { it.isEmpty() }) {
       append(packageComponent)
       append('/')
@@ -265,6 +265,7 @@ public class FileSpec private constructor(
     internal val memberImports = sortedSetOf<Import>()
     internal var indent = DEFAULT_INDENT
     override val tags: MutableMap<KClass<*>, Any> = mutableMapOf()
+    internal var relativePath :String? = null
 
     public val defaultImports: MutableSet<String> = mutableSetOf()
     public val imports: List<Import> get() = memberImports.toList()
@@ -553,6 +554,10 @@ public class FileSpec private constructor(
         }
       }
       return FileSpec(this)
+    }
+
+    public fun relativePath(relativePath: String): Builder = apply {
+      this.relativePath = relativePath
     }
   }
 

--- a/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/FileWritingTest.kt
+++ b/kotlinpoet/src/commonTest/kotlin/com/squareup/kotlinpoet/FileWritingTest.kt
@@ -312,4 +312,12 @@ class FileWritingTest {
     val testPath = fsRoot.resolve("fun.kt")
     assertThat(Files.exists(testPath)).isTrue()
   }
+
+  @Test fun fileWithDifferentRelativePathFromThePackageName() {
+    val expectRelativePath = "example/directory"
+    val file = FileSpec.builder("com.example", "File")
+      .relativePath(expectRelativePath)
+      .build()
+    assertThat(file.relativePath).isEqualTo(expectRelativePath)
+  }
 }


### PR DESCRIPTION
- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
