### PR TITLE
Suppress Java class warning

### DIFF
--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -34,6 +34,7 @@ import java.util.function.Function
 import kotlin.test.Ignore
 import kotlin.test.Test
 
+@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN") // Explicitly testing Java classes.
 class FileSpecTest {
   @Test fun importStaticReadmeExample() {
     val hoverboard = ClassName("com.mattel", "Hoverboard")

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/ParameterizedTypeNameTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/ParameterizedTypeNameTest.kt
@@ -33,6 +33,7 @@ import kotlin.reflect.full.createType
 import kotlin.reflect.jvm.kotlinFunction
 import org.junit.Test
 
+@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN") // Explicitly testing Java classes.
 class ParameterizedTypeNameTest {
   @Test fun classNamePlusParameter() {
     val typeName = ClassName("kotlin.collections", "List")


### PR DESCRIPTION
This becomes a proper warning in Kotlin 2.3.0, and we fail the build on warnings.