### PR TITLE
Migrate LineWrapper from JVM to common

### DIFF
--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/LineWrapper.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/LineWrapper.kt
@@ -15,8 +15,6 @@
  */
 package com.squareup.kotlinpoet
 
-import java.io.Closeable
-
 /**
  * Implements soft line wrapping on an appendable. To use, append characters using
  * [LineWrapper.append], which will handle formatting characters as necessary. Use
@@ -26,7 +24,7 @@ internal class LineWrapper(
   private val out: Appendable,
   private val indent: String,
   private val columnLimit: Int,
-) : Closeable {
+) : AutoCloseable {
 
   private var closed = false
 


### PR DESCRIPTION
Part of https://github.com/square/kotlinpoet/issues/304, https://github.com/square/kotlinpoet/pull/1959

Migrate `LineWrapper` from JVM to common