### PR TITLE
Update current latest JDK for test tasks to 24

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,7 +122,7 @@ subprojects {
     fun Project.setupCheckTask(testTaskName: String) {
       // Copied from https://github.com/square/retrofit/blob/master/retrofit/build.gradle#L28.
       // Create a test task for each supported JDK. We check every "LTS" + current version.
-      val versionsToTest = listOf(8, 11, 17, 21, 23)
+      val versionsToTest = listOf(8, 11, 17, 21, 24)
       for (majorVersion in versionsToTest) {
         val jdkTest = tasks.register<Test>("testJdk$majorVersion") {
           val javaToolchains = project.extensions.getByType(JavaToolchainService::class)


### PR DESCRIPTION
Seems that Foojay API and the whole toolchain resolution pipeline have been having issues recently, trying to bump latest JDK version we test against to try to work around.