### PR TITLE
Migrating the `Util.kt` and `KModifier` from JVM to common

### DIFF
--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/KModifier.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/KModifier.kt
@@ -19,7 +19,6 @@ import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.KModifier.PROTECTED
 import com.squareup.kotlinpoet.KModifier.PUBLIC
-import java.util.EnumSet
 
 public enum class KModifier(
   internal val keyword: String,
@@ -89,4 +88,4 @@ public enum class KModifier(
   }
 }
 
-internal val VISIBILITY_MODIFIERS: Set<KModifier> = EnumSet.of(PUBLIC, INTERNAL, PROTECTED, PRIVATE)
+internal val VISIBILITY_MODIFIERS: Set<KModifier> = enumSetOf(PUBLIC, INTERNAL, PROTECTED, PRIVATE)

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/KModifier.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/KModifier.kt
@@ -88,4 +88,4 @@ public enum class KModifier(
   }
 }
 
-internal val VISIBILITY_MODIFIERS: Set<KModifier> = enumSetOf(PUBLIC, INTERNAL, PROTECTED, PRIVATE)
+internal val VISIBILITY_MODIFIERS: Set<KModifier> = setOf(PUBLIC, INTERNAL, PROTECTED, PRIVATE)

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Util.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Util.kt
@@ -15,23 +15,17 @@
  */
 package com.squareup.kotlinpoet
 
-import com.squareup.kotlinpoet.CodeBlock.Companion.isPlaceholder
-import java.util.Collections
-
 internal object NullAppendable : Appendable {
-  override fun append(charSequence: CharSequence) = this
-  override fun append(charSequence: CharSequence, start: Int, end: Int) = this
-  override fun append(c: Char) = this
+  override fun append(value: CharSequence?) = this
+  override fun append(value: CharSequence?, startIndex: Int, endIndex: Int) = this
+  override fun append(value: Char) = this
 }
 
-internal fun <K, V> Map<K, V>.toImmutableMap(): Map<K, V> =
-  Collections.unmodifiableMap(LinkedHashMap(this))
+internal expect fun <K, V> Map<K, V>.toImmutableMap(): Map<K, V>
 
-internal fun <T> Collection<T>.toImmutableList(): List<T> =
-  Collections.unmodifiableList(ArrayList(this))
+internal expect fun <T> Collection<T>.toImmutableList(): List<T>
 
-internal fun <T> Collection<T>.toImmutableSet(): Set<T> =
-  Collections.unmodifiableSet(LinkedHashSet(this))
+internal expect fun <T> Collection<T>.toImmutableSet(): Set<T>
 
 internal inline fun <reified T : Enum<T>> Collection<T>.toEnumSet(): Set<T> =
   enumValues<T>().filterTo(mutableSetOf(), this::contains)
@@ -63,9 +57,13 @@ internal fun characterLiteralWithoutSingleQuotes(c: Char) = when {
   c == '\"' -> "\"" // \u0022: double quote (")
   c == '\'' -> "\\'" // \u0027: single quote (')
   c == '\\' -> "\\\\" // \u005c: backslash (\)
-  c.isIsoControl -> String.format("\\u%04x", c.code)
+  c.isIsoControl -> formatIsoControlCode(c.code)
   else -> c.toString()
 }
+
+internal expect fun formatIsoControlCode(code: Int): String
+
+internal expect fun Int.toHexStr(): String
 
 internal fun escapeCharacterLiterals(s: String) = buildString {
   for (c in s) append(characterLiteralWithoutSingleQuotes(c))
@@ -138,34 +136,27 @@ internal fun stringLiteralWithQuotes(
   }
 }
 
-internal fun CodeBlock.ensureEndsWithNewLine() = trimTrailingNewLine('\n')
+// TODO Waiting for `CodeBlock` migration.
+// internal fun CodeBlock.ensureEndsWithNewLine()
 
