### PR TITLE
Migrate OriginatingElementsHolder and Taggable from JVM to common

### DIFF
--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -1253,6 +1253,9 @@ public final class com/squareup/kotlinpoet/jvm/JvmAnnotations {
 	public static final fun volatile (Lcom/squareup/kotlinpoet/PropertySpec$Builder;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
 }
 
+public abstract interface annotation class com/squareup/kotlinpoet/jvm/alias/JvmTypeAliasKotlinPoetApi : java/lang/annotation/Annotation {
+}
+
 public final class com/squareup/kotlinpoet/tags/TypeAliasTag {
 	public fun <init> (Lcom/squareup/kotlinpoet/TypeName;)V
 	public final fun getAbbreviatedType ()Lcom/squareup/kotlinpoet/TypeName;

--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -1253,6 +1253,10 @@ public final class com/squareup/kotlinpoet/jvm/JvmAnnotations {
 	public static final fun volatile (Lcom/squareup/kotlinpoet/PropertySpec$Builder;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
 }
 
+public final class com/squareup/kotlinpoet/jvm/alias/JvmClass_jvmKt {
+	public static final fun getKotlin (Ljava/lang/Class;)Lkotlin/reflect/KClass;
+}
+
 public abstract interface annotation class com/squareup/kotlinpoet/jvm/alias/JvmTypeAliasKotlinPoetApi : java/lang/annotation/Annotation {
 }
 

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/OriginatingElementsHolder.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/OriginatingElementsHolder.kt
@@ -15,24 +15,26 @@
  */
 package com.squareup.kotlinpoet
 
-import javax.lang.model.element.Element
+import com.squareup.kotlinpoet.jvm.alias.JvmDefaultWithCompatibility
+import com.squareup.kotlinpoet.jvm.alias.JvmElement
+import kotlin.jvm.JvmInline
 
 /** A type that can have originating [elements][Element]. */
 public interface OriginatingElementsHolder {
 
   /** The originating elements of this type. */
-  public val originatingElements: List<Element>
+  public val originatingElements: List<JvmElement>
 
   /** The builder analogue to [OriginatingElementsHolder] types. */
   @JvmDefaultWithCompatibility
   public interface Builder<out T : Builder<T>> {
 
     /** Mutable map of the current originating elements this builder contains. */
-    public val originatingElements: MutableList<Element>
+    public val originatingElements: MutableList<JvmElement>
 
     /** Adds an [originatingElement] to this type's list of originating elements. */
     @Suppress("UNCHECKED_CAST")
-    public fun addOriginatingElement(originatingElement: Element): T = apply {
+    public fun addOriginatingElement(originatingElement: JvmElement): T = apply {
       originatingElements += originatingElement
     } as T
   }
@@ -41,10 +43,10 @@ public interface OriginatingElementsHolder {
 internal fun OriginatingElementsHolder.Builder<*>.buildOriginatingElements() =
   OriginatingElements(originatingElements.toImmutableList())
 
-internal fun List<Element>.buildOriginatingElements() =
+internal fun List<JvmElement>.buildOriginatingElements() =
   OriginatingElements(toImmutableList())
 
 @JvmInline
 internal value class OriginatingElements(
-  override val originatingElements: List<Element>,
+  override val originatingElements: List<JvmElement>,
 ) : OriginatingElementsHolder

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Taggable.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Taggable.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet
+
+import com.squareup.kotlinpoet.jvm.alias.JvmClass
+import com.squareup.kotlinpoet.jvm.alias.JvmDefaultWithCompatibility
+import com.squareup.kotlinpoet.jvm.alias.kotlin
+import kotlin.jvm.JvmInline
+import kotlin.reflect.KClass
+
+/** A type that can be tagged with extra metadata of the user's choice. */
+@JvmDefaultWithCompatibility
+public interface Taggable {
+
+  /** Returns all tags. */
+  public val tags: Map<KClass<*>, Any> get() = emptyMap()
+
+  /** Returns the tag attached with [type] as a key, or null if no tag is attached with that key. */
+  public fun <T : Any> tag(type: JvmClass<T>): T? = tag(type.kotlin)
+
+  /** Returns the tag attached with [type] as a key, or null if no tag is attached with that key. */
+  public fun <T : Any> tag(type: KClass<T>): T? {
+    @Suppress("UNCHECKED_CAST")
+    return tags[type] as T?
+  }
+
+  /** The builder analogue to [Taggable] types. */
+  @JvmDefaultWithCompatibility
+  public interface Builder<out T : Builder<T>> {
+
+    /** Mutable map of the current tags this builder contains. */
+    public val tags: MutableMap<KClass<*>, Any>
+
+    /**
+     * Attaches [tag] to the request using [type] as a key. Tags can be read from a
+     * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+     * [type].
+     *
+     * Use this API to attach originating elements, debugging, or other application data to a spec
+     * so that you may read it in other APIs or callbacks.
+     */
+    public fun tag(type: JvmClass<*>, tag: Any?): T = tag(type.kotlin, tag)
+
+    /**
+     * Attaches [tag] to the request using [type] as a key. Tags can be read from a
+     * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+     * [type].
+     *
+     * Use this API to attach originating elements, debugging, or other application data to a spec
+     * so that you may read it in other APIs or callbacks.
+     */
+    @Suppress("UNCHECKED_CAST")
+    public fun tag(type: KClass<*>, tag: Any?): T = apply {
+      if (tag == null) {
+        this.tags.remove(type)
+      } else {
+        this.tags[type] = tag
+      }
+    } as T
+  }
+}
+
+/** Returns the tag attached with [T] as a key, or null if no tag is attached with that key. */
+public inline fun <reified T : Any> Taggable.tag(): T? = tag(T::class)
+
+internal fun Taggable.Builder<*>.buildTagMap(): TagMap = TagMap(tags)
+
+@JvmInline
+internal value class TagMap private constructor(override val tags: Map<KClass<*>, Any>) : Taggable {
+  companion object {
+    operator fun invoke(tags: Map<KClass<*>, Any>): TagMap = TagMap(tags.toImmutableMap())
+  }
+}

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmClass.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmClass.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.jvm.alias
+
+import kotlin.reflect.KClass
+
+/**
+ * An expected typealias for `java.lang.Class`.
+ */
+public expect class JvmClass<T : Any>
+
+/**
+ * Convert [JvmClass] to [KClass].
+ */
+public expect val <T : Any> JvmClass<T>.kotlin: KClass<T>

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmDefaultWithCompatibility.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmDefaultWithCompatibility.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.jvm.alias
+
+/**
+ * A typealias annotation for `kotlin.jvm.JvmDefaultWithCompatibility`.
+ */
+@OptIn(ExperimentalMultiplatform::class)
+@OptionalExpectation
+public expect annotation class JvmDefaultWithCompatibility()

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmElement.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmElement.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.jvm.alias
+
+/**
+ * An expected typealias for `javax.lang.model.element.Element`.
+ */
+public expect interface JvmElement
+
+/**
+ * An expected typealias for `javax.lang.model.element.TypeElement`.
+ */
+public expect interface JvmTypeElement : JvmElement
+
+/**
+ * An expected typealias for `javax.lang.model.element.ExecutableElement`.
+ */
+public expect interface JvmExecutableElement : JvmElement
+
+/**
+ * An expected typealias for `javax.lang.model.element.VariableElement`.
+ */
+public expect interface JvmVariableElement : JvmElement

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmTypeAliasKotlinPoetApi.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmTypeAliasKotlinPoetApi.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.jvm.alias
+
+/**
+ * An expected type for JVM to `typealias` only.
+ */
+@MustBeDocumented
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY, AnnotationTarget.TYPEALIAS)
+@RequiresOptIn(
+  level = RequiresOptIn.Level.ERROR,
+  message = "An expected type for JVM to `typealias` only." +
+    " Don't implement or use it in non-JVM platforms.",
+)
+public annotation class JvmTypeAliasKotlinPoetApi

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/Taggable.jvm.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/Taggable.jvm.kt
@@ -15,63 +15,6 @@
  */
 package com.squareup.kotlinpoet
 
-import kotlin.reflect.KClass
-
-/** A type that can be tagged with extra metadata of the user's choice. */
-@JvmDefaultWithCompatibility
-public interface Taggable {
-
-  /** Returns all tags. */
-  public val tags: Map<KClass<*>, Any> get() = emptyMap()
-
-  /** Returns the tag attached with [type] as a key, or null if no tag is attached with that key. */
-  public fun <T : Any> tag(type: Class<T>): T? = tag(type.kotlin)
-
-  /** Returns the tag attached with [type] as a key, or null if no tag is attached with that key. */
-  public fun <T : Any> tag(type: KClass<T>): T? {
-    @Suppress("UNCHECKED_CAST")
-    return tags[type] as T?
-  }
-
-  /** The builder analogue to [Taggable] types. */
-  @JvmDefaultWithCompatibility
-  public interface Builder<out T : Builder<T>> {
-
-    /** Mutable map of the current tags this builder contains. */
-    public val tags: MutableMap<KClass<*>, Any>
-
-    /**
-     * Attaches [tag] to the request using [type] as a key. Tags can be read from a
-     * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
-     * [type].
-     *
-     * Use this API to attach originating elements, debugging, or other application data to a spec
-     * so that you may read it in other APIs or callbacks.
-     */
-    public fun tag(type: Class<*>, tag: Any?): T = tag(type.kotlin, tag)
-
-    /**
-     * Attaches [tag] to the request using [type] as a key. Tags can be read from a
-     * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
-     * [type].
-     *
-     * Use this API to attach originating elements, debugging, or other application data to a spec
-     * so that you may read it in other APIs or callbacks.
-     */
-    @Suppress("UNCHECKED_CAST")
-    public fun tag(type: KClass<*>, tag: Any?): T = apply {
-      if (tag == null) {
-        this.tags.remove(type)
-      } else {
-        this.tags[type] = tag
-      }
-    } as T
-  }
-}
-
-/** Returns the tag attached with [T] as a key, or null if no tag is attached with that key. */
-public inline fun <reified T : Any> Taggable.tag(): T? = tag(T::class)
-
 /**
  * Attaches [tag] to the request using [T] as a key. Tags can be read from a
  * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
@@ -149,12 +92,3 @@ public inline fun <reified T : Any> TypeAliasSpec.Builder.tag(tag: T?): TypeAlia
  */
 public inline fun <reified T : Any> TypeSpec.Builder.tag(tag: T?): TypeSpec.Builder =
   tag(T::class, tag)
-
-internal fun Taggable.Builder<*>.buildTagMap(): TagMap = TagMap(tags)
-
-@JvmInline
-internal value class TagMap private constructor(override val tags: Map<KClass<*>, Any>) : Taggable {
-  companion object {
-    operator fun invoke(tags: Map<KClass<*>, Any>): TagMap = TagMap(tags.toImmutableMap())
-  }
-}

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmClass.jvm.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmClass.jvm.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.jvm.alias
+
+import kotlin.jvm.kotlin as jvmKotlin
+import kotlin.reflect.KClass
+
+/**
+ * An expected typealias for [Class].
+ */
+public actual typealias JvmClass<T> = Class<T>
+
+/**
+ * Convert [JvmClass] to [KClass].
+ */
+public actual val <T : Any> JvmClass<T>.kotlin: KClass<T>
+  get() = jvmKotlin

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmDefaultWithCompatibility.jvm.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmDefaultWithCompatibility.jvm.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.jvm.alias
+
+/**
+ * A typealias annotation for [kotlin.jvm.JvmDefaultWithCompatibility].
+ */
+public actual typealias JvmDefaultWithCompatibility = kotlin.jvm.JvmDefaultWithCompatibility

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmElement.jvm.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmElement.jvm.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.jvm.alias
+
+import javax.lang.model.element.Element
+import javax.lang.model.element.ExecutableElement
+import javax.lang.model.element.TypeElement
+import javax.lang.model.element.VariableElement
+
+/**
+ * Type alias for [Element].
+ */
+public actual typealias JvmElement = Element
+
+/**
+ * Type alias for [TypeElement].
+ */
+public actual typealias JvmTypeElement = TypeElement
+
+/**
+ * Type alias for [ExecutableElement].
+ */
+public actual typealias JvmExecutableElement = ExecutableElement
+
+/**
+ * Type alias for [VariableElement].
+ */
+public actual typealias JvmVariableElement = VariableElement

--- a/kotlinpoet/src/nonJvmMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmClass.nonJvm.kt
+++ b/kotlinpoet/src/nonJvmMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmClass.nonJvm.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.jvm.alias
+
+import kotlin.reflect.KClass
+
+@JvmTypeAliasKotlinPoetApi
+public actual class JvmClass<@Suppress("unused")
+  T : Any,> private constructor()
+
+@JvmTypeAliasKotlinPoetApi
+public actual val <T : Any> JvmClass<T>.kotlin: KClass<T>
+  get() = throw UnsupportedOperationException()

--- a/kotlinpoet/src/nonJvmMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmElement.nonJvm.kt
+++ b/kotlinpoet/src/nonJvmMain/kotlin/com/squareup/kotlinpoet/jvm/alias/JvmElement.nonJvm.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet.jvm.alias
+
+@JvmTypeAliasKotlinPoetApi
+public actual interface JvmElement
+
+@JvmTypeAliasKotlinPoetApi
+public actual interface JvmTypeElement : JvmElement
+
+@JvmTypeAliasKotlinPoetApi
+public actual interface JvmExecutableElement : JvmElement
+
+@JvmTypeAliasKotlinPoetApi
+public actual interface JvmVariableElement : JvmElement


### PR DESCRIPTION
Part of https://github.com/square/kotlinpoet/issues/304, https://github.com/square/kotlinpoet/pull/1959

Migrate `OriginatingElementsHolder` and `Taggable` from JVM to common