### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: write
 name: Release
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/square/kotlinpoet/security/code-scanning/4](https://github.com/square/kotlinpoet/security/code-scanning/4)

To fix the problem, we should add a `permissions` block to the workflow, either at the root level (applies to all jobs) or at the job level (applies only to the specific job). The permissions should be set to the minimum required for the workflow to function. Since the workflow deploys to GitHub Pages, it needs `contents: write` permission. If it also interacts with other resources (e.g., issues, pull requests), those permissions should be added as needed, but from the provided snippet, only `contents: write` is required. The best fix is to add the following block at the root level, just after the `name:` and before `on:`:

```yaml
permissions:
  contents: write
```

This ensures the workflow only has write access to repository contents, which is needed for deployment, and no other unnecessary permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
