### PR TITLE
Allow to use context parameters as Names (#2114)

### DIFF
--- a/docs/context-parameters.md
+++ b/docs/context-parameters.md
@@ -22,10 +22,16 @@ public fun greet() {
 You can add multiple context parameters:
 
 ```kotlin
+val loggerType = ClassName("java.util.logging", "Logger")
+val configType = ClassName("com.example", "Config")
+
+val logger = ContextParameter("logger", loggerType)
+val config = ContextParameter("config", configType)
+
 val processData = FunSpec.builder("processData")
-  .contextParameter("logger", ClassName("com.example", "Logger"))
-  .contextParameter("config", ClassName("com.example", "Config"))
-  .addStatement("logger.info(\"Processing with config: ${'$'}config\")")
+  .contextParameter("logger", loggerType)
+  .contextParameter("config", configType)
+  .addStatement("%N.info(\"Processing with config: ${'$'}%N\")", logger, config)
   .build()
 ```
 

--- a/docs/context-parameters.md
+++ b/docs/context-parameters.md
@@ -29,8 +29,8 @@ val logger = ContextParameter("logger", loggerType)
 val config = ContextParameter("config", configType)
 
 val processData = FunSpec.builder("processData")
-  .contextParameter("logger", loggerType)
-  .contextParameter("config", configType)
+  .contextParameter(logger)
+  .contextParameter(config)
   .addStatement("%N.info(\"Processing with config: ${'$'}%N\")", logger, config)
   .build()
 ```

--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -392,8 +392,6 @@ public final class com/squareup/kotlinpoet/FunSpec$Builder : com/squareup/kotlin
 	public final fun callThisConstructor ([Ljava/lang/String;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public static synthetic fun callThisConstructor$default (Lcom/squareup/kotlinpoet/FunSpec$Builder;[Lcom/squareup/kotlinpoet/CodeBlock;ILjava/lang/Object;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun clearBody ()Lcom/squareup/kotlinpoet/FunSpec$Builder;
-	public synthetic fun contextParameter (Lcom/squareup/kotlinpoet/TypeName;)Lcom/squareup/kotlinpoet/ContextParameterizable$Builder;
-	public synthetic fun contextParameter (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;)Lcom/squareup/kotlinpoet/ContextParameterizable$Builder;
 	public synthetic fun contextParameters (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/ContextParameterizable$Builder;
 	public synthetic fun contextReceivers (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/ContextReceivable$Builder;
 	public final fun endControlFlow ()Lcom/squareup/kotlinpoet/FunSpec$Builder;
@@ -795,9 +793,6 @@ public final class com/squareup/kotlinpoet/PropertySpec$Builder : com/squareup/k
 	public final fun addTypeVariable (Lcom/squareup/kotlinpoet/TypeVariableName;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
 	public final fun addTypeVariables (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
 	public final fun build ()Lcom/squareup/kotlinpoet/PropertySpec;
-	public synthetic fun contextParameter (Lcom/squareup/kotlinpoet/TypeName;)Lcom/squareup/kotlinpoet/ContextParameterizable$Builder;
-	public synthetic fun contextParameter (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;)Lcom/squareup/kotlinpoet/ContextParameterizable$Builder;
-	public synthetic fun contextParameters (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/ContextParameterizable$Builder;
 	public final fun delegate (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
 	public final fun delegate (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
 	public fun getAnnotations ()Ljava/util/List;

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlock.kt
@@ -362,6 +362,7 @@ public class CodeBlock private constructor(
       is FunSpec -> o.name
       is TypeSpec -> o.name!!
       is MemberName -> o.simpleName
+      is ContextParameter -> if (o.name == "_") throw IllegalStateException("Named context parameter required") else o.name
       else -> throw IllegalArgumentException("expected name but was $o")
     }
 

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/ContextParameter.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/ContextParameter.kt
@@ -92,6 +92,13 @@ public interface ContextParameterizable {
       contextParameters(listOf(ContextParameter(type)))
 
     /**
+     * Adds the given [ContextParameter] to this type's list of context parameters.
+     */
+    @ExperimentalKotlinPoetApi
+    public fun contextParameter(contextParameter: ContextParameter): T =
+      contextParameters(listOf(contextParameter))
+
+    /**
      * Adds a context parameter with the given [name] and [type] to this type's list of context parameters.
      */
     @DelicateKotlinPoetApi(

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
@@ -304,6 +304,7 @@ public class FunSpec private constructor(
     builder.tags += tagMap.tags
     builder.originatingElements += originatingElements
     builder.contextReceiverTypes += contextReceiverTypes
+    builder.contextParameters += contextParameters
     return builder
   }
 
@@ -377,24 +378,6 @@ public class FunSpec private constructor(
       check(!name.isConstructor) { "constructors cannot have context receivers" }
       check(!name.isAccessor) { "$name cannot have context receivers" }
       contextReceiverTypes += receiverTypes
-    }
-
-    /**
-     * Adds a context parameter with the given [name] and [type] to this function.
-     */
-    @ExperimentalKotlinPoetApi
-    override fun contextParameter(name: String, type: TypeName): Builder = apply {
-      checkContextParametersAllowed()
-      contextParameters += ContextParameter(name, type)
-    }
-
-    /**
-     * Adds a context parameter with the name "_" and [type] to this type's list of context parameters.
-     */
-    @ExperimentalKotlinPoetApi
-    override fun contextParameter(type: TypeName): Builder = apply {
-      checkContextParametersAllowed()
-      contextParameters += ContextParameter(type)
     }
 
     /**

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/PropertySpec.kt
@@ -172,6 +172,7 @@ public class PropertySpec private constructor(
     builder.tags += tagMap.tags
     builder.originatingElements += originatingElements
     builder.contextReceiverTypes += contextReceiverTypes
+    builder.contextParameters += contextParameters
     return builder
   }
 
@@ -204,30 +205,6 @@ public class PropertySpec private constructor(
 
     @ExperimentalKotlinPoetApi
     override val contextParameters: MutableList<ContextParameter> = mutableListOf()
-
-    /**
-     * Adds a context parameter with the given [name] and [type] to this property.
-     */
-    @ExperimentalKotlinPoetApi
-    override fun contextParameter(name: String, type: TypeName): Builder = apply {
-      contextParameters += ContextParameter(name, type)
-    }
-
-    /**
-     * Adds a context parameter with the name "_" and [type] to this type's list of context parameters.
-     */
-    @ExperimentalKotlinPoetApi
-    override fun contextParameter(type: TypeName): Builder = apply {
-      contextParameters += ContextParameter(type)
-    }
-
-    /**
-     * Adds context parameters to this property.
-     */
-    @ExperimentalKotlinPoetApi
-    override fun contextParameters(parameters: Iterable<ContextParameter>): Builder = apply {
-      contextParameters += parameters
-    }
 
     /** True to create a `var` instead of a `val`. */
     public fun mutable(mutable: Boolean = true): Builder = apply {

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/CodeBlockTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/CodeBlockTest.kt
@@ -681,4 +681,23 @@ class CodeBlockTest {
 
     Locale.setDefault(defaultLocale)
   }
+
+  @Test fun nameFromContextParameter() {
+    val logger = ContextParameter("logger", ClassName("java.util.logging", "Logger"))
+    assertThat(CodeBlock.of("%N", logger).toString()).isEqualTo("logger")
+  }
+
+  @Test fun nameFromMultipleContextParameters() {
+    val logger = ContextParameter("logger", ClassName("java.util.logging", "Logger"))
+    val config = ContextParameter("config", ClassName("com.example", "Config"))
+    assertThat(CodeBlock.of("%N.info(\"Processing with config: ${'$'}%N\")", logger, config).toString())
+      .isEqualTo("logger.info(\"Processing with config: ${'$'}config\")")
+  }
+
+  @Test fun nameFromUnnamedContextParameter() {
+    val unnamed = ContextParameter(ClassName("java.util.logging", "Logger"))
+    assertThrows<IllegalStateException> {
+      CodeBlock.of("%N", unnamed)
+    }.hasMessageThat().isEqualTo("Named context parameter required")
+  }
 }

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -702,6 +702,30 @@ class FunSpecTest {
     }.hasMessageThat().isEqualTo("Using both context receivers and context parameters is not allowed")
   }
 
+  @Test fun contextParameterInAddStatement() {
+    val loggerType = ClassName("java.util.logging", "Logger")
+    val configType = ClassName("com.example", "Config")
+
+    val logger = ContextParameter("logger", loggerType)
+    val config = ContextParameter("config", configType)
+
+    val processData = FunSpec.builder("processData")
+      .contextParameter("logger", loggerType)
+      .contextParameter("config", configType)
+      .addStatement("%N.info(\"Processing with config: ${'$'}%N\")", logger, config)
+      .build()
+
+    assertThat(processData.toString()).isEqualTo(
+      """
+      |context(logger: java.util.logging.Logger, config: com.example.Config)
+      |public fun processData() {
+      |  logger.info("Processing with config: ${'$'}config")
+      |}
+      |
+      """.trimMargin(),
+    )
+  }
+
   @Test fun constructorWithContextParameter() {
     assertThrows<IllegalStateException> {
       FunSpec.constructorBuilder()

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -710,8 +710,8 @@ class FunSpecTest {
     val config = ContextParameter("config", configType)
 
     val processData = FunSpec.builder("processData")
-      .contextParameter("logger", loggerType)
-      .contextParameter("config", configType)
+      .contextParameter(logger)
+      .contextParameter(config)
       .addStatement("%N.info(\"Processing with config: ${'$'}%N\")", logger, config)
       .build()
 

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -288,6 +288,7 @@ class PropertySpecTest {
       .addModifiers(KModifier.PUBLIC)
       .addTypeVariable(TypeVariableName("T"))
       .delegate("Delegates.notNull()")
+      .contextParameter("user", STRING)
       .receiver(Int::class)
       .getter(
         FunSpec.getterBuilder()


### PR DESCRIPTION
- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
