### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/square/kotlinpoet/security/code-scanning/6](https://github.com/square/kotlinpoet/security/code-scanning/6)

To fix the problem, you should add a `permissions` block to the workflow to explicitly limit the permissions granted to the GITHUB_TOKEN. The best way to do this is to add the block at the workflow root level (before the `jobs:` key), which will apply to all jobs unless overridden. For this workflow, the jobs only need to read repository contents (for checkout and build), so the minimal required permission is `contents: read`. You should add the following block after the workflow `name` and before the `on:` key:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
