### PR TITLE
Don't look for illegal characters in escaped identifiers

### DIFF
--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Util.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Util.kt
@@ -274,7 +274,9 @@ internal val String.allCharactersAreUnderscore get() = this.all { it == UNDERSCO
 private val ILLEGAL_CHARACTERS_TO_ESCAPE = setOf('.', ';', '[', ']', '/', '<', '>', ':', '\\')
 
 private fun String.failIfEscapeInvalid() {
-  require(!any { it in ILLEGAL_CHARACTERS_TO_ESCAPE }) {
+  // Don't check for illegal characters in escaped identifiers, even though escaping doesn't always
+  // make an invalid identifier valid.
+  require(alreadyEscaped() || none { it in ILLEGAL_CHARACTERS_TO_ESCAPE }) {
     "Can't escape identifier $this because it contains illegal characters: " +
       ILLEGAL_CHARACTERS_TO_ESCAPE.intersect(this.toSet()).joinToString("")
   }

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -1169,7 +1169,7 @@ class KotlinPoetTest {
   }
 
   // https://github.com/square/kotlinpoet/issues/2203
-  @Test fun allowIllegalCharactersInEscapedIdentifiers() {
+  @Test fun allowIllegalCharactersInAutoEscapedIdentifiers() {
     val enum = TypeSpec.enumBuilder("MyEnum")
       // Dots are illegal, but the identifier will be escaped, so this shouldn't fail.
       .addEnumConstant("with.dots")
@@ -1187,6 +1187,30 @@ class KotlinPoetTest {
     val type = TypeSpec.classBuilder("Foo.Bar")
       .build()
     // Even with escaping, this is invalid Kotlin code, but our checks here are lenient.
+    assertThat(type.toString()).isEqualTo(
+      """
+      public class `Foo.Bar`
+
+      """.trimIndent(),
+    )
+  }
+
+  // https://github.com/square/kotlinpoet/issues/2203
+  @Test fun allowIllegalCharactersInManuallyEscapedIdentifiers() {
+    val enum = TypeSpec.enumBuilder("MyEnum")
+      .addEnumConstant("`with.dots`")
+      .build()
+    assertThat(enum.toString()).isEqualTo(
+      """
+      public enum class MyEnum {
+        `with.dots`,
+      }
+
+      """.trimIndent(),
+    )
+
+    val type = TypeSpec.classBuilder("`Foo.Bar`")
+      .build()
     assertThat(type.toString()).isEqualTo(
       """
       public class `Foo.Bar`

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -1168,13 +1168,31 @@ class KotlinPoetTest {
     )
   }
 
-  // https://github.com/square/kotlinpoet/issues/701
-  @Test fun noIllegalCharacterInIdentifier() {
-    assertThrows<IllegalArgumentException> {
-      TypeSpec.enumBuilder("MyEnum")
-        .addEnumConstant("with.dots") // dots are illegal, so this should fail
-        .build().toString()
-    }.hasMessageThat().isEqualTo("Can't escape identifier `with.dots` because it contains illegal characters: .")
+  // https://github.com/square/kotlinpoet/issues/2203
+  @Test fun allowIllegalCharactersInEscapedIdentifiers() {
+    val enum = TypeSpec.enumBuilder("MyEnum")
+      // Dots are illegal, but the identifier will be escaped, so this shouldn't fail.
+      .addEnumConstant("with.dots")
+      .build()
+    // This is valid Kotlin code.
+    assertThat(enum.toString()).isEqualTo(
+      """
+      public enum class MyEnum {
+        `with.dots`,
+      }
+
+      """.trimIndent(),
+    )
+
+    val type = TypeSpec.classBuilder("Foo.Bar")
+      .build()
+    // Even with escaping, this is invalid Kotlin code, but our checks here are lenient.
+    assertThat(type.toString()).isEqualTo(
+      """
+      public class `Foo.Bar`
+
+      """.trimIndent(),
+    )
   }
 
   // https://github.com/square/kotlinpoet/issues/814


### PR DESCRIPTION
There are cases when escaping an illegal identifier does not make
it legal, e.g.:

```kotlin
class `My.Class` // Doesn't compile
```

But in many cases escaping an identifier does make it legal:

```kotlin
enum class MyEnum {
  `Foo.Bar` // Compiles
}
```

Since KotlinPoet is not a compiler, we don't want to over-police
illegal identifier checks, so we'll assume every escaped
identifier is valid, that way we don't block correctly escaped
identifiers.

Fixes #2203