### PR TITLE
Add support for delegates to Anonymous classes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,8 @@ Change Log
 
 ## Unreleased
 
+* Fix: Support delegates on anonymous classes. (#2034)
+
 ## Version 2.0.0
 
 Thanks to [@brokenhappy][brokenhappy], [@tajobe][tajobe], [@niyajali][niyajali],

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/TypeSpec.kt
@@ -159,7 +159,7 @@ public class TypeSpec private constructor(
         }
 
         if (allSuperTypes.isNotEmpty()) {
-          codeWriter.emitCode(allSuperTypes.joinToCode(separator = ", ", prefix = " : "))
+          codeWriter.emitCode(allSuperTypes.joinToCode(prefix = " : "))
         }
         if (hasNoBody) {
           codeWriter.emit(" {\n}")

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/TypeSpec.kt
@@ -142,23 +142,24 @@ public class TypeSpec private constructor(
         codeWriter.emitCode("object")
         val supertype = if (superclass != ANY) {
           if (!areNestedExternal && !modifiers.contains(EXPECT)) {
-            listOf(CodeBlock.of(" %T(%L)", superclass, superclassConstructorParametersBlock))
+            listOf(CodeBlock.of("%T(%L)", superclass, superclassConstructorParametersBlock))
           } else {
-            listOf(CodeBlock.of(" %T", superclass))
+            listOf(CodeBlock.of("%T", superclass))
           }
         } else {
           listOf()
         }
 
-        val allSuperTypes = supertype + if (superinterfaces.isNotEmpty()) {
-          superinterfaces.keys.map { CodeBlock.of(" %T", it) }
-        } else {
-          emptyList()
+        val allSuperTypes = supertype + superinterfaces.entries.map { (type, init) ->
+          if (init == null) {
+            CodeBlock.of("%T", type)
+          } else {
+            CodeBlock.of("%T by %L", type, init)
+          }
         }
 
         if (allSuperTypes.isNotEmpty()) {
-          codeWriter.emitCode(" :")
-          codeWriter.emitCode(allSuperTypes.joinToCode(","))
+          codeWriter.emitCode(allSuperTypes.joinToCode(separator = ", ", prefix = " : "))
         }
         if (hasNoBody) {
           codeWriter.emit(" {\n}")

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -4396,7 +4396,7 @@ class TypeSpecTest {
       )
       .addSuperinterface(
         Runnable::class,
-        CodeBlock.of("Runnable ({ %T.debug(\"Hello world\") })", Logger::class.asTypeName()),
+        CodeBlock.of("Runnable ({ %T.debug(\"Hello world\") })", Logger::class),
       )
       .build()
 
@@ -4435,17 +4435,13 @@ class TypeSpecTest {
   // https://github.com/square/kotlinpoet/issues/2033
   @Test fun testMultipleDelegatesOnAnonymousObject() {
     val type = TypeSpec.anonymousClassBuilder()
-      .primaryConstructor(
-        FunSpec.constructorBuilder()
-          .build(),
-      )
       .addSuperinterface(
         Function::class.parameterizedBy(String::class, Int::class),
         CodeBlock.of("kotlin.Function ({ text -> text.toIntOrNull() ?: 0 })"),
       )
       .addSuperinterface(
         Runnable::class,
-        CodeBlock.of("java.lang.Runnable ({ %T.debug(\"Hello world\") })", Logger::class.asTypeName()),
+        CodeBlock.of("java.lang.Runnable ({ %T.debug(\"Hello world\") })", Logger::class),
       )
       .build()
 

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -4367,7 +4367,7 @@ class TypeSpecTest {
     val type = TypeSpec.objectBuilder("Guac")
       .addSuperinterface(
         Consumer::class.parameterizedBy(String::class),
-        CodeBlock.of("({ println(it) })"),
+        CodeBlock.of("Consumer({ println(it) })"),
       )
       .build()
 
@@ -4377,7 +4377,7 @@ class TypeSpecTest {
         |import java.util.function.Consumer
         |import kotlin.String
         |
-        |public object Guac : Consumer<String> by ({ println(it) })
+        |public object Guac : Consumer<String> by Consumer({ println(it) })
         |
     """.trimMargin()
 
@@ -4416,6 +4416,47 @@ class TypeSpecTest {
 
     assertThat(toString(type)).isEqualTo(expect)
   }
+// https://github.com/square/kotlinpoet/issues/2033
+  @Test fun testDelegateOnAnonymousObject() {
+    val type = TypeSpec.anonymousClassBuilder()
+      .addSuperinterface(
+        Consumer::class.parameterizedBy(String::class),
+        CodeBlock.of("java.util.function.Consumer({ println(it) })"),
+      )
+      .build()
+
+    val expect = """
+        |object : java.util.function.Consumer<kotlin.String> by java.util.function.Consumer({ println(it) }) {
+        |}
+    """.trimMargin()
+
+    assertThat(type.toString()).isEqualTo(expect)
+  }
+  // https://github.com/square/kotlinpoet/issues/2033
+  @Test fun testMultipleDelegatesOnAnonymousObject() {
+    val type = TypeSpec.anonymousClassBuilder()
+      .primaryConstructor(
+        FunSpec.constructorBuilder()
+          .build(),
+      )
+      .addSuperinterface(
+        Function::class.parameterizedBy(String::class, Int::class),
+        CodeBlock.of("kotlin.Function ({ text -> text.toIntOrNull() ?: 0 })"),
+      )
+      .addSuperinterface(
+        Runnable::class,
+        CodeBlock.of("java.lang.Runnable ({ %T.debug(\"Hello world\") })", Logger::class.asTypeName()),
+      )
+      .build()
+
+    val expect = """
+        |object : kotlin.Function<kotlin.String, kotlin.Int> by kotlin.Function ({ text -> text.toIntOrNull() ?: 0 }), java.lang.Runnable by java.lang.Runnable ({ java.util.logging.Logger.debug("Hello world") }) {
+        |}
+    """.trimMargin()
+
+    assertThat(type.toString()).isEqualTo(expect)
+  }
+
 
   @Test fun testNoSuchParameterDelegate() {
     assertThrows<IllegalArgumentException> {

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -4416,6 +4416,7 @@ class TypeSpecTest {
 
     assertThat(toString(type)).isEqualTo(expect)
   }
+
 // https://github.com/square/kotlinpoet/issues/2033
   @Test fun testDelegateOnAnonymousObject() {
     val type = TypeSpec.anonymousClassBuilder()
@@ -4432,6 +4433,7 @@ class TypeSpecTest {
 
     assertThat(type.toString()).isEqualTo(expect)
   }
+
   // https://github.com/square/kotlinpoet/issues/2033
   @Test fun testMultipleDelegatesOnAnonymousObject() {
     val type = TypeSpec.anonymousClassBuilder()
@@ -4452,7 +4454,6 @@ class TypeSpecTest {
 
     assertThat(type.toString()).isEqualTo(expect)
   }
-
 
   @Test fun testNoSuchParameterDelegate() {
     assertThrows<IllegalArgumentException> {


### PR DESCRIPTION
- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.

Fixes https://github.com/square/kotlinpoet/issues/2033

