### PR TITLE
Add -Xjdk-release=8 compiler flag to ensure Java 8 compatibility

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,6 @@ Change Log
 
 ## Unreleased
 
- * Fix: Add -Xjdk-release=8 compiler flag to ensure Java 8 API compatibility. (#2152)
  * Fix: FunSpec.beginControlFlow to accept nullable arguments for consistency with CodeBlock.beginControlFlow. (#2174)
  * New: Add support for type aliases in types.
  * Fix: Annotation array parameters with annotation elements now correctly handled. (#2142)


### PR DESCRIPTION
Fixes #2152

Adds the `-Xjdk-release=8` compiler flag to ensure the Kotlin compiler only uses APIs available in Java 8, providing true Java 8 compatibility.

- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
