### PR TITLE
Keep // prefix on wrapped file comment lines

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,8 @@ Change Log
 
 ## Unreleased
 
+ * Fix: Keep the `//` prefix on wrapped file comment lines. (#1922)
+
 ## Version 2.3.0
 
 Thanks to [@haruue][haruue], [@hfhbd][hfhbd], [@yz4230][yz4230], [@mina-jaff][mina-jaff], [@BoD][BoD],

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeWriter.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeWriter.kt
@@ -644,8 +644,8 @@ internal class CodeWriter(
       } else {
         out.append(
           line,
-          indentLevel = if (kdoc) indentLevel else indentLevel + 2,
-          linePrefix = if (kdoc) " * " else "",
+          indentLevel = if (kdoc || comment) indentLevel else indentLevel + 2,
+          linePrefix = if (kdoc) " * " else if (comment) "// " else "",
         )
       }
       trailingNewline = false

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/LineWrappingTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/LineWrappingTest.kt
@@ -261,6 +261,26 @@ class LineWrappingTest {
       )
   }
 
+  @Test
+  fun fileCommentKeepsPrefixOnWrappedLines() {
+    val fileSpec =
+      FileSpec.builder("com.squareup.tacos", "Taco.kt")
+        .addFileComment(
+          "This is a really long line of text that will♢have to be wrapped when it is♢used in a comment because it is so long"
+        )
+        .build()
+    assertThat(fileSpec.toString())
+      .isEqualTo(
+        """
+        |// This is a really long line of text that will have to be wrapped when it is
+        |// used in a comment because it is so long
+        |package com.squareup.tacos
+        |
+        |"""
+          .trimMargin()
+      )
+  }
+
   private fun toString(typeSpec: TypeSpec): String {
     return FileSpec.get("com.squareup.tacos", typeSpec).toString()
   }


### PR DESCRIPTION
When a file comment added with `addFileComment` is long enough to wrap, the wrapped continuation lines kept their indentation but dropped the `//` prefix, so the wrapped text stopped being a valid comment. The wrapping path in `CodeWriter` already keeps the KDoc star prefix but passed an empty prefix for comments. Comments now get the same handling.

Fixes #1922.

- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