-internal fun CodeBlock.trimTrailingNewLine(replaceWith: Char? = null) = if (isEmpty()) {
-  this
-} else {
-  with(toBuilder()) {
-    val lastFormatPart = trim().formatParts.last()
-    if (lastFormatPart.isPlaceholder && args.isNotEmpty()) {
-      val lastArg = args.last()
-      if (lastArg is String) {
-        val trimmedArg = lastArg.trimEnd('\n')
-        args[args.size - 1] = if (replaceWith != null) {
-          trimmedArg + replaceWith
-        } else {
-          trimmedArg
-        }
-      }
-    } else {
-      formatParts[formatParts.lastIndexOf(lastFormatPart)] = lastFormatPart.trimEnd('\n')
-      if (replaceWith != null) {
-        formatParts += "$replaceWith"
-      }
-    }
-    return@with build()
-  }
-}
+// TODO Waiting for `CodeBlock` migration.
+// internal fun CodeBlock.trimTrailingNewLine(replaceWith: Char? = null)
 
-private val IDENTIFIER_REGEX =
+/**
+ *  Will crash if used `IDENTIFIER_REGEX_VALUE.toRegex()` directly in WasmJs:
+ *  `PatternSyntaxException: No such character class`.
+ *
+ *  It works in JS and JVM.
+ *
+ *  For now:
+ *  - Keep the use of `Regex` in JVM and JS.
+ *  - And use `RegExp` directly in WasmJs for matching,
+ *    using it in a similar way as in JS.
+ *
+ *  See also: [KT-71003](https://youtrack.jetbrains.com/issue/KT-71003)
+ */
+internal const val IDENTIFIER_REGEX_VALUE =
+  // language=regexp
   (
     "((\\p{gc=Lu}+|\\p{gc=Ll}+|\\p{gc=Lt}+|\\p{gc=Lm}+|\\p{gc=Lo}+|\\p{gc=Nl}+)+" +
       "\\d*" +
@@ -173,9 +164,8 @@ private val IDENTIFIER_REGEX =
       "|" +
       "(`[^\n\r`]+`)"
     )
-    .toRegex()
 
