### PR TITLE
Fix FunSpec.beginControlFlow to accept nullable args

### DIFF
--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
@@ -543,7 +543,7 @@ public class FunSpec private constructor(
      * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
      * * Shouldn't contain braces or newline characters.
      */
-    public fun beginControlFlow(controlFlow: String, vararg args: Any): Builder = apply {
+    public fun beginControlFlow(controlFlow: String, vararg args: Any?): Builder = apply {
       body.beginControlFlow(controlFlow, *args)
     }
 

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -1053,6 +1053,23 @@ class FunSpecTest {
     assertThat(funSpec.toBuilder().build()).isEqualTo(funSpec)
   }
 
+  @Test fun beginControlFlowWithNullArgs() {
+    val funSpec = FunSpec.builder("f")
+      .beginControlFlow("foo(%S)", null)
+      .endControlFlow()
+      .build()
+
+    assertThat(funSpec.toString()).isEqualTo(
+      """
+      |public fun f() {
+      |  foo(null) {
+      |  }
+      |}
+      |
+      """.trimMargin(),
+    )
+  }
+
   @Test fun receiverWithKdoc() {
     val funSpec = FunSpec.builder("toBar")
       .receiver(String::class, kdoc = "the string to transform.")


### PR DESCRIPTION
Fixes #2174: https://github.com/square/kotlinpoet/issues/2174
This PR fixes the inconsistency between `FunSpec.beginControlFlow` and `CodeBlock.beginControlFlow` by changing the parameter type from `vararg args: Any` to `vararg args: Any?`.

**Changes:**
- Updated `FunSpec.beginControlFlow` to accept nullable arguments
- Added test case to verify null arguments work correctly

The fix makes the APIs consistent and allows passing null values as documented in the original issue.

- [ ] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [ ] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
