### PR TITLE
emitNullable correctly when deferring type in CodeWriter

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@ Change Log
  * New: Add support for type aliases in types.
  * New: Add `FileSpec.addImport(MemberName)` to explicitly import a member (#2198)
  * New: Add `NameAllocator.contains` to check if a given tag is already allocated (#2154)
+ * Fix: `emitNullable` correctly when deferring type in `CodeWriter`. (#2216)
  * Fix: `FunSpec.beginControlFlow` to accept nullable arguments for consistency with `CodeBlock.beginControlFlow`. (#2174)
  * Fix: Annotation array parameters with annotation elements now correctly handled. (#2142)
  * Fix: `KType.asTypeName` now correctly handles recursively bound generics (e.g. `T : Comparable<T>`). (#1914)

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeWriter.kt
@@ -336,8 +336,10 @@ internal class CodeWriter(
               }
             }
           }
-          if (!defer) typeName.emit(this)
-          typeName.emitNullable(this)
+          if (!defer) {
+            typeName.emit(this)
+            typeName.emitNullable(this)
+          }
         }
 
         "%M" -> {
@@ -395,6 +397,7 @@ internal class CodeWriter(
             }
             if (!doBreak) {
               deferredTypeName!!.emit(this)
+              deferredTypeName.emitNullable(this)
               deferredTypeName = null
             }
           }


### PR DESCRIPTION
Fixes #2216.

- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.