### PR TITLE
Fix interop-kotlin-metadata API link (#2118)

### DIFF
--- a/docs/interop-kotlin-metadata.md
+++ b/docs/interop-kotlin-metadata.md
@@ -1,8 +1,8 @@
 KotlinPoet-metadata
 ===================
 
-`interop:kotlinx-metadata` is an API for working with Kotlin `@Metadata` annotations. Its API
-sits atop [kotlinx-metadata](https://github.com/JetBrains/kotlin/tree/master/libraries/kotlinx-metadata/jvm),
+`interop:kotlin-metadata` is an API for working with Kotlin `@Metadata` annotations. Its API
+sits atop [kotlin-metadata](https://github.com/JetBrains/kotlin/tree/master/libraries/kotlinx-metadata/jvm),
 offering extensions for its types + JVM metadata information. This can be used to read
 Kotlin language semantics off of `Class` or `TypeElement` `@Metadata` annotations.
 
@@ -26,7 +26,7 @@ kmClass.functions.forEach { println(it.name) }
 ### Flags
 
 There are a number of boolean flags available to types as well under `Flags.kt`. These read the
-underlying kotlinx-metadata `Flags` property.
+underlying kotlin-metadata `Flags` property.
 
 Using the Taco example above, we can glean certain information:
 
@@ -37,7 +37,7 @@ println("Is data class? ${kmClass.isData}")
 
 ### Interop with KotlinPoet
 
-`interop:kotlinx-metadata` offers an API for converting core kotlinx-metadata `Km` types to
+`interop:kotlin-metadata` offers an API for converting core kotlin-metadata `Km` types to
 KotlinPoet source representations of their APIs. This includes full type resolution, signatures,
 enclosed elements, and general stub source representations of the underlying API.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,7 +83,7 @@ nav:
   - 'API':
     - 'kotlinpoet': 1.x/kotlinpoet/index.html
     - 'interop-javapoet': 1.x/interop-javapoet/index.html
-    - 'interop-kotlinx-metadata': 1.x/interop-kotlinx-metadata/index.html
+    - 'interop-kotlin-metadata': 1.x/interop-kotlin-metadata/index.html
     - 'interop-ksp': 1.x/interop-ksp/index.html
   - 'Stack Overflow ⏏': https://stackoverflow.com/questions/tagged/kotlinpoet?sort=active
   - 'Change Log': changelog.md


### PR DESCRIPTION
- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
