### PR TITLE
Handle recursively bound generics in KType.asTypeName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ reports
 *.iml
 classes
 
+.vscode
+
 # Mkdocs files
 docs/1.x/*
 site

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ Change Log
 ## Unreleased
 
  * Fix: Annotation array parameters with annotation elements now correctly handled. (#2142)
+ * Fix: `KType.asTypeName` now correctly handles recursively bound generics (e.g. `T : Comparable<T>`). (#1914)
  * In-development snapshots are now published to the Central Portal Snapshots repository at https://central.sonatype.com/repository/maven-snapshots/.
  * New: Add NameAllocator.contains to check if a given tag is already allocated (#2154)
 


### PR DESCRIPTION
Fixes #1914.

- [x] `docs/changelog.md` has been updated if applicable.
