### PR TITLE
Add support for explicit backing fields

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@ Change Log
 
 ## Unreleased
 
+ * New: Support for explicit backing fields. (#2325)
  * Fix: Keep the `//` prefix on wrapped file comment lines. (#1922)
 
 ## Version 2.3.0

--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -750,6 +750,8 @@ public final class com/squareup/kotlinpoet/PropertySpec : com/squareup/kotlinpoe
 	public static final fun builder (Ljava/lang/String;Lkotlin/reflect/KClass;[Lcom/squareup/kotlinpoet/KModifier;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getAnnotations ()Ljava/util/List;
+	public final fun getBackingFieldInitializer ()Lcom/squareup/kotlinpoet/CodeBlock;
+	public final fun getBackingFieldType ()Lcom/squareup/kotlinpoet/TypeName;
 	public fun getContextParameters ()Ljava/util/List;
 	public fun getContextReceiverTypes ()Ljava/util/List;
 	public final fun getDelegated ()Z
@@ -794,6 +796,10 @@ public final class com/squareup/kotlinpoet/PropertySpec$Builder : com/squareup/k
 	public final fun addModifiers ([Lcom/squareup/kotlinpoet/KModifier;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
 	public final fun addTypeVariable (Lcom/squareup/kotlinpoet/TypeVariableName;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
 	public final fun addTypeVariables (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
+	public final fun backingFieldInitializer (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
+	public final fun backingFieldInitializer (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
+	public final fun backingFieldType (Lcom/squareup/kotlinpoet/TypeName;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
+	public final fun backingFieldType (Lkotlin/reflect/KClass;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
 	public final fun build ()Lcom/squareup/kotlinpoet/PropertySpec;
 	public final fun delegate (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;
 	public final fun delegate (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/PropertySpec$Builder;

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/PropertySpec.kt
@@ -52,6 +52,8 @@ private constructor(
   public val getter: FunSpec? = builder.getter
   public val setter: FunSpec? = builder.setter
   public val receiverType: TypeName? = builder.receiverType
+  public val backingFieldType: TypeName = builder.backingFieldType
+  public val backingFieldInitializer: CodeBlock? = builder.backingFieldInitializer
 
   init {
     require(
@@ -134,6 +136,17 @@ private constructor(
       setter.emit(codeWriter, null, implicitAccessorModifiers, false)
       codeWriter.emitCode("⇤")
     }
+    if (backingFieldType != type || backingFieldInitializer != null) {
+      codeWriter.emitCode("⇥")
+      codeWriter.emit("field")
+      if (backingFieldType != type) {
+        codeWriter.emitCode(": %T", backingFieldType)
+      }
+      if (backingFieldInitializer != null) {
+        codeWriter.emitCode(" = %L", backingFieldInitializer)
+      }
+      codeWriter.emitCode("⇤")
+    }
   }
 
   internal fun fromPrimaryConstructorParameter(parameter: ParameterSpec): PropertySpec {
@@ -192,6 +205,8 @@ private constructor(
     internal var getter: FunSpec? = null
     internal var setter: FunSpec? = null
     internal var receiverType: TypeName? = null
+    internal var backingFieldType: TypeName = type
+    internal var backingFieldInitializer: CodeBlock? = null
 
     public val modifiers: MutableList<KModifier> = mutableListOf()
     public val typeVariables: MutableList<TypeVariableName> = mutableListOf()
@@ -263,6 +278,47 @@ private constructor(
     public fun receiver(receiverType: Type): Builder = receiver(receiverType.asTypeName())
 
     public fun receiver(receiverType: KClass<*>): Builder = receiver(receiverType.asTypeName())
+
+    /**
+     * Specify the type of this property's backing field. If different from [type], an explicit
+     * backing field will be emitted (see
+     * [KEEP-0430](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0430-explicit-backing-fields.md)):
+     * ```kotlin
+     * val city: LiveData<String> field: MutableLiveData<String>
+     * ```
+     *
+     * Setting backing field type to the same value as [type] has no effect.
+     */
+    public fun backingFieldType(type: TypeName): Builder = apply {
+      this.backingFieldType = type
+    }
+
+    /**
+     * Specify the type of this property's backing field. If different from [type], an explicit
+     * backing field will be emitted (see
+     * [KEEP-0430](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0430-explicit-backing-fields.md)):
+     * ```kotlin
+     * val city: LiveData<String> field: MutableLiveData<String>
+     * ```
+     *
+     * Setting backing field type to the same value as [type] has no effect.
+     */
+    public fun backingFieldType(type: KClass<*>): Builder = backingFieldType(type.asTypeName())
+
+    /**
+     * Specify an explicit initializer for this property's backing field (see
+     * [KEEP-0430](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0430-explicit-backing-fields.md)).
+     */
+    public fun backingFieldInitializer(codeBlock: CodeBlock): Builder = apply {
+      this.backingFieldInitializer = codeBlock
+    }
+
+    /**
+     * Specify an explicit initializer for this property's backing field (see
+     * [KEEP-0430](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0430-explicit-backing-fields.md)).
+     */
+    public fun backingFieldInitializer(format: String, vararg args: Any?): Builder =
+      backingFieldInitializer(CodeBlock.of(format, *args))
 
     // region Overrides for binary compatibility
     @Suppress("RedundantOverride")

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -884,4 +884,75 @@ class PropertySpecTest {
       .isInstanceOf<IllegalStateException>()
       .hasMessage("Using both context receivers and context parameters is not allowed")
   }
+
+  @Test
+  fun explicitBackingFieldWithTypeOnly() {
+    val propertySpec =
+      PropertySpec.builder("city", ClassName(packageName = "", "LiveData").parameterizedBy(STRING))
+        .mutable(false)
+        .backingFieldType(ClassName(packageName = "", "MutableLiveData").parameterizedBy(STRING))
+        .build()
+    assertThat(propertySpec.toString())
+      .isEqualTo(
+        """
+        val city: LiveData<kotlin.String>
+          field: MutableLiveData<kotlin.String>
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun explicitBackingFieldWithInitializerOnly() {
+    val propertySpec =
+      PropertySpec.builder("city", ClassName(packageName = "", "LiveData").parameterizedBy(STRING))
+        .mutable(false)
+        .backingFieldInitializer("%T()", ClassName(packageName = "", "MutableLiveData"))
+        .build()
+    assertThat(propertySpec.toString())
+      .isEqualTo(
+        """
+        val city: LiveData<kotlin.String>
+          field = MutableLiveData()
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun explicitBackingFieldWithTypeAndInitializer() {
+    val mutableLiveData = ClassName(packageName = "", "MutableLiveData")
+    val propertySpec =
+      PropertySpec.builder("city", ClassName(packageName = "", "LiveData").parameterizedBy(STRING))
+        .mutable(false)
+        .backingFieldType(mutableLiveData.parameterizedBy(STRING))
+        .backingFieldInitializer("%T()", mutableLiveData)
+        .build()
+    assertThat(propertySpec.toString())
+      .isEqualTo(
+        """
+        val city: LiveData<kotlin.String>
+          field: MutableLiveData<kotlin.String> = MutableLiveData()
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun explicitBackingFieldWithSameTypeAsProperty() {
+    val liveDataOfString = ClassName(packageName = "", "LiveData").parameterizedBy(STRING)
+    val propertySpec =
+      PropertySpec.builder("city", liveDataOfString)
+        .mutable(false)
+        .backingFieldType(liveDataOfString)
+        .build()
+    assertThat(propertySpec.toString())
+      .isEqualTo(
+        """
+        val city: LiveData<kotlin.String>
+
+        """
+          .trimIndent()
+      )
+  }
 }


### PR DESCRIPTION
Closes #2317 

- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
