### PR TITLE
Aliased import ignored for nullable variants of that type

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,8 +5,7 @@ Change Log
 
 * Fix: Support delegates on anonymous classes. (#2034)
 * Fix: `TypeName.MUTABLE_MAP_ENTRY` now correctly uses the `MutableEntry` nested class name. (#2061)
-* Fix: Aliased import ignored for nullable variants of that type. (#2020)
-* Fix: Aliased import may throw java.lang.IllegalArgumentException if nullable and not nullable variants of it are used. (#2021)
+* Fix: Use the same aliased import for both the nullable and non-nullable versions of a type (#2020 #2021)
 
 
 ## Version 2.0.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,8 @@ Change Log
 
 * Fix: Support delegates on anonymous classes. (#2034)
 * Fix: `TypeName.MUTABLE_MAP_ENTRY` now correctly uses the `MutableEntry` nested class name. (#2061)
+* Fix: Aliased import ignored for nullable variants of that type. (#2020)
+* Fix: Aliased import may throw java.lang.IllegalArgumentException if nullable and not nullable variants of it are used. (#2021)
 
 
 ## Version 2.0.0

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeWriter.kt
@@ -514,7 +514,7 @@ internal class CodeWriter(
     // Check for name clashes with members.
     if (simpleName !in importableMembers) {
       // Maintain the inner class name if the alias exists.
-      val newImportTypes = if (alias == null) {
+      val newImportTypes = if (alias == null || className.isNullable) {
         topLevelClassName
       } else {
         className

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeWriter.kt
@@ -514,10 +514,10 @@ internal class CodeWriter(
     // Check for name clashes with members.
     if (simpleName !in importableMembers) {
       // Maintain the inner class name if the alias exists.
-      val newImportTypes = if (alias == null || className.isNullable) {
+      val newImportTypes = if (alias == null) {
         topLevelClassName
       } else {
-        className
+        className.copy(nullable = false) as ClassName
       }
       importableTypes[simpleName] = importableTypes.getValue(simpleName) + newImportTypes
     }

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -1262,28 +1262,28 @@ class FunSpecTest {
       """.trimMargin(),
     )
   }
-  
+
   @Test fun importAliasWithNullableReturnNestedClass() {
-  val packageName = "org.example"
-  val className = ClassName(packageName, "Person", "Id")
-  val spec = FileSpec.builder("org.example", "SomeFile")
-    .addAliasedImport(className, "PID")
-    .addFunction(
-      FunSpec.builder("pid")
-        .returns(className.copy(nullable = true))
-        .addCode("return %T()", className)
-        .build(),
-    )
-    .build()
-  assertThat(spec.toString()).isEqualTo(
-    """
+    val packageName = "org.example"
+    val className = ClassName(packageName, "Person", "Id")
+    val spec = FileSpec.builder("org.example", "SomeFile")
+      .addAliasedImport(className, "PID")
+      .addFunction(
+        FunSpec.builder("pid")
+          .returns(className.copy(nullable = true))
+          .addCode("return %T()", className)
+          .build(),
+      )
+      .build()
+    assertThat(spec.toString()).isEqualTo(
+      """
     |package org.example
     |
     |import org.example.Person.Id as PID
     |
     |public fun pid(): PID? = PID()
     |
-    """.trimMargin(),
-  )
-}
+      """.trimMargin(),
+    )
+  }
 }

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -1238,4 +1238,28 @@ class FunSpecTest {
       """.trimMargin(),
     )
   }
+
+  @Test fun importAliasWithNullableReturn() {
+    val packageName = "org.example"
+    val className = ClassName(packageName, "PersonId")
+    val spec = FileSpec.builder("org.example", "SomeFile")
+      .addAliasedImport(className, "PID")
+      .addFunction(
+        FunSpec.builder("pid")
+          .returns(className.copy(nullable = true))
+          .addCode("return %T()", className)
+          .build()
+      )
+      .build()
+    assertThat(spec.toString()).isEqualTo(
+      """
+      |package org.example
+      |
+      |import org.example.PersonId as PID
+      |
+      |public fun pid(): PID? = PID()
+      |
+      """.trimMargin(),
+    )
+  }
 }

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -1248,7 +1248,7 @@ class FunSpecTest {
         FunSpec.builder("pid")
           .returns(className.copy(nullable = true))
           .addCode("return %T()", className)
-          .build()
+          .build(),
       )
       .build()
     assertThat(spec.toString()).isEqualTo(

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -1262,4 +1262,28 @@ class FunSpecTest {
       """.trimMargin(),
     )
   }
+  
+  @Test fun importAliasWithNullableReturnNestedClass() {
+  val packageName = "org.example"
+  val className = ClassName(packageName, "Person", "Id")
+  val spec = FileSpec.builder("org.example", "SomeFile")
+    .addAliasedImport(className, "PID")
+    .addFunction(
+      FunSpec.builder("pid")
+        .returns(className.copy(nullable = true))
+        .addCode("return %T()", className)
+        .build(),
+    )
+    .build()
+  assertThat(spec.toString()).isEqualTo(
+    """
+    |package org.example
+    |
+    |import org.example.Person.Id as PID
+    |
+    |public fun pid(): PID? = PID()
+    |
+    """.trimMargin(),
+  )
+}
 }


### PR DESCRIPTION
- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.

Closes #2020. Closes #2021.
