### PR TITLE
feat: Add support for defining nested type aliases

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@ Change Log
 
 ## Unreleased
 
+ * New: Add support for type aliases in types. (#PR_NUMBER)
  * Fix: Annotation array parameters with annotation elements now correctly handled. (#2142)
  * Fix: `KType.asTypeName` now correctly handles recursively bound generics (e.g. `T : Comparable<T>`). (#1914)
  * Fix: Don't convert multi-statement function to expression body. (#1979)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,7 @@ Change Log
 
 ## Unreleased
 
- * New: Add support for type aliases in types. (#PR_NUMBER)
+ * New: Add support for type aliases in types.
  * Fix: Annotation array parameters with annotation elements now correctly handled. (#2142)
  * Fix: `KType.asTypeName` now correctly handles recursively bound generics (e.g. `T : Comparable<T>`). (#1914)
  * Fix: Don't convert multi-statement function to expression body. (#1979)

--- a/docs/type-aliases.md
+++ b/docs/type-aliases.md
@@ -47,3 +47,26 @@ typealias FileTable<K> = Map<K, Set<File>>
 
 typealias Predicate<T> = (T) -> Boolean
 ```
+
+Type aliases can also be added to types (classes, interfaces, objects) as well:
+
+> Note: Nested type aliases are a beta feature in Kotlin. See the official documentation
+> [here](https://kotlinlang.org/docs/type-aliases.html#nested-type-aliases) for more details.
+
+```kotlin
+val taco = TypeSpec.classBuilder("Taco")
+  .addTypeAlias(TypeAliasSpec.builder("Topping", String::class).build())
+  .build()
+```
+
+Which generates the following:
+
+```kotlin
+package com.squareup.tacos
+
+import kotlin.String
+
+public class Taco {
+  public typealias Topping = String
+}
+```

--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -1011,6 +1011,7 @@ public final class com/squareup/kotlinpoet/TypeSpec : com/squareup/kotlinpoet/An
 	public final fun getSuperclassConstructorParameters ()Ljava/util/List;
 	public final fun getSuperinterfaces ()Ljava/util/Map;
 	public fun getTags ()Ljava/util/Map;
+	public final fun getTypeAliasSpecs ()Ljava/util/List;
 	public fun getTypeSpecs ()Ljava/util/List;
 	public final fun getTypeVariables ()Ljava/util/List;
 	public fun hashCode ()I
@@ -1087,6 +1088,7 @@ public final class com/squareup/kotlinpoet/TypeSpec$Builder : com/squareup/kotli
 	public final fun addSuperinterfaces (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/TypeSpec$Builder;
 	public fun addType (Lcom/squareup/kotlinpoet/TypeSpec;)Lcom/squareup/kotlinpoet/TypeSpec$Builder;
 	public synthetic fun addType (Lcom/squareup/kotlinpoet/TypeSpec;)Lcom/squareup/kotlinpoet/TypeSpecHolder$Builder;
+	public final fun addTypeAlias (Lcom/squareup/kotlinpoet/TypeAliasSpec;)Lcom/squareup/kotlinpoet/TypeSpec$Builder;
 	public final fun addTypeVariable (Lcom/squareup/kotlinpoet/TypeVariableName;)Lcom/squareup/kotlinpoet/TypeSpec$Builder;
 	public final fun addTypeVariables (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/TypeSpec$Builder;
 	public fun addTypes (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/TypeSpec$Builder;
@@ -1105,6 +1107,7 @@ public final class com/squareup/kotlinpoet/TypeSpec$Builder : com/squareup/kotli
 	public final fun getSuperclassConstructorParameters ()Ljava/util/List;
 	public final fun getSuperinterfaces ()Ljava/util/Map;
 	public fun getTags ()Ljava/util/Map;
+	public final fun getTypeAliasSpecs ()Ljava/util/List;
 	public final fun getTypeSpecs ()Ljava/util/List;
 	public final fun getTypeVariables ()Ljava/util/List;
 	public final fun primaryConstructor (Lcom/squareup/kotlinpoet/FunSpec;)Lcom/squareup/kotlinpoet/TypeSpec$Builder;

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/TypeSpec.kt
@@ -80,6 +80,7 @@ public class TypeSpec private constructor(
   public val initializerIndex: Int = builder.initializerIndex
   override val funSpecs: List<FunSpec> = builder.funSpecs.toImmutableList()
   public override val typeSpecs: List<TypeSpec> = builder.typeSpecs.toImmutableList()
+  public val typeAliasSpecs: List<TypeAliasSpec> = builder.typeAliasSpecs.toImmutableList()
   internal val nestedTypesSimpleNames = typeSpecs.map { it.name }.toImmutableSet()
 
   @Deprecated("Use annotations property", ReplaceWith("annotations"), ERROR)
@@ -98,6 +99,7 @@ public class TypeSpec private constructor(
     builder.propertySpecs += propertySpecs
     builder.funSpecs += funSpecs
     builder.typeSpecs += typeSpecs
+    builder.typeAliasSpecs += typeAliasSpecs
     builder.initializerBlock.add(initializerBlock)
     builder.initializerIndex = initializerIndex
     builder.superinterfaces.putAll(superinterfaces)
@@ -328,6 +330,12 @@ public class TypeSpec private constructor(
         firstMember = false
       }
 
+      for (typeAliasSpec in typeAliasSpecs) {
+        if (!firstMember) codeWriter.emit("\n")
+        typeAliasSpec.emit(codeWriter)
+        firstMember = false
+      }
+
       codeWriter.unindent()
       codeWriter.popType()
 
@@ -418,7 +426,8 @@ public class TypeSpec private constructor(
         initializerBlock.isEmpty() &&
         (primaryConstructor?.body?.isEmpty() ?: true) &&
         funSpecs.isEmpty() &&
-        typeSpecs.isEmpty()
+        typeSpecs.isEmpty() &&
+        typeAliasSpecs.isEmpty()
     }
 
   override fun equals(other: Any?): Boolean {
@@ -509,6 +518,7 @@ public class TypeSpec private constructor(
     public val propertySpecs: MutableList<PropertySpec> = mutableListOf()
     public val funSpecs: MutableList<FunSpec> = mutableListOf()
     public val typeSpecs: MutableList<TypeSpec> = mutableListOf()
+    public val typeAliasSpecs: MutableList<TypeAliasSpec> = mutableListOf()
 
     @Deprecated("Use annotations property", ReplaceWith("annotations"), ERROR)
     public val annotationSpecs: MutableList<AnnotationSpec> get() = annotations
@@ -704,6 +714,10 @@ public class TypeSpec private constructor(
 
     override fun addType(typeSpec: TypeSpec): Builder = apply {
       typeSpecs += typeSpec
+    }
+
+    public fun addTypeAlias(typeAliasSpec: TypeAliasSpec): Builder = apply {
+      typeAliasSpecs += typeAliasSpec
     }
 
     @ExperimentalKotlinPoetApi

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/TypeSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/TypeSpecTest.kt
@@ -4834,6 +4834,17 @@ class TypeSpecTest {
     assertThat(builder.build().typeSpecs).containsExactly(seasoning)
   }
 
+  @Test fun modifyTypeAliases() {
+    val builder = TypeSpec.classBuilder("Taco")
+      .addTypeAlias(TypeAliasSpec.builder("Topping", String::class.asTypeName()).build())
+
+    val seasoning = TypeAliasSpec.builder("Seasoning", String::class.asTypeName()).build()
+    builder.typeAliasSpecs.clear()
+    builder.typeAliasSpecs.add(seasoning)
+
+    assertThat(builder.build().typeAliasSpecs).containsExactly(seasoning)
+  }
+
   @Test fun modifySuperinterfaces() {
     val builder = TypeSpec.classBuilder("Taco")
       .addSuperinterface(List::class)
@@ -5997,6 +6008,24 @@ class TypeSpecTest {
         )
         .build()
     }.hasMessageThat().isEqualTo("primary constructor can't delegate to other constructors")
+  }
+
+  @Test fun addTypeAlias() {
+    val typeSpec = TypeSpec.classBuilder("Taco")
+      .addTypeAlias(TypeAliasSpec.builder("Topping", String::class).build())
+      .build()
+    assertThat(toString(typeSpec)).isEqualTo(
+      """
+        |package com.squareup.tacos
+        |
+        |import kotlin.String
+        |
+        |public class Taco {
+        |  public typealias Topping = String
+        |}
+        |
+      """.trimMargin(),
+    )
   }
 
   companion object {


### PR DESCRIPTION
- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.

This change introduces the ability to add [nested type alias declarations](https://kotlinlang.org/docs/type-aliases.html#nested-type-aliases).

Example:

```kotlin
// generator
val typeSpec = TypeSpec.classBuilder("Taco")
  .addTypeAlias(TypeAliasSpec.builder("Topping", String::class).build())
  .build()
```

```kotlin
// output
package com.squareup.tacos

import kotlin.String

public class Taco {
  public typealias Topping = String
}
```