### PR TITLE
Update release date of 2.3.0 in changelog.md

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@ Change Log
 Thanks to [@haruue][haruue], [@hfhbd][hfhbd], [@yz4230][yz4230], [@mina-jaff][mina-jaff], [@BoD][BoD],
 [@RaoPrashanth][RaoPrashanth] for contributing to this release.
 
-_2026-05-27_
+_2026-03-27_
 
  * New: Kotlin 2.3.20.
  * New: KSP 2.3.6.


### PR DESCRIPTION
- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