-internal val String.isIdentifier get() = IDENTIFIER_REGEX.matches(this)
+internal expect val String.isIdentifier: Boolean
 
 // https://kotlinlang.org/docs/reference/keyword-reference.html
 internal val KEYWORDS = setOf(
@@ -317,7 +307,7 @@ internal fun String.escapeAsAlias(validate: Boolean = true): String {
 
   val newAlias = StringBuilder("")
 
-  if (!Character.isJavaIdentifierStart(first())) {
+  if (!first().isJavaIdentifierStart()) {
     newAlias.append('_')
   }
 
@@ -327,8 +317,8 @@ internal fun String.escapeAsAlias(validate: Boolean = true): String {
       continue
     }
 
-    if (!Character.isJavaIdentifierPart(ch)) {
-      newAlias.append("_U").append(Integer.toHexString(ch.code).padStart(4, '0'))
+    if (!ch.isJavaIdentifierPart()) {
+      newAlias.append("_U").append(ch.code.toHexStr().padStart(4, '0'))
       continue
     }
 
@@ -348,8 +338,8 @@ private fun String.escapeIfAllCharactersAreUnderscore() = if (allCharactersAreUn
 
 private fun String.escapeIfNotJavaIdentifier(): String {
   return if ((
-      !Character.isJavaIdentifierStart(first()) ||
-        drop(1).any { !Character.isJavaIdentifierPart(it) }
+      !first().isJavaIdentifierStart() ||
+        drop(1).any { !it.isJavaIdentifierPart() }
       ) &&
     !alreadyEscaped()
   ) {
@@ -362,3 +352,9 @@ private fun String.escapeIfNotJavaIdentifier(): String {
 internal fun String.escapeSegmentsIfNecessary(delimiter: Char = '.') = split(delimiter)
   .filter { it.isNotEmpty() }
   .joinToString(delimiter.toString()) { it.escapeIfNecessary() }
+
+internal expect inline fun <reified E : Enum<E>> enumSetOf(vararg values: E): MutableSet<E>
+
+internal expect fun Char.isJavaIdentifierStart(): Boolean
+
+internal expect fun Char.isJavaIdentifierPart(): Boolean

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Util.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Util.kt
@@ -61,9 +61,11 @@ internal fun characterLiteralWithoutSingleQuotes(c: Char) = when {
   else -> c.toString()
 }
 
-internal expect fun formatIsoControlCode(code: Int): String
+internal fun formatIsoControlCode(code: Int): String =
+  "\\u${code.toHexStr().padStart(4, '0')}"
 
-internal expect fun Int.toHexStr(): String
+internal fun Int.toHexStr(): String =
+  toUInt().toString(16)
 
 internal fun escapeCharacterLiterals(s: String) = buildString {
   for (c in s) append(characterLiteralWithoutSingleQuotes(c))

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Util.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Util.kt
@@ -353,8 +353,6 @@ internal fun String.escapeSegmentsIfNecessary(delimiter: Char = '.') = split(del
   .filter { it.isNotEmpty() }
   .joinToString(delimiter.toString()) { it.escapeIfNecessary() }
 
-internal expect inline fun <reified E : Enum<E>> enumSetOf(vararg values: E): MutableSet<E>
-
 internal expect fun Char.isJavaIdentifierStart(): Boolean
 
 internal expect fun Char.isJavaIdentifierPart(): Boolean

--- a/kotlinpoet/src/jsMain/kotlin/com/squareup/kotlinpoet/Util.js.kt
+++ b/kotlinpoet/src/jsMain/kotlin/com/squareup/kotlinpoet/Util.js.kt
@@ -1,0 +1,5 @@
+package com.squareup.kotlinpoet
+
+private val IDENTIFIER_REGEX = IDENTIFIER_REGEX_VALUE.toRegex()
+
+internal actual val String.isIdentifier: Boolean get() = IDENTIFIER_REGEX.matches(this)

--- a/kotlinpoet/src/jsMain/kotlin/com/squareup/kotlinpoet/Util.js.kt
+++ b/kotlinpoet/src/jsMain/kotlin/com/squareup/kotlinpoet/Util.js.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.kotlinpoet
 
 private val IDENTIFIER_REGEX = IDENTIFIER_REGEX_VALUE.toRegex()

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/Util.jvm.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/Util.jvm.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet
+
+import com.squareup.kotlinpoet.CodeBlock.Companion.isPlaceholder
+import java.util.Collections
+import java.util.EnumSet
+
+internal actual fun <K, V> Map<K, V>.toImmutableMap(): Map<K, V> =
+  Collections.unmodifiableMap(LinkedHashMap(this))
+
+internal actual fun <T> Collection<T>.toImmutableList(): List<T> =
+  Collections.unmodifiableList(ArrayList(this))
+
+internal actual fun <T> Collection<T>.toImmutableSet(): Set<T> =
+  Collections.unmodifiableSet(LinkedHashSet(this))
+
+internal actual fun formatIsoControlCode(code: Int): String =
+  String.format("\\u%04x", code)
+
+internal actual fun Int.toHexStr(): String =
+  Integer.toHexString(this)
+
+// TODO Waiting for `CodeBlock` migration.
+internal fun CodeBlock.ensureEndsWithNewLine() = trimTrailingNewLine('\n')
+
+// TODO Waiting for `CodeBlock` migration.
+internal fun CodeBlock.trimTrailingNewLine(replaceWith: Char? = null) = if (isEmpty()) {
+  this
+} else {
+  with(toBuilder()) {
+    val lastFormatPart = trim().formatParts.last()
+    if (lastFormatPart.isPlaceholder && args.isNotEmpty()) {
+      val lastArg = args.last()
+      if (lastArg is String) {
+        val trimmedArg = lastArg.trimEnd('\n')
+        args[args.size - 1] = if (replaceWith != null) {
+          trimmedArg + replaceWith
+        } else {
+          trimmedArg
+        }
+      }
+    } else {
+      formatParts[formatParts.lastIndexOf(lastFormatPart)] = lastFormatPart.trimEnd('\n')
+      if (replaceWith != null) {
+        formatParts += "$replaceWith"
+      }
+    }
+    return@with build()
+  }
+}
+
+private val IDENTIFIER_REGEX = IDENTIFIER_REGEX_VALUE.toRegex()
+
+internal actual val String.isIdentifier: Boolean
+  get() = IDENTIFIER_REGEX.matches(this)
+
+internal actual inline fun <reified E : Enum<E>> enumSetOf(vararg values: E): MutableSet<E> {
+  return when(values.size) {
+    0 -> EnumSet.noneOf(E::class.java)
+    1 -> EnumSet.of(values[0])
+    2 -> EnumSet.of(values[0], values[1])
+    3 -> EnumSet.of(values[0], values[1], values[2])
+    4 -> EnumSet.of(values[0], values[1], values[2], values[3])
+    5 -> EnumSet.of(values[0], values[1], values[2], values[3], values[4])
+    else -> EnumSet.copyOf(values.toSet())
+  }
+}
+
+internal actual fun Char.isJavaIdentifierStart(): Boolean =
+  Character.isJavaIdentifierStart(this)
+
+internal actual fun Char.isJavaIdentifierPart(): Boolean =
+  Character.isJavaIdentifierPart(this)

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/Util.jvm.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/Util.jvm.kt
@@ -68,18 +68,6 @@ private val IDENTIFIER_REGEX = IDENTIFIER_REGEX_VALUE.toRegex()
 internal actual val String.isIdentifier: Boolean
   get() = IDENTIFIER_REGEX.matches(this)
 
-internal actual inline fun <reified E : Enum<E>> enumSetOf(vararg values: E): MutableSet<E> {
-  return when (values.size) {
-    0 -> EnumSet.noneOf(E::class.java)
-    1 -> EnumSet.of(values[0])
-    2 -> EnumSet.of(values[0], values[1])
-    3 -> EnumSet.of(values[0], values[1], values[2])
-    4 -> EnumSet.of(values[0], values[1], values[2], values[3])
-    5 -> EnumSet.of(values[0], values[1], values[2], values[3], values[4])
-    else -> EnumSet.copyOf(values.toSet())
-  }
-}
-
 internal actual fun Char.isJavaIdentifierStart(): Boolean =
   Character.isJavaIdentifierStart(this)
 

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/Util.jvm.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/Util.jvm.kt
@@ -69,7 +69,7 @@ internal actual val String.isIdentifier: Boolean
   get() = IDENTIFIER_REGEX.matches(this)
 
 internal actual inline fun <reified E : Enum<E>> enumSetOf(vararg values: E): MutableSet<E> {
-  return when(values.size) {
+  return when (values.size) {
     0 -> EnumSet.noneOf(E::class.java)
     1 -> EnumSet.of(values[0])
     2 -> EnumSet.of(values[0], values[1])

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/Util.jvm.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/Util.jvm.kt
@@ -17,7 +17,6 @@ package com.squareup.kotlinpoet
 
 import com.squareup.kotlinpoet.CodeBlock.Companion.isPlaceholder
 import java.util.Collections
-import java.util.EnumSet
 
 internal actual fun <K, V> Map<K, V>.toImmutableMap(): Map<K, V> =
   Collections.unmodifiableMap(LinkedHashMap(this))
@@ -27,12 +26,6 @@ internal actual fun <T> Collection<T>.toImmutableList(): List<T> =
 
 internal actual fun <T> Collection<T>.toImmutableSet(): Set<T> =
   Collections.unmodifiableSet(LinkedHashSet(this))
-
-internal actual fun formatIsoControlCode(code: Int): String =
-  String.format("\\u%04x", code)
-
-internal actual fun Int.toHexStr(): String =
-  Integer.toHexString(this)
 
 // TODO Waiting for `CodeBlock` migration.
 internal fun CodeBlock.ensureEndsWithNewLine() = trimTrailingNewLine('\n')

--- a/kotlinpoet/src/nonJvmMain/kotlin/com/squareup/kotlinpoet/Util.nonJvm.kt
+++ b/kotlinpoet/src/nonJvmMain/kotlin/com/squareup/kotlinpoet/Util.nonJvm.kt
@@ -1,0 +1,87 @@
+package com.squareup.kotlinpoet
+
+internal actual fun <K, V> Map<K, V>.toImmutableMap(): Map<K, V> =
+  toMap()
+
+internal actual fun <T> Collection<T>.toImmutableList(): List<T> =
+  toList()
+
+internal actual fun <T> Collection<T>.toImmutableSet(): Set<T> =
+  toSet()
+
+internal actual fun formatIsoControlCode(code: Int): String {
+  return buildString(6) {
+    append("\\u")
+    appendFormat04x(code)
+  }
+}
+
+@OptIn(ExperimentalStdlibApi::class)
+private val HexFormatWithoutLeadingZeros = HexFormat {
+  number {
+    removeLeadingZeros = true
+  }
+}
+
+@OptIn(ExperimentalStdlibApi::class)
+internal fun Appendable.appendFormat04x(code: Int) {
+  val hex = code.toHexString(HexFormatWithoutLeadingZeros)
+  if (hex.length < 4) {
+    repeat(4 - hex.length) { append('0') }
+  }
+  append(hex)
+}
+
+@OptIn(ExperimentalStdlibApi::class)
+internal actual fun Int.toHexStr(): String =
+  toHexString(HexFormatWithoutLeadingZeros)
+
+internal actual inline fun <reified E : Enum<E>> enumSetOf(vararg values: E): MutableSet<E> =
+  values.toMutableSet()
+
+internal actual fun Char.isJavaIdentifierStart(): Boolean {
+  return isLetter() ||
+    this in CharCategory.LETTER_NUMBER ||
+    this == '$' ||
+    this == '_'
+}
+
+
+internal actual fun Char.isJavaIdentifierPart(): Boolean {
+  //  TODO
+  //   A character may be part of a Java identifier if any of the following conditions are true:
+  //   - it is a letter
+  //   - it is a currency symbol (such as '$')
+  //   - it is a connecting punctuation character (such as '_')
+  //   - it is a digit
+  //   - it is a numeric letter (such as a Roman numeral character)
+  //   - it is a combining mark
+  //   - it is a non-spacing mark
+  //   isIdentifierIgnorable returns true for the character.
+  //   Also missing here:
+  //   - a combining mark
+  return isLetter() ||
+    isDigit() ||
+    this in CharCategory.LETTER_NUMBER ||
+    this in CharCategory.NON_SPACING_MARK ||
+    this == '_' ||
+    this == '$' ||
+    isIdentifierIgnorable()
+  //
+}
+
+internal fun Char.isIdentifierIgnorable(): Boolean {
+   // The following Unicode characters are ignorable in a Java identifier or a Unicode identifier:
+   // - ISO control characters that are not whitespace
+   //   - '\u0000' through '\u0008'
+   //   - '\u000E' through '\u001B'
+   //   - '\u007F' through '\u009F'
+   // - all characters that have the FORMAT general category value
+  return (
+    isISOControl() && (
+        this in '\u0000'..'\u0008' ||
+        this in '\u000E'..'\u001B' ||
+        this in '\u007F'..'\u009F'
+      )
+    ) || this in CharCategory.FORMAT
+}

--- a/kotlinpoet/src/nonJvmMain/kotlin/com/squareup/kotlinpoet/Util.nonJvm.kt
+++ b/kotlinpoet/src/nonJvmMain/kotlin/com/squareup/kotlinpoet/Util.nonJvm.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.kotlinpoet
 
 internal actual fun <K, V> Map<K, V>.toImmutableMap(): Map<K, V> =
@@ -46,7 +61,6 @@ internal actual fun Char.isJavaIdentifierStart(): Boolean {
     this == '_'
 }
 
-
 internal actual fun Char.isJavaIdentifierPart(): Boolean {
   //  TODO
   //   A character may be part of a Java identifier if any of the following conditions are true:
@@ -71,15 +85,15 @@ internal actual fun Char.isJavaIdentifierPart(): Boolean {
 }
 
 internal fun Char.isIdentifierIgnorable(): Boolean {
-   // The following Unicode characters are ignorable in a Java identifier or a Unicode identifier:
-   // - ISO control characters that are not whitespace
-   //   - '\u0000' through '\u0008'
-   //   - '\u000E' through '\u001B'
-   //   - '\u007F' through '\u009F'
-   // - all characters that have the FORMAT general category value
+  // The following Unicode characters are ignorable in a Java identifier or a Unicode identifier:
+  // - ISO control characters that are not whitespace
+  //   - '\u0000' through '\u0008'
+  //   - '\u000E' through '\u001B'
+  //   - '\u007F' through '\u009F'
+  // - all characters that have the FORMAT general category value
   return (
     isISOControl() && (
-        this in '\u0000'..'\u0008' ||
+      this in '\u0000'..'\u0008' ||
         this in '\u000E'..'\u001B' ||
         this in '\u007F'..'\u009F'
       )

--- a/kotlinpoet/src/nonJvmMain/kotlin/com/squareup/kotlinpoet/Util.nonJvm.kt
+++ b/kotlinpoet/src/nonJvmMain/kotlin/com/squareup/kotlinpoet/Util.nonJvm.kt
@@ -24,7 +24,6 @@ internal actual fun <T> Collection<T>.toImmutableList(): List<T> =
 internal actual fun <T> Collection<T>.toImmutableSet(): Set<T> =
   toSet()
 
-
 internal actual fun Char.isJavaIdentifierStart(): Boolean {
   return isLetter() ||
     this in CharCategory.LETTER_NUMBER ||

--- a/kotlinpoet/src/nonJvmMain/kotlin/com/squareup/kotlinpoet/Util.nonJvm.kt
+++ b/kotlinpoet/src/nonJvmMain/kotlin/com/squareup/kotlinpoet/Util.nonJvm.kt
@@ -24,32 +24,6 @@ internal actual fun <T> Collection<T>.toImmutableList(): List<T> =
 internal actual fun <T> Collection<T>.toImmutableSet(): Set<T> =
   toSet()
 
-internal actual fun formatIsoControlCode(code: Int): String {
-  return buildString(6) {
-    append("\\u")
-    appendFormat04x(code)
-  }
-}
-
-@OptIn(ExperimentalStdlibApi::class)
-private val HexFormatWithoutLeadingZeros = HexFormat {
-  number {
-    removeLeadingZeros = true
-  }
-}
-
-@OptIn(ExperimentalStdlibApi::class)
-internal fun Appendable.appendFormat04x(code: Int) {
-  val hex = code.toHexString(HexFormatWithoutLeadingZeros)
-  if (hex.length < 4) {
-    repeat(4 - hex.length) { append('0') }
-  }
-  append(hex)
-}
-
-@OptIn(ExperimentalStdlibApi::class)
-internal actual fun Int.toHexStr(): String =
-  toHexString(HexFormatWithoutLeadingZeros)
 
 internal actual fun Char.isJavaIdentifierStart(): Boolean {
   return isLetter() ||

--- a/kotlinpoet/src/nonJvmMain/kotlin/com/squareup/kotlinpoet/Util.nonJvm.kt
+++ b/kotlinpoet/src/nonJvmMain/kotlin/com/squareup/kotlinpoet/Util.nonJvm.kt
@@ -51,9 +51,6 @@ internal fun Appendable.appendFormat04x(code: Int) {
 internal actual fun Int.toHexStr(): String =
   toHexString(HexFormatWithoutLeadingZeros)
 
-internal actual inline fun <reified E : Enum<E>> enumSetOf(vararg values: E): MutableSet<E> =
-  values.toMutableSet()
-
 internal actual fun Char.isJavaIdentifierStart(): Boolean {
   return isLetter() ||
     this in CharCategory.LETTER_NUMBER ||

--- a/kotlinpoet/src/wasmJsMain/kotlin/com/squareup/kotlinpoet/Util.wasmJs.kt
+++ b/kotlinpoet/src/wasmJsMain/kotlin/com/squareup/kotlinpoet/Util.wasmJs.kt
@@ -1,0 +1,26 @@
+package com.squareup.kotlinpoet
+
+internal actual val String.isIdentifier: Boolean
+  get() {
+    val regExp = RegExp(IDENTIFIER_REGEX_VALUE, "gu")
+    regExp.reset()
+
+    val match = regExp.exec(this) ?: return false
+    return match.index == 0 && regExp.lastIndex == length
+  }
+
+internal external interface RegExpMatch {
+  val index: Int
+  val length: Int
+}
+
+internal external class RegExp(pattern: String, flags: String? = definedExternally) : JsAny {
+  fun exec(str: String): RegExpMatch?
+  override fun toString(): String
+
+  var lastIndex: Int
+}
+
+internal fun RegExp.reset() {
+  lastIndex = 0
+}

--- a/kotlinpoet/src/wasmJsMain/kotlin/com/squareup/kotlinpoet/Util.wasmJs.kt
+++ b/kotlinpoet/src/wasmJsMain/kotlin/com/squareup/kotlinpoet/Util.wasmJs.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.kotlinpoet
 
 internal actual val String.isIdentifier: Boolean


### PR DESCRIPTION
Part of #304, #1959

Migrating `Util.kt` and `KModifier` from JVM to common.

- Non-JVM platform implementations have some questionable implementations (They mark the TODO).
- There is a known issue ([KT-71003](https://youtrack.jetbrains.com/issue/KT-71003)) regarding the use of Kotlin `Regex` in WasmJS.
- there are some functions that need to wait for other types of migration.

On the JVM, however, the effect is the same before and after migration.

Let me know if there's anything I need to do, thanks.
If these changes are not reviewed until after 2.0, you can always tell me, convert it to draft, or close it~ 