### PR TITLE
fix-variance-for-function-output-types

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@ Change Log
 
 ## Unreleased
 
+ * Fix: Support variance emission for TypeVariableName in parameterized types. (#1933)
  * Fix: FunSpec.beginControlFlow to accept nullable arguments for consistency with CodeBlock.beginControlFlow. (#2174)
  * New: Add support for type aliases in types.
  * Fix: Annotation array parameters with annotation elements now correctly handled. (#2142)

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/ParameterizedTypeName.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/ParameterizedTypeName.kt
@@ -83,11 +83,25 @@ public class ParameterizedTypeName internal constructor(
       rawType.emitAnnotations(out)
       rawType.emit(out)
     }
+
     if (typeArguments.isNotEmpty()) {
       out.emit("<")
       typeArguments.forEachIndexed { index, parameter ->
         if (index > 0) out.emit(", ")
         parameter.emitAnnotations(out)
+
+        if (parameter is TypeVariableName && parameter.variance != null) {
+          val shouldEmitVariance = System.getProperty("kotlinpoet.emit.variance", "false").toBoolean()
+
+          if (shouldEmitVariance) {
+            when (parameter.variance) {
+              KModifier.OUT -> out.emit("out ")
+              KModifier.IN -> out.emit("in ")
+              else -> Unit
+            }
+          }
+        }
+
         parameter.emit(out)
         parameter.emitNullable(out)
       }

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -569,6 +569,77 @@ class KotlinPoetTest {
     assertThat(list.toString()).isEqualTo("kotlin.collections.List<kotlin.Int?>?")
   }
 
+  @Test
+  fun typeVariableWithOutVariance() {
+    System.setProperty("kotlinpoet.emit.variance", "true")
+
+    try {
+      val funspec = FunSpec.builder("foo")
+        .addTypeVariable(TypeVariableName("T"))
+        .returns(
+          ClassName.bestGuess("kotlin.Array")
+            .parameterizedBy(TypeVariableName("T", variance = KModifier.OUT)),
+        )
+        .addStatement("TODO()")
+        .build()
+
+      val result = FileSpec.builder("foo.bar", "Baz")
+        .addFunction(funspec)
+        .build()
+        .toString()
+
+      assertThat(result).contains("Array<out T>")
+    } finally {
+      System.clearProperty("kotlinpoet.emit.variance")
+    }
+  }
+
+  @Test
+  fun typeVariableWithInVariance() {
+    System.setProperty("kotlinpoet.emit.variance", "true")
+
+    try {
+      val funspec = FunSpec.builder("foo")
+        .addTypeVariable(TypeVariableName("T"))
+        .returns(
+          ClassName.bestGuess("kotlin.Array")
+            .parameterizedBy(TypeVariableName("T", variance = KModifier.IN)),
+        )
+        .addStatement("TODO()")
+        .build()
+
+      val result = FileSpec.builder("foo.bar", "Baz")
+        .addFunction(funspec)
+        .build()
+        .toString()
+
+      assertThat(result).contains("Array<in T>")
+    } finally {
+      System.clearProperty("kotlinpoet.emit.variance")
+    }
+  }
+
+  @Test
+  fun typeVariableWithoutVariance() {
+    val funspec = FunSpec.builder("foo")
+      .addTypeVariable(TypeVariableName("T"))
+      .returns(
+        ClassName.bestGuess("kotlin.Array")
+          .parameterizedBy(TypeVariableName("T")),
+      )
+      .addStatement("TODO()")
+      .build()
+
+    val result = FileSpec.builder("foo.bar", "Baz")
+      .addFunction(funspec)
+      .build()
+      .toString()
+
+    assertThat(result).contains("Array<T>")
+    assertThat(result).doesNotContain("Array<out T>")
+    assertThat(result).doesNotContain("Array<in T>")
+  }
+
   @Test fun getAndSet() {
     val source = FileSpec.builder(tacosPackage, "Taco")
       .addProperty(


### PR DESCRIPTION
Issue: https://github.com/square/kotlinpoet/issues/1933
- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
