### PR TITLE
Check the Gradle distribution checksum

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=296742a352f0b20ec14b143fb684965ad66086c7810b7b255dee216670716175
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
It is generally a good idea to ensure the integrity of the Gradle distribution to prevent MITM attacks when downloading. (See https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:verification)

Renovate automatically updates this.

- [X] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [X] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
