### PR TITLE
Fix annotation array args with annotation elements

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,8 @@ Change Log
 
 ## Unreleased
 
+ * Fix: Annotation array parameters with annotation elements now correctly handled. (#2142)
+
 ## Version 2.2.0
 
 Thanks to [@IRus][IRus] for contributing to this release.

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -146,6 +146,7 @@ public class AnnotationSpec private constructor(
        * `%L` for other types.
        */
       internal fun memberForValue(value: Any) = when (value) {
+        is Annotation -> CodeBlock.of("%L", get(value))
         is Class<*> -> CodeBlock.of("%T::class", value)
         is Enum<*> -> CodeBlock.of("%T.%L", value.javaClass, value.name)
         is String -> CodeBlock.of("%S", value)

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/AnnotationSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/AnnotationSpecTest.kt
@@ -65,6 +65,7 @@ class AnnotationSpecTest {
     val p: Int,
     val q: AnnotationC = AnnotationC("foo"),
     val r: Array<KClass<out Number>> = [Byte::class, Short::class, Int::class, Long::class],
+    val s: Array<AnnotationC> = [AnnotationC("foo"), AnnotationC("bar")],
   )
 
   @HasDefaultsAnnotation(
@@ -76,6 +77,7 @@ class AnnotationSpecTest {
     j = AnnotationA(),
     q = AnnotationC("bar"),
     r = [Float::class, Double::class],
+    s = [AnnotationC("bar")],
   )
   inner class IsAnnotated
 
@@ -116,6 +118,7 @@ class AnnotationSpecTest {
         |  p = 1_701,
         |  q = AnnotationSpecTest.AnnotationC(value = "bar"),
         |  r = arrayOf(Float::class, Double::class),
+        |  s = arrayOf(AnnotationSpecTest.AnnotationC(value = "bar")),
         |)
         |public class Taco
         |
@@ -147,6 +150,7 @@ class AnnotationSpecTest {
         |  p = 1_701,
         |  q = AnnotationSpecTest.AnnotationC(value = "bar"),
         |  r = arrayOf(Float::class, Double::class),
+        |  s = arrayOf(AnnotationSpecTest.AnnotationC(value = "bar")),
         |)
         |public class IsAnnotated
         |
@@ -194,6 +198,7 @@ class AnnotationSpecTest {
         |  p = 1_701,
         |  q = AnnotationSpecTest.AnnotationC(value = "bar"),
         |  r = arrayOf(Float::class, Double::class),
+        |  s = arrayOf(AnnotationSpecTest.AnnotationC(value = "bar")),
         |)
         |public class Taco
         |
@@ -233,6 +238,7 @@ class AnnotationSpecTest {
         |  p = 1_701,
         |  q = AnnotationSpecTest.AnnotationC(value = "bar"),
         |  r = arrayOf(Float::class, Double::class),
+        |  s = arrayOf(AnnotationSpecTest.AnnotationC(value = "bar")),
         |)
         |public class Taco
         |


### PR DESCRIPTION
Previously, `AnnotationSpec.Builder.memberForValue()` did not correctly handle annotation instances inside annotation array parameters. For example, given:

```kotlin
annotation class AnnotationC(val value: String)
annotation class AnnotationD(
  val s: Array<AnnotationC> = [AnnotationC("foo")]
)
```

When generating code from existing annotation instances using reflection, KotlinPoet would produce the following invalid Kotlin code:

```kotlin
@AnnotationD(
  s = arrayOf(@com.example.AnnotationC("foo")),
)
public class Taco
```

With this change, annotation values in arrays are handled by delegating to `AnnotationSpec.get()`, producing valid Kotlin code. Related test functions have also been updated accordingly.


- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
