### PR TITLE
Switch to `-jvm-default` flag

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ subprojects {
   tasks.withType<KotlinCompile> {
     compilerOptions {
       jvmTarget = JvmTarget.JVM_1_8
-      freeCompilerArgs.add("-Xjvm-default=all")
+      freeCompilerArgs.add("-jvm-default=no-compatibility")
       freeCompilerArgs.add("-Xjdk-release=8")
     }
   }

--- a/interop/kotlin-metadata/build.gradle.kts
+++ b/interop/kotlin-metadata/build.gradle.kts
@@ -25,7 +25,6 @@ tasks.jar {
 
 tasks.compileTestKotlin {
   compilerOptions {
-    freeCompilerArgs.addAll("-Xjvm-default=all")
     optIn.add("org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi")
   }
 }

--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -1247,8 +1247,8 @@ public final class com/squareup/kotlinpoet/WildcardTypeNames {
 }
 
 public final class com/squareup/kotlinpoet/jvm/JvmAnnotations {
-	public static final fun jvmDefault (Lcom/squareup/kotlinpoet/FunSpec$Builder;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
-	public static final fun jvmDefault (Lcom/squareup/kotlinpoet/PropertySpec$Builder;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
+	public static final synthetic fun jvmDefault (Lcom/squareup/kotlinpoet/FunSpec$Builder;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
+	public static final synthetic fun jvmDefault (Lcom/squareup/kotlinpoet/PropertySpec$Builder;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
 	public static final fun jvmField (Lcom/squareup/kotlinpoet/PropertySpec$Builder;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
 	public static final fun jvmInline (Lcom/squareup/kotlinpoet/TypeSpec$Builder;)Lcom/squareup/kotlinpoet/TypeSpec$Builder;
 	public static final fun jvmMultifileClass (Lcom/squareup/kotlinpoet/FileSpec$Builder;)Lcom/squareup/kotlinpoet/FileSpec$Builder;

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/jvm/JvmAnnotations.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/jvm/JvmAnnotations.kt
@@ -28,6 +28,7 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asTypeName
 import java.lang.reflect.Type
+import kotlin.DeprecationLevel.HIDDEN
 import kotlin.reflect.KClass
 
 public fun FileSpec.Builder.jvmName(name: String): FileSpec.Builder = addAnnotation(
@@ -126,19 +127,9 @@ public fun TypeName.jvmWildcard(): TypeName =
   copy(annotations = this.annotations + AnnotationSpec.builder(JvmWildcard::class).build())
 
 @Suppress("DEPRECATION")
-@Deprecated(
-  """
-  'JvmDefault' is deprecated. Switch to new -Xjvm-default modes: `all` or `all-compatibility`.
-  In KotlinPoet 1.15.0 and newer, this method is a no-op. It will be deleted in KotlinPoet 2.0.
-""",
-)
+@Deprecated("", level = HIDDEN)
 public fun PropertySpec.Builder.jvmDefault(): PropertySpec.Builder = this
 
 @Suppress("DEPRECATION")
-@Deprecated(
-  """
-  'JvmDefault' is deprecated. Switch to new -Xjvm-default modes: `all` or `all-compatibility`.
-  In KotlinPoet 1.15.0 and newer, this method is a no-op. It will be deleted in KotlinPoet 2.0.
-""",
-)
+@Deprecated("", level = HIDDEN)
 public fun FunSpec.Builder.jvmDefault(): FunSpec.Builder = this


### PR DESCRIPTION
`-Xjvm-default` is deprecated in Kotlin 2.3.0.

Also hide no-op functions related to JVM default annotation generation.