### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle-wrapper.yaml
+++ b/.github/workflows/gradle-wrapper.yaml
@@ -7,6 +7,8 @@ on:
       - 'gradlew.bat'
       - 'gradle/wrapper/**'
 
+permissions:
+  contents: read
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/square/kotlinpoet/security/code-scanning/7](https://github.com/square/kotlinpoet/security/code-scanning/7)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. In this case, since the workflow only checks out code and runs a build, it only needs read access to repository contents. The best way to do this is to add a `permissions` block at the top level of the workflow (before `jobs:`), setting `contents: read`. This will apply the restriction to all jobs in the workflow unless overridden. No additional imports or definitions are needed; just a single YAML block addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
