### PR TITLE
Don't convert multi-statement function to expression body

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ Change Log
 
  * Fix: Annotation array parameters with annotation elements now correctly handled. (#2142)
  * Fix: `KType.asTypeName` now correctly handles recursively bound generics (e.g. `T : Comparable<T>`). (#1914)
+ * Fix: Don't convert multi-statement function to expression body. (#1979)
  * In-development snapshots are now published to the Central Portal Snapshots repository at https://central.sonatype.com/repository/maven-snapshots/.
  * New: Add NameAllocator.contains to check if a given tag is already allocated (#2154)
 

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlock.kt
@@ -154,6 +154,21 @@ public class CodeBlock private constructor(
 
   internal fun hasStatements() = formatParts.any { "«" in it }
 
+  internal fun hasUnmatchedClosingStatement(): Boolean {
+    var openCount = 0
+    for (formatPart in formatParts) {
+      if (formatPart == "«") {
+        openCount++
+      } else if (formatPart == "»") {
+        if (openCount == 0) {
+          return true
+        }
+        openCount--
+      }
+    }
+    return false
+  }
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null) return false

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
@@ -241,6 +241,12 @@ public class FunSpec private constructor(
 
   private fun CodeBlock.asExpressionBody(): CodeBlock? {
     val codeBlock = this.trim()
+
+    // If after trimming there are unmatched closing statement symbols, we can't have an expression body.
+    if (codeBlock.hasUnmatchedClosingStatement()) {
+      return null
+    }
+
     val asReturnExpressionBody = codeBlock.withoutPrefix(RETURN_EXPRESSION_BODY_PREFIX_SPACE)
       ?: codeBlock.withoutPrefix(RETURN_EXPRESSION_BODY_PREFIX_NBSP)
     if (asReturnExpressionBody != null) {

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -1438,4 +1438,23 @@ class FunSpecTest {
       """.trimMargin(),
     )
   }
+
+  // https://github.com/square/kotlinpoet/issues/1979
+  @Test fun returnExpressionMultipleStatements() {
+    val spec = FunSpec.builder("three")
+      .returns(INT)
+      .addStatement("return 1")
+      .addStatement(".plus(2)")
+      .build()
+
+    assertThat(spec.toString()).isEqualTo(
+      """
+      |public fun three(): kotlin.Int {
+      |  return 1
+      |  .plus(2)
+      |}
+      |
+      """.trimMargin(),
+    )
+  }
 }


### PR DESCRIPTION
Fixes #1979.

- [x] `docs/changelog.md` has been updated if applicable.
