### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/square/kotlinpoet/security/code-scanning/5](https://github.com/square/kotlinpoet/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the jobs in this workflow do not appear to require any write access (they only build, check, and generate docs), the minimal permission of `contents: read` is appropriate. This can be set at the top level of the workflow (applies to all jobs), or at the job level if different jobs require different permissions. The best way is to add the following block after the `name:` and before `on:`:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
