### PR TITLE
Handle recursively bound generics in TypeVariableName equals/hashCode

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ Change Log
 
  * New: Support for explicit backing fields. (#2325)
  * Fix: Keep the `//` prefix on wrapped file comment lines. (#1922)
+ * Fix: `TypeVariableName.equals`/`hashCode` no longer overflow on recursively bound generics like `Enum<E : Enum<E>>`. (#1737)
 
 ## Version 2.3.0
 

--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -85,7 +85,6 @@ public final class com/squareup/kotlinpoet/ClassName : com/squareup/kotlinpoet/T
 	public fun copy (ZLjava/util/List;Ljava/util/Map;)Lcom/squareup/kotlinpoet/ClassName;
 	public synthetic fun copy (ZLjava/util/List;Ljava/util/Map;)Lcom/squareup/kotlinpoet/TypeName;
 	public final fun enclosingClassName ()Lcom/squareup/kotlinpoet/ClassName;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCanonicalName ()Ljava/lang/String;
 	public final fun getPackageName ()Ljava/lang/String;
 	public final fun getSimpleName ()Ljava/lang/String;
@@ -526,7 +525,6 @@ public final class com/squareup/kotlinpoet/LambdaTypeName : com/squareup/kotlinp
 	public synthetic fun copy (ZLjava/util/List;Ljava/util/Map;)Lcom/squareup/kotlinpoet/TypeName;
 	public final fun copy (ZLjava/util/List;ZLjava/util/Map;)Lcom/squareup/kotlinpoet/LambdaTypeName;
 	public static synthetic fun copy$default (Lcom/squareup/kotlinpoet/LambdaTypeName;ZLjava/util/List;ZLjava/util/Map;ILjava/lang/Object;)Lcom/squareup/kotlinpoet/LambdaTypeName;
-	public fun equals (Ljava/lang/Object;)Z
 	public static final fun get (Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Lcom/squareup/kotlinpoet/TypeName;)Lcom/squareup/kotlinpoet/LambdaTypeName;
 	public static final fun get (Lcom/squareup/kotlinpoet/TypeName;[Lcom/squareup/kotlinpoet/ParameterSpec;Lcom/squareup/kotlinpoet/TypeName;)Lcom/squareup/kotlinpoet/LambdaTypeName;
 	public static final fun get (Lcom/squareup/kotlinpoet/TypeName;[Lcom/squareup/kotlinpoet/TypeName;Lcom/squareup/kotlinpoet/TypeName;)Lcom/squareup/kotlinpoet/LambdaTypeName;
@@ -702,7 +700,6 @@ public final class com/squareup/kotlinpoet/ParameterizedTypeName : com/squareup/
 	public synthetic fun copy (ZLjava/util/List;Ljava/util/Map;)Lcom/squareup/kotlinpoet/TypeName;
 	public final fun copy (ZLjava/util/List;Ljava/util/Map;Ljava/util/List;)Lcom/squareup/kotlinpoet/ParameterizedTypeName;
 	public static synthetic fun copy$default (Lcom/squareup/kotlinpoet/ParameterizedTypeName;ZLjava/util/List;Ljava/util/Map;Ljava/util/List;ILjava/lang/Object;)Lcom/squareup/kotlinpoet/ParameterizedTypeName;
-	public fun equals (Ljava/lang/Object;)Z
 	public static final fun get (Lcom/squareup/kotlinpoet/ClassName;Lcom/squareup/kotlinpoet/TypeName;)Lcom/squareup/kotlinpoet/ParameterizedTypeName;
 	public static final fun get (Lcom/squareup/kotlinpoet/ClassName;Ljava/util/List;)Lcom/squareup/kotlinpoet/ParameterizedTypeName;
 	public static final fun get (Lcom/squareup/kotlinpoet/ClassName;[Lcom/squareup/kotlinpoet/TypeName;)Lcom/squareup/kotlinpoet/ParameterizedTypeName;
@@ -913,7 +910,7 @@ public abstract class com/squareup/kotlinpoet/TypeName : com/squareup/kotlinpoet
 	public abstract fun copy (ZLjava/util/List;Ljava/util/Map;)Lcom/squareup/kotlinpoet/TypeName;
 	public static synthetic fun copy$default (Lcom/squareup/kotlinpoet/TypeName;ZLjava/util/List;ILjava/lang/Object;)Lcom/squareup/kotlinpoet/TypeName;
 	public static synthetic fun copy$default (Lcom/squareup/kotlinpoet/TypeName;ZLjava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/squareup/kotlinpoet/TypeName;
-	public fun equals (Ljava/lang/Object;)Z
+	public final fun equals (Ljava/lang/Object;)Z
 	public fun getAnnotations ()Ljava/util/List;
 	public fun getTags ()Ljava/util/Map;
 	public fun hashCode ()I
@@ -1171,7 +1168,6 @@ public final class com/squareup/kotlinpoet/TypeVariableName : com/squareup/kotli
 	public synthetic fun copy (ZLjava/util/List;Ljava/util/Map;)Lcom/squareup/kotlinpoet/TypeName;
 	public fun copy (ZLjava/util/List;Ljava/util/Map;)Lcom/squareup/kotlinpoet/TypeVariableName;
 	public static synthetic fun copy$default (Lcom/squareup/kotlinpoet/TypeVariableName;ZLjava/util/List;Ljava/util/List;ZLjava/util/Map;ILjava/lang/Object;)Lcom/squareup/kotlinpoet/TypeVariableName;
-	public fun equals (Ljava/lang/Object;)Z
 	public static final fun get (Ljava/lang/String;)Lcom/squareup/kotlinpoet/TypeVariableName;
 	public static final fun get (Ljava/lang/String;Lcom/squareup/kotlinpoet/KModifier;)Lcom/squareup/kotlinpoet/TypeVariableName;
 	public static final fun get (Ljava/lang/String;Ljava/util/List;)Lcom/squareup/kotlinpoet/TypeVariableName;
@@ -1230,7 +1226,6 @@ public final class com/squareup/kotlinpoet/WildcardTypeName : com/squareup/kotli
 	public static final fun consumerOf (Lkotlin/reflect/KClass;)Lcom/squareup/kotlinpoet/WildcardTypeName;
 	public synthetic fun copy (ZLjava/util/List;Ljava/util/Map;)Lcom/squareup/kotlinpoet/TypeName;
 	public fun copy (ZLjava/util/List;Ljava/util/Map;)Lcom/squareup/kotlinpoet/WildcardTypeName;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getInTypes ()Ljava/util/List;
 	public final fun getOutTypes ()Ljava/util/List;
 	public fun hashCode ()I

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/ClassName.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/ClassName.kt
@@ -189,10 +189,8 @@ public class ClassName internal constructor(
   override fun emit(out: CodeWriter) =
     out.emit(out.lookupName(this).escapeSegmentsIfNecessary())
 
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (javaClass != other?.javaClass) return false
-    if (!super.equals(other)) return false
+  override fun equalsWithGuard(other: TypeName, seen: RecursiveComparison): Boolean {
+    if (!super.equalsWithGuard(other, seen)) return false
 
     other as ClassName
 

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/LambdaTypeName.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/LambdaTypeName.kt
@@ -102,17 +102,15 @@ private constructor(
     return out
   }
 
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (javaClass != other?.javaClass) return false
-    if (!super.equals(other)) return false
+  override fun equalsWithGuard(other: TypeName, seen: RecursiveComparison): Boolean {
+    if (!super.equalsWithGuard(other, seen)) return false
 
     other as LambdaTypeName
 
-    if (receiver != other.receiver) return false
-    if (contextReceivers != other.contextReceivers) return false
-    if (contextParameters != other.contextParameters) return false
-    if (returnType != other.returnType) return false
+    if (!receiver.deepEquals(other.receiver, seen)) return false
+    if (!contextReceivers.deepEquals(other.contextReceivers, seen)) return false
+    if (!contextParameters.deepEquals(other.contextParameters, seen)) return false
+    if (!returnType.deepEquals(other.returnType, seen)) return false
     if (isSuspending != other.isSuspending) return false
     if (parameters != other.parameters) return false
 

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/ParameterizedTypeName.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/ParameterizedTypeName.kt
@@ -102,16 +102,14 @@ internal constructor(
   public fun nestedClass(name: String, typeArguments: List<TypeName>): ParameterizedTypeName =
     ParameterizedTypeName(this, rawType.nestedClass(name), typeArguments)
 
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (javaClass != other?.javaClass) return false
-    if (!super.equals(other)) return false
+  override fun equalsWithGuard(other: TypeName, seen: RecursiveComparison): Boolean {
+    if (!super.equalsWithGuard(other, seen)) return false
 
     other as ParameterizedTypeName
 
-    if (enclosingType != other.enclosingType) return false
-    if (rawType != other.rawType) return false
-    if (typeArguments != other.typeArguments) return false
+    if (!enclosingType.deepEquals(other.enclosingType, seen)) return false
+    if (!rawType.deepEquals(other.rawType, seen)) return false
+    if (!typeArguments.deepEquals(other.typeArguments, seen)) return false
 
     return true
   }

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/TypeName.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/TypeName.kt
@@ -23,6 +23,8 @@ import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.lang.reflect.TypeVariable
 import java.lang.reflect.WildcardType
+import java.util.Collections
+import java.util.IdentityHashMap
 import javax.lang.model.element.Modifier
 import javax.lang.model.element.TypeElement
 import javax.lang.model.element.TypeParameterElement
@@ -93,16 +95,22 @@ constructor(
   public val isAnnotated: Boolean
     get() = annotations.isNotEmpty()
 
-  override fun equals(other: Any?): Boolean {
+  final override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (javaClass != other?.javaClass) return false
+    if (other !is TypeName) return false
+    return deepEquals(other, RecursiveComparison())
+  }
 
-    other as TypeName
-
+  /**
+   * Compares this type name's own fields with [other], which is guaranteed to have the same class.
+   * Subtypes override this to compare their fields, reaching child type names through [deepEquals]
+   * so recursively bounded generics like `Enum<E : Enum<E>>` are compared without overflowing the
+   * stack. (#1737)
+   */
+  internal open fun equalsWithGuard(other: TypeName, seen: RecursiveComparison): Boolean {
     if (isNullable != other.isNullable) return false
     if (annotations != other.annotations) return false
     // do not check for equality of tags, these are considered side-channel data
-
     return true
   }
 
@@ -231,6 +239,37 @@ constructor(
         else -> throw IllegalArgumentException("unexpected type: $type")
       }
     }
+  }
+}
+
+/**
+ * Compares two child type names through [seen], so recursively bounded generics like `Enum<E :
+ * Enum<E>>` terminate instead of overflowing the stack. (#1737)
+ */
+internal fun TypeName?.deepEquals(other: TypeName?, seen: RecursiveComparison): Boolean {
+  if (this === other) return true
+  if (this == null || other == null) return false
+  if (javaClass != other.javaClass) return false
+  return equalsWithGuard(other, seen)
+}
+
+internal fun List<TypeName>.deepEquals(other: List<TypeName>, seen: RecursiveComparison): Boolean {
+  if (size != other.size) return false
+  for (index in indices) {
+    if (!this[index].deepEquals(other[index], seen)) return false
+  }
+  return true
+}
+
+/** Tracks, by reference identity, the [TypeName] pairs currently being compared. (#1737) */
+internal class RecursiveComparison {
+  // Allocated on first use so non-recursive comparisons stay allocation-free.
+  private var compared: IdentityHashMap<TypeName, MutableSet<TypeName>>? = null
+
+  /** Records ([left], [right]). Returns false if that exact pair is already being compared. */
+  fun enter(left: TypeName, right: TypeName): Boolean {
+    val pairs = compared ?: IdentityHashMap<TypeName, MutableSet<TypeName>>().also { compared = it }
+    return pairs.getOrPut(left) { Collections.newSetFromMap(IdentityHashMap()) }.add(right)
   }
 }
 

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/TypeVariableName.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/TypeVariableName.kt
@@ -71,15 +71,17 @@ private constructor(
 
   override fun emit(out: CodeWriter) = out.emit(name)
 
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (javaClass != other?.javaClass) return false
-    if (!super.equals(other)) return false
+  override fun equalsWithGuard(other: TypeName, seen: RecursiveComparison): Boolean {
+    // A recursively bounded variable like `Enum<E : Enum<E>>` reaches itself through its bounds,
+    // the only place a type-name cycle can form. Recording the pair here lets the repeat visit
+    // cut the cycle instead of overflowing the stack. (#1737)
+    if (!seen.enter(this, other)) return true
+    if (!super.equalsWithGuard(other, seen)) return false
 
     other as TypeVariableName
 
     if (name != other.name) return false
-    if (bounds != other.bounds) return false
+    if (!bounds.deepEquals(other.bounds, seen)) return false
     if (variance != other.variance) return false
     if (isReified != other.isReified) return false
 
@@ -89,7 +91,8 @@ private constructor(
   override fun hashCode(): Int {
     var result = super.hashCode()
     result = 31 * result + name.hashCode()
-    result = 31 * result + bounds.hashCode()
+    // `bounds` is omitted: it can refer back to this variable for recursive generics like
+    // `Enum<E : Enum<E>>` and would recurse forever. equals still compares bounds. (#1737)
     result = 31 * result + (variance?.hashCode() ?: 0)
     result = 31 * result + isReified.hashCode()
     return result

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/WildcardTypeName.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/WildcardTypeName.kt
@@ -53,15 +53,13 @@ private constructor(
     }
   }
 
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (javaClass != other?.javaClass) return false
-    if (!super.equals(other)) return false
+  override fun equalsWithGuard(other: TypeName, seen: RecursiveComparison): Boolean {
+    if (!super.equalsWithGuard(other, seen)) return false
 
     other as WildcardTypeName
 
-    if (outTypes != other.outTypes) return false
-    if (inTypes != other.inTypes) return false
+    if (!outTypes.deepEquals(other.outTypes, seen)) return false
+    if (!inTypes.deepEquals(other.inTypes, seen)) return false
 
     return true
   }

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/TypeVariableNameTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/TypeVariableNameTest.kt
@@ -21,6 +21,7 @@ import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotEqualTo
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeVariableName.Companion.NULLABLE_ANY_LIST
 import java.io.Serializable
 import kotlin.test.Test
@@ -323,5 +324,47 @@ class TypeVariableNameTest {
 
     assertThat(typeVariableName).isEqualTo(tagged)
     assertThat(typeVariableName.hashCode()).isEqualTo(tagged.hashCode())
+  }
+
+  @Test
+  fun recursivelyBoundedTypeVariableEqualsAndHashCode() {
+    // `Enum<E : Enum<E>>` produces a type variable whose bounds refer back to itself.
+    val typeParameter = Enum::class.java.typeParameters[0]
+    val first = TypeVariableName.get(typeParameter)
+    val second = TypeVariableName.get(typeParameter)
+
+    assertThat(first.hashCode()).isEqualTo(second.hashCode())
+    assertThat(first).isEqualTo(second)
+    assertThat(second).isEqualTo(first)
+    assertThat(first).isNotEqualTo(TypeVariableName("E"))
+  }
+
+  @Test
+  fun equalsComparesNestedBounds() {
+    fun boundedBy(argument: TypeName) =
+      TypeVariableName("T")
+        .copy(bounds = listOf(LIST.parameterizedBy(WildcardTypeName.producerOf(argument))))
+
+    assertThat(boundedBy(Number::class.asTypeName()))
+      .isEqualTo(boundedBy(Number::class.asTypeName()))
+    assertThat(boundedBy(Number::class.asTypeName()))
+      .isNotEqualTo(boundedBy(String::class.asTypeName()))
+  }
+
+  @Test
+  fun equalsComparesEnclosingTypeOfBound() {
+    fun boundedByInnerOf(outerArgument: TypeName) =
+      TypeVariableName("T")
+        .copy(
+          bounds =
+            listOf(
+              ClassName("com.example", "Outer")
+                .parameterizedBy(outerArgument)
+                .nestedClass("Inner", listOf(STRING))
+            )
+        )
+
+    assertThat(boundedByInnerOf(INT)).isEqualTo(boundedByInnerOf(INT))
+    assertThat(boundedByInnerOf(INT)).isNotEqualTo(boundedByInnerOf(STRING))
   }
 }


### PR DESCRIPTION
`TypeVariableName` builds cyclic graphs for recursively bound generics like `Enum<E : Enum<E>>`, where the bound points back at the variable. `equals` and `hashCode` followed those bounds with no guard and overflowed the stack. `equals` now walks them through a shared identity guard that stops the moment it revisits a pair. `hashCode` leaves bounds out, which JavaPoet does too.

Fixes #1737.

- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
