### PR TITLE
Opt-in to Wasm-JS interop

### DIFF
--- a/kotlinpoet/build.gradle.kts
+++ b/kotlinpoet/build.gradle.kts
@@ -97,6 +97,9 @@ kotlin {
       dependsOn(nonJvmMain)
     }
     wasmJsMain {
+      languageSettings {
+        optIn("kotlin.js.ExperimentalWasmJsInterop")
+      }
       dependsOn(nonJvmMain)
     }
   }


### PR DESCRIPTION
In Kotlin 2.2.20 some of the functions we use become opt-in for this.