### PR TITLE
Add `CodeBlockHolder`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ Change Log
 
  * New: Support for explicit backing fields. (#2325)
  * New: `value class` validations have been relaxed to support multi-field value classes. (#2329)
+ * New: Extract `CodeBlockHolder` interface for constructs that can hold a `CodeBlock` body and their builders. (#1553)
  * Fix: Keep the `//` prefix on wrapped file comment lines. (#1922)
  * Fix: `TypeVariableName.equals`/`hashCode` no longer overflow on recursively bound generics like `Enum<E : Enum<E>>`. (#1737)
 

--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -146,14 +146,15 @@ public abstract interface class com/squareup/kotlinpoet/CodeBlockHolder {
 }
 
 public abstract interface class com/squareup/kotlinpoet/CodeBlockHolder$Builder {
-	public abstract fun addCode (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
-	public abstract fun addCode (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
-	public abstract fun addNamedCode (Ljava/lang/String;Ljava/util/Map;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
-	public abstract fun addStatement (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
-	public abstract fun beginControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
-	public abstract fun clearBody ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
-	public abstract fun endControlFlow ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
-	public abstract fun nextControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun addCode (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun addCode (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun addNamedCode (Ljava/lang/String;Ljava/util/Map;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun addStatement (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun beginControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun clearBody ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun endControlFlow ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun getBody ()Lcom/squareup/kotlinpoet/CodeBlock$Builder;
+	public fun nextControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
 }
 
 public final class com/squareup/kotlinpoet/CodeBlocks {
@@ -311,6 +312,7 @@ public final class com/squareup/kotlinpoet/FileSpec$Builder : com/squareup/kotli
 	public synthetic fun endControlFlow ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
 	public fun endControlFlow ()Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public fun getAnnotations ()Ljava/util/List;
+	public fun getBody ()Lcom/squareup/kotlinpoet/CodeBlock$Builder;
 	public final fun getDefaultImports ()Ljava/util/Set;
 	public final fun getImports ()Ljava/util/List;
 	public final fun getMembers ()Ljava/util/List;
@@ -424,6 +426,7 @@ public final class com/squareup/kotlinpoet/FunSpec$Builder : com/squareup/kotlin
 	public synthetic fun endControlFlow ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
 	public fun endControlFlow ()Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public fun getAnnotations ()Ljava/util/List;
+	public fun getBody ()Lcom/squareup/kotlinpoet/CodeBlock$Builder;
 	public fun getKdoc ()Lcom/squareup/kotlinpoet/CodeBlock$Builder;
 	public final fun getModifiers ()Ljava/util/List;
 	public fun getOriginatingElements ()Ljava/util/List;

--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -146,15 +146,14 @@ public abstract interface class com/squareup/kotlinpoet/CodeBlockHolder {
 }
 
 public abstract interface class com/squareup/kotlinpoet/CodeBlockHolder$Builder {
-	public fun addCode (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
-	public fun addCode (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
-	public fun addNamedCode (Ljava/lang/String;Ljava/util/Map;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
-	public fun addStatement (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
-	public fun beginControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
-	public fun clearBody ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
-	public fun endControlFlow ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
-	public abstract fun getBody ()Lcom/squareup/kotlinpoet/CodeBlock$Builder;
-	public fun nextControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun addCode (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun addCode (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun addNamedCode (Ljava/lang/String;Ljava/util/Map;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun addStatement (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun beginControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun clearBody ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun endControlFlow ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun nextControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
 }
 
 public final class com/squareup/kotlinpoet/CodeBlocks {
@@ -312,7 +311,6 @@ public final class com/squareup/kotlinpoet/FileSpec$Builder : com/squareup/kotli
 	public synthetic fun endControlFlow ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
 	public fun endControlFlow ()Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public fun getAnnotations ()Ljava/util/List;
-	public fun getBody ()Lcom/squareup/kotlinpoet/CodeBlock$Builder;
 	public final fun getDefaultImports ()Ljava/util/Set;
 	public final fun getImports ()Ljava/util/List;
 	public final fun getMembers ()Ljava/util/List;
@@ -426,7 +424,6 @@ public final class com/squareup/kotlinpoet/FunSpec$Builder : com/squareup/kotlin
 	public synthetic fun endControlFlow ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
 	public fun endControlFlow ()Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public fun getAnnotations ()Ljava/util/List;
-	public fun getBody ()Lcom/squareup/kotlinpoet/CodeBlock$Builder;
 	public fun getKdoc ()Lcom/squareup/kotlinpoet/CodeBlock$Builder;
 	public final fun getModifiers ()Ljava/util/List;
 	public fun getOriginatingElements ()Ljava/util/List;

--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -141,6 +141,21 @@ public final class com/squareup/kotlinpoet/CodeBlock$Companion {
 	public final fun of (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlock;
 }
 
+public abstract interface class com/squareup/kotlinpoet/CodeBlockHolder {
+	public abstract fun getBody ()Lcom/squareup/kotlinpoet/CodeBlock;
+}
+
+public abstract interface class com/squareup/kotlinpoet/CodeBlockHolder$Builder {
+	public abstract fun addCode (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun addCode (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun addNamedCode (Ljava/lang/String;Ljava/util/Map;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun addStatement (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun beginControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun clearBody ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun endControlFlow ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun nextControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+}
+
 public final class com/squareup/kotlinpoet/CodeBlocks {
 	public static final fun buildCodeBlock (Lkotlin/jvm/functions/Function1;)Lcom/squareup/kotlinpoet/CodeBlock;
 	public static final fun joinToCode (Ljava/util/Collection;)Lcom/squareup/kotlinpoet/CodeBlock;
@@ -198,7 +213,7 @@ public final class com/squareup/kotlinpoet/Dynamic : com/squareup/kotlinpoet/Typ
 public abstract interface annotation class com/squareup/kotlinpoet/ExperimentalKotlinPoetApi : java/lang/annotation/Annotation {
 }
 
-public final class com/squareup/kotlinpoet/FileSpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/MemberSpecHolder, com/squareup/kotlinpoet/Taggable, com/squareup/kotlinpoet/TypeSpecHolder {
+public final class com/squareup/kotlinpoet/FileSpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/CodeBlockHolder, com/squareup/kotlinpoet/MemberSpecHolder, com/squareup/kotlinpoet/Taggable, com/squareup/kotlinpoet/TypeSpecHolder {
 	public static final field Companion Lcom/squareup/kotlinpoet/FileSpec$Companion;
 	public static final fun builder (Lcom/squareup/kotlinpoet/ClassName;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public static final fun builder (Lcom/squareup/kotlinpoet/MemberName;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
@@ -206,7 +221,7 @@ public final class com/squareup/kotlinpoet/FileSpec : com/squareup/kotlinpoet/An
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun get (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeSpec;)Lcom/squareup/kotlinpoet/FileSpec;
 	public fun getAnnotations ()Ljava/util/List;
-	public final fun getBody ()Lcom/squareup/kotlinpoet/CodeBlock;
+	public fun getBody ()Lcom/squareup/kotlinpoet/CodeBlock;
 	public final fun getComment ()Lcom/squareup/kotlinpoet/CodeBlock;
 	public final fun getDefaultImports ()Ljava/util/Set;
 	public fun getFunSpecs ()Ljava/util/List;
@@ -236,7 +251,7 @@ public final class com/squareup/kotlinpoet/FileSpec : com/squareup/kotlinpoet/An
 	public final fun writeTo (Ljavax/annotation/processing/Filer;)V
 }
 
-public final class com/squareup/kotlinpoet/FileSpec$Builder : com/squareup/kotlinpoet/Annotatable$Builder, com/squareup/kotlinpoet/MemberSpecHolder$Builder, com/squareup/kotlinpoet/Taggable$Builder, com/squareup/kotlinpoet/TypeSpecHolder$Builder {
+public final class com/squareup/kotlinpoet/FileSpec$Builder : com/squareup/kotlinpoet/Annotatable$Builder, com/squareup/kotlinpoet/CodeBlockHolder$Builder, com/squareup/kotlinpoet/MemberSpecHolder$Builder, com/squareup/kotlinpoet/Taggable$Builder, com/squareup/kotlinpoet/TypeSpecHolder$Builder {
 	public final fun addAliasedImport (Lcom/squareup/kotlinpoet/ClassName;Ljava/lang/String;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun addAliasedImport (Lcom/squareup/kotlinpoet/ClassName;Ljava/lang/String;Ljava/lang/String;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun addAliasedImport (Lcom/squareup/kotlinpoet/MemberName;Ljava/lang/String;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
@@ -253,8 +268,10 @@ public final class com/squareup/kotlinpoet/FileSpec$Builder : com/squareup/kotli
 	public synthetic fun addAnnotations (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/Annotatable$Builder;
 	public fun addAnnotations (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun addBodyComment (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
-	public final fun addCode (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
-	public final fun addCode (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
+	public synthetic fun addCode (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun addCode (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
+	public synthetic fun addCode (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun addCode (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun addComment (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun addDefaultPackageImport (Ljava/lang/String;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun addFileComment (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
@@ -273,21 +290,26 @@ public final class com/squareup/kotlinpoet/FileSpec$Builder : com/squareup/kotli
 	public final fun addImport (Lkotlin/reflect/KClass;[Ljava/lang/String;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun addKotlinDefaultImports (ZZ)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public static synthetic fun addKotlinDefaultImports$default (Lcom/squareup/kotlinpoet/FileSpec$Builder;ZZILjava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
-	public final fun addNamedCode (Ljava/lang/String;Ljava/util/Map;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
+	public synthetic fun addNamedCode (Ljava/lang/String;Ljava/util/Map;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun addNamedCode (Ljava/lang/String;Ljava/util/Map;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public fun addProperty (Lcom/squareup/kotlinpoet/PropertySpec;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public synthetic fun addProperty (Lcom/squareup/kotlinpoet/PropertySpec;)Lcom/squareup/kotlinpoet/MemberSpecHolder$Builder;
-	public final fun addStatement (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
+	public synthetic fun addStatement (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun addStatement (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public fun addType (Lcom/squareup/kotlinpoet/TypeSpec;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public synthetic fun addType (Lcom/squareup/kotlinpoet/TypeSpec;)Lcom/squareup/kotlinpoet/TypeSpecHolder$Builder;
 	public final fun addTypeAlias (Lcom/squareup/kotlinpoet/TypeAliasSpec;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public fun addTypes (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public synthetic fun addTypes (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/TypeSpecHolder$Builder;
-	public final fun beginControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
+	public synthetic fun beginControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun beginControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun build ()Lcom/squareup/kotlinpoet/FileSpec;
-	public final fun clearBody ()Lcom/squareup/kotlinpoet/FileSpec$Builder;
+	public synthetic fun clearBody ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun clearBody ()Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun clearComment ()Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun clearImports ()Lcom/squareup/kotlinpoet/FileSpec$Builder;
-	public final fun endControlFlow ()Lcom/squareup/kotlinpoet/FileSpec$Builder;
+	public synthetic fun endControlFlow ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun endControlFlow ()Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public fun getAnnotations ()Ljava/util/List;
 	public final fun getDefaultImports ()Ljava/util/Set;
 	public final fun getImports ()Ljava/util/List;
@@ -297,7 +319,8 @@ public final class com/squareup/kotlinpoet/FileSpec$Builder : com/squareup/kotli
 	public fun getTags ()Ljava/util/Map;
 	public final fun indent (Ljava/lang/String;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun isScript ()Z
-	public final fun nextControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
+	public synthetic fun nextControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun nextControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 }
 
 public final class com/squareup/kotlinpoet/FileSpec$Companion {
@@ -309,14 +332,14 @@ public final class com/squareup/kotlinpoet/FileSpec$Companion {
 	public static synthetic fun scriptBuilder$default (Lcom/squareup/kotlinpoet/FileSpec$Companion;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 }
 
-public final class com/squareup/kotlinpoet/FunSpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/ContextParameterizable, com/squareup/kotlinpoet/ContextReceivable, com/squareup/kotlinpoet/Documentable, com/squareup/kotlinpoet/OriginatingElementsHolder, com/squareup/kotlinpoet/Taggable {
+public final class com/squareup/kotlinpoet/FunSpec : com/squareup/kotlinpoet/Annotatable, com/squareup/kotlinpoet/CodeBlockHolder, com/squareup/kotlinpoet/ContextParameterizable, com/squareup/kotlinpoet/ContextReceivable, com/squareup/kotlinpoet/Documentable, com/squareup/kotlinpoet/OriginatingElementsHolder, com/squareup/kotlinpoet/Taggable {
 	public static final field Companion Lcom/squareup/kotlinpoet/FunSpec$Companion;
 	public static final fun builder (Lcom/squareup/kotlinpoet/MemberName;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public static final fun builder (Ljava/lang/String;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public static final fun constructorBuilder ()Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getAnnotations ()Ljava/util/List;
-	public final fun getBody ()Lcom/squareup/kotlinpoet/CodeBlock;
+	public fun getBody ()Lcom/squareup/kotlinpoet/CodeBlock;
 	public fun getContextParameters ()Ljava/util/List;
 	public fun getContextReceiverTypes ()Ljava/util/List;
 	public final fun getDelegateConstructor ()Ljava/lang/String;
@@ -347,7 +370,7 @@ public final class com/squareup/kotlinpoet/FunSpec : com/squareup/kotlinpoet/Ann
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/squareup/kotlinpoet/FunSpec$Builder : com/squareup/kotlinpoet/Annotatable$Builder, com/squareup/kotlinpoet/ContextParameterizable$Builder, com/squareup/kotlinpoet/ContextReceivable$Builder, com/squareup/kotlinpoet/Documentable$Builder, com/squareup/kotlinpoet/OriginatingElementsHolder$Builder, com/squareup/kotlinpoet/Taggable$Builder {
+public final class com/squareup/kotlinpoet/FunSpec$Builder : com/squareup/kotlinpoet/Annotatable$Builder, com/squareup/kotlinpoet/CodeBlockHolder$Builder, com/squareup/kotlinpoet/ContextParameterizable$Builder, com/squareup/kotlinpoet/ContextReceivable$Builder, com/squareup/kotlinpoet/Documentable$Builder, com/squareup/kotlinpoet/OriginatingElementsHolder$Builder, com/squareup/kotlinpoet/Taggable$Builder {
 	public synthetic fun addAnnotation (Lcom/squareup/kotlinpoet/AnnotationSpec;)Lcom/squareup/kotlinpoet/Annotatable$Builder;
 	public fun addAnnotation (Lcom/squareup/kotlinpoet/AnnotationSpec;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public synthetic fun addAnnotation (Lcom/squareup/kotlinpoet/ClassName;)Lcom/squareup/kotlinpoet/Annotatable$Builder;
@@ -358,8 +381,10 @@ public final class com/squareup/kotlinpoet/FunSpec$Builder : com/squareup/kotlin
 	public fun addAnnotation (Lkotlin/reflect/KClass;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public synthetic fun addAnnotations (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/Annotatable$Builder;
 	public fun addAnnotations (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
-	public final fun addCode (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
-	public final fun addCode (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
+	public synthetic fun addCode (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun addCode (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
+	public synthetic fun addCode (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun addCode (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun addComment (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public synthetic fun addKdoc (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/Documentable$Builder;
 	public fun addKdoc (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
@@ -367,7 +392,8 @@ public final class com/squareup/kotlinpoet/FunSpec$Builder : com/squareup/kotlin
 	public fun addKdoc (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun addModifiers (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun addModifiers ([Lcom/squareup/kotlinpoet/KModifier;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
-	public final fun addNamedCode (Ljava/lang/String;Ljava/util/Map;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
+	public synthetic fun addNamedCode (Ljava/lang/String;Ljava/util/Map;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun addNamedCode (Ljava/lang/String;Ljava/util/Map;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun addParameter (Lcom/squareup/kotlinpoet/ParameterSpec;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun addParameter (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun addParameter (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;[Lcom/squareup/kotlinpoet/KModifier;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
@@ -376,10 +402,12 @@ public final class com/squareup/kotlinpoet/FunSpec$Builder : com/squareup/kotlin
 	public final fun addParameter (Ljava/lang/String;Lkotlin/reflect/KClass;Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun addParameter (Ljava/lang/String;Lkotlin/reflect/KClass;[Lcom/squareup/kotlinpoet/KModifier;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun addParameters (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
-	public final fun addStatement (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
+	public synthetic fun addStatement (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun addStatement (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun addTypeVariable (Lcom/squareup/kotlinpoet/TypeVariableName;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun addTypeVariables (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
-	public final fun beginControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
+	public synthetic fun beginControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun beginControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun build ()Lcom/squareup/kotlinpoet/FunSpec;
 	public final fun callSuperConstructor (Ljava/lang/Iterable;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun callSuperConstructor (Ljava/util/List;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
@@ -391,8 +419,10 @@ public final class com/squareup/kotlinpoet/FunSpec$Builder : com/squareup/kotlin
 	public final fun callThisConstructor ([Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun callThisConstructor ([Ljava/lang/String;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public static synthetic fun callThisConstructor$default (Lcom/squareup/kotlinpoet/FunSpec$Builder;[Lcom/squareup/kotlinpoet/CodeBlock;ILjava/lang/Object;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
-	public final fun clearBody ()Lcom/squareup/kotlinpoet/FunSpec$Builder;
-	public final fun endControlFlow ()Lcom/squareup/kotlinpoet/FunSpec$Builder;
+	public synthetic fun clearBody ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun clearBody ()Lcom/squareup/kotlinpoet/FunSpec$Builder;
+	public synthetic fun endControlFlow ()Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun endControlFlow ()Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public fun getAnnotations ()Ljava/util/List;
 	public fun getKdoc ()Lcom/squareup/kotlinpoet/CodeBlock$Builder;
 	public final fun getModifiers ()Ljava/util/List;
@@ -401,7 +431,8 @@ public final class com/squareup/kotlinpoet/FunSpec$Builder : com/squareup/kotlin
 	public fun getTags ()Ljava/util/Map;
 	public final fun getTypeVariables ()Ljava/util/List;
 	public final fun jvmModifiers (Ljava/lang/Iterable;)V
-	public final fun nextControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
+	public synthetic fun nextControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun nextControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun receiver (Lcom/squareup/kotlinpoet/TypeName;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun receiver (Lcom/squareup/kotlinpoet/TypeName;Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun receiver (Ljava/lang/reflect/Type;)Lcom/squareup/kotlinpoet/FunSpec$Builder;

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlockHolder.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlockHolder.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.kotlinpoet
+
+/** A spec which contains a body of code. */
+public interface CodeBlockHolder {
+  public val body: CodeBlock
+
+  public interface Builder<out T : Builder<T>> {
+    public fun addCode(format: String, vararg args: Any?): T
+
+    public fun addCode(codeBlock: CodeBlock): T
+
+    public fun addNamedCode(format: String, args: Map<String, *>): T
+
+    public fun addStatement(format: String, vararg args: Any?): T
+
+    public fun beginControlFlow(controlFlow: String, vararg args: Any?): T
+
+    public fun nextControlFlow(controlFlow: String, vararg args: Any?): T
+
+    public fun endControlFlow(): T
+
+    public fun clearBody(): T
+  }
+}

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlockHolder.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlockHolder.kt
@@ -20,20 +20,42 @@ public interface CodeBlockHolder {
   public val body: CodeBlock
 
   public interface Builder<out T : Builder<T>> {
-    public fun addCode(format: String, vararg args: Any?): T
+    public val body: CodeBlock.Builder
 
-    public fun addCode(codeBlock: CodeBlock): T
+    @Suppress("UNCHECKED_CAST")
+    public fun addCode(format: String, vararg args: Any?): T =
+      apply { body.add(format, *args) } as T
 
-    public fun addNamedCode(format: String, args: Map<String, *>): T
+    @Suppress("UNCHECKED_CAST")
+    public fun addCode(codeBlock: CodeBlock): T = apply { body.add(codeBlock) } as T
 
-    public fun addStatement(format: String, vararg args: Any?): T
+    @Suppress("UNCHECKED_CAST")
+    public fun addNamedCode(format: String, args: Map<String, *>): T =
+      apply { body.addNamed(format, args) } as T
 
-    public fun beginControlFlow(controlFlow: String, vararg args: Any?): T
+    @Suppress("UNCHECKED_CAST")
+    public fun addStatement(format: String, vararg args: Any?): T =
+      apply { body.addStatement(format, *args) } as T
 
-    public fun nextControlFlow(controlFlow: String, vararg args: Any?): T
+    /**
+     * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
+     *   Shouldn't contain braces or newline characters.
+     */
+    @Suppress("UNCHECKED_CAST")
+    public fun beginControlFlow(controlFlow: String, vararg args: Any?): T =
+      apply { body.beginControlFlow(controlFlow, *args) } as T
 
-    public fun endControlFlow(): T
+    /**
+     * @param controlFlow the control flow construct and its code, such as "else if (foo == 10)".
+     *   Shouldn't contain braces or newline characters.
+     */
+    @Suppress("UNCHECKED_CAST")
+    public fun nextControlFlow(controlFlow: String, vararg args: Any?): T =
+      apply { body.nextControlFlow(controlFlow, *args) } as T
 
-    public fun clearBody(): T
+    @Suppress("UNCHECKED_CAST")
+    public fun endControlFlow(): T = apply { body.endControlFlow() } as T
+
+    @Suppress("UNCHECKED_CAST") public fun clearBody(): T = apply { body.clear() } as T
   }
 }

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlockHolder.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlockHolder.kt
@@ -20,42 +20,20 @@ public interface CodeBlockHolder {
   public val body: CodeBlock
 
   public interface Builder<out T : Builder<T>> {
-    public val body: CodeBlock.Builder
+    public fun addCode(format: String, vararg args: Any?): T
 
-    @Suppress("UNCHECKED_CAST")
-    public fun addCode(format: String, vararg args: Any?): T =
-      apply { body.add(format, *args) } as T
+    public fun addCode(codeBlock: CodeBlock): T
 
-    @Suppress("UNCHECKED_CAST")
-    public fun addCode(codeBlock: CodeBlock): T = apply { body.add(codeBlock) } as T
+    public fun addNamedCode(format: String, args: Map<String, *>): T
 
-    @Suppress("UNCHECKED_CAST")
-    public fun addNamedCode(format: String, args: Map<String, *>): T =
-      apply { body.addNamed(format, args) } as T
+    public fun addStatement(format: String, vararg args: Any?): T
 
-    @Suppress("UNCHECKED_CAST")
-    public fun addStatement(format: String, vararg args: Any?): T =
-      apply { body.addStatement(format, *args) } as T
+    public fun beginControlFlow(controlFlow: String, vararg args: Any?): T
 
-    /**
-     * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
-     *   Shouldn't contain braces or newline characters.
-     */
-    @Suppress("UNCHECKED_CAST")
-    public fun beginControlFlow(controlFlow: String, vararg args: Any?): T =
-      apply { body.beginControlFlow(controlFlow, *args) } as T
+    public fun nextControlFlow(controlFlow: String, vararg args: Any?): T
 
-    /**
-     * @param controlFlow the control flow construct and its code, such as "else if (foo == 10)".
-     *   Shouldn't contain braces or newline characters.
-     */
-    @Suppress("UNCHECKED_CAST")
-    public fun nextControlFlow(controlFlow: String, vararg args: Any?): T =
-      apply { body.nextControlFlow(controlFlow, *args) } as T
+    public fun endControlFlow(): T
 
-    @Suppress("UNCHECKED_CAST")
-    public fun endControlFlow(): T = apply { body.endControlFlow() } as T
-
-    @Suppress("UNCHECKED_CAST") public fun clearBody(): T = apply { body.clear() } as T
+    public fun clearBody(): T
   }
 }

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
@@ -281,7 +281,7 @@ private constructor(builder: Builder, private val tagMap: TagMap = builder.build
       get() = memberImports.toList()
 
     public val members: MutableList<Any> = mutableListOf()
-    internal val body = CodeBlock.builder()
+    override val body: CodeBlock.Builder = CodeBlock.builder()
 
     /**
      * Add an annotation to the file.
@@ -464,19 +464,19 @@ private constructor(builder: Builder, private val tagMap: TagMap = builder.build
 
     public fun indent(indent: String): Builder = apply { this.indent = indent }
 
-    override fun addCode(format: String, vararg args: Any?): Builder = apply {
+    override fun addCode(format: String, vararg args: Any?): Builder {
       check(isScript) { "addCode() is only allowed in script files" }
-      body.add(format, *args)
+      return super.addCode(format, *args)
     }
 
-    override fun addNamedCode(format: String, args: Map<String, *>): Builder = apply {
+    override fun addNamedCode(format: String, args: Map<String, *>): Builder {
       check(isScript) { "addNamedCode() is only allowed in script files" }
-      body.addNamed(format, args)
+      return super.addNamedCode(format, args)
     }
 
-    override fun addCode(codeBlock: CodeBlock): Builder = apply {
+    override fun addCode(codeBlock: CodeBlock): Builder {
       check(isScript) { "addCode() is only allowed in script files" }
-      body.add(codeBlock)
+      return super.addCode(codeBlock)
     }
 
     /** Adds a comment to the body of this script file in the order that it was added. */
@@ -485,37 +485,29 @@ private constructor(builder: Builder, private val tagMap: TagMap = builder.build
       body.add("// $format\n", *args)
     }
 
-    /**
-     * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
-     *   Shouldn't contain braces or newline characters.
-     */
-    override fun beginControlFlow(controlFlow: String, vararg args: Any?): Builder = apply {
+    override fun beginControlFlow(controlFlow: String, vararg args: Any?): Builder {
       check(isScript) { "beginControlFlow() is only allowed in script files" }
-      body.beginControlFlow(controlFlow, *args)
+      return super.beginControlFlow(controlFlow, *args)
     }
 
-    /**
-     * @param controlFlow the control flow construct and its code, such as "else if (foo == 10)".
-     *   Shouldn't contain braces or newline characters.
-     */
-    override fun nextControlFlow(controlFlow: String, vararg args: Any?): Builder = apply {
+    override fun nextControlFlow(controlFlow: String, vararg args: Any?): Builder {
       check(isScript) { "nextControlFlow() is only allowed in script files" }
-      body.nextControlFlow(controlFlow, *args)
+      return super.nextControlFlow(controlFlow, *args)
     }
 
-    override fun endControlFlow(): Builder = apply {
+    override fun endControlFlow(): Builder {
       check(isScript) { "endControlFlow() is only allowed in script files" }
-      body.endControlFlow()
+      return super.endControlFlow()
     }
 
-    override fun addStatement(format: String, vararg args: Any?): Builder = apply {
+    override fun addStatement(format: String, vararg args: Any?): Builder {
       check(isScript) { "addStatement() is only allowed in script files" }
-      body.addStatement(format, *args)
+      return super.addStatement(format, *args)
     }
 
-    override fun clearBody(): Builder = apply {
+    override fun clearBody(): Builder {
       check(isScript) { "clearBody() is only allowed in script files" }
-      body.clear()
+      return super.clearBody()
     }
 
     // region Overrides for binary compatibility

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
@@ -48,7 +48,7 @@ import kotlin.reflect.KClass
  */
 public class FileSpec
 private constructor(builder: Builder, private val tagMap: TagMap = builder.buildTagMap()) :
-  Taggable by tagMap, Annotatable, TypeSpecHolder, MemberSpecHolder {
+  Taggable by tagMap, Annotatable, TypeSpecHolder, MemberSpecHolder, CodeBlockHolder {
   override val annotations: List<AnnotationSpec> = builder.annotations.toImmutableList()
   override val typeSpecs: List<TypeSpec> =
     builder.members.filterIsInstance<TypeSpec>().toImmutableList()
@@ -61,7 +61,7 @@ private constructor(builder: Builder, private val tagMap: TagMap = builder.build
   public val name: String = builder.name
   public val members: List<Any> = builder.members.toList()
   public val defaultImports: Set<String> = builder.defaultImports.toSet()
-  public val body: CodeBlock = builder.body.build()
+  override val body: CodeBlock = builder.body.build()
   public val isScript: Boolean = builder.isScript
   private val memberImports = builder.memberImports.associateBy(Import::qualifiedName)
   private val indent = builder.indent
@@ -267,7 +267,8 @@ private constructor(builder: Builder, private val tagMap: TagMap = builder.build
     Taggable.Builder<Builder>,
     Annotatable.Builder<Builder>,
     TypeSpecHolder.Builder<Builder>,
-    MemberSpecHolder.Builder<Builder> {
+    MemberSpecHolder.Builder<Builder>,
+    CodeBlockHolder.Builder<Builder> {
 
     override val annotations: MutableList<AnnotationSpec> = mutableListOf()
     internal val comment = CodeBlock.builder()
@@ -463,17 +464,17 @@ private constructor(builder: Builder, private val tagMap: TagMap = builder.build
 
     public fun indent(indent: String): Builder = apply { this.indent = indent }
 
-    public fun addCode(format: String, vararg args: Any?): Builder = apply {
+    override fun addCode(format: String, vararg args: Any?): Builder = apply {
       check(isScript) { "addCode() is only allowed in script files" }
       body.add(format, *args)
     }
 
-    public fun addNamedCode(format: String, args: Map<String, *>): Builder = apply {
+    override fun addNamedCode(format: String, args: Map<String, *>): Builder = apply {
       check(isScript) { "addNamedCode() is only allowed in script files" }
       body.addNamed(format, args)
     }
 
-    public fun addCode(codeBlock: CodeBlock): Builder = apply {
+    override fun addCode(codeBlock: CodeBlock): Builder = apply {
       check(isScript) { "addCode() is only allowed in script files" }
       body.add(codeBlock)
     }
@@ -488,7 +489,7 @@ private constructor(builder: Builder, private val tagMap: TagMap = builder.build
      * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
      *   Shouldn't contain braces or newline characters.
      */
-    public fun beginControlFlow(controlFlow: String, vararg args: Any): Builder = apply {
+    override fun beginControlFlow(controlFlow: String, vararg args: Any?): Builder = apply {
       check(isScript) { "beginControlFlow() is only allowed in script files" }
       body.beginControlFlow(controlFlow, *args)
     }
@@ -497,22 +498,22 @@ private constructor(builder: Builder, private val tagMap: TagMap = builder.build
      * @param controlFlow the control flow construct and its code, such as "else if (foo == 10)".
      *   Shouldn't contain braces or newline characters.
      */
-    public fun nextControlFlow(controlFlow: String, vararg args: Any): Builder = apply {
+    override fun nextControlFlow(controlFlow: String, vararg args: Any?): Builder = apply {
       check(isScript) { "nextControlFlow() is only allowed in script files" }
       body.nextControlFlow(controlFlow, *args)
     }
 
-    public fun endControlFlow(): Builder = apply {
+    override fun endControlFlow(): Builder = apply {
       check(isScript) { "endControlFlow() is only allowed in script files" }
       body.endControlFlow()
     }
 
-    public fun addStatement(format: String, vararg args: Any): Builder = apply {
+    override fun addStatement(format: String, vararg args: Any?): Builder = apply {
       check(isScript) { "addStatement() is only allowed in script files" }
       body.addStatement(format, *args)
     }
 
-    public fun clearBody(): Builder = apply {
+    override fun clearBody(): Builder = apply {
       check(isScript) { "clearBody() is only allowed in script files" }
       body.clear()
     }

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
@@ -281,7 +281,7 @@ private constructor(builder: Builder, private val tagMap: TagMap = builder.build
       get() = memberImports.toList()
 
     public val members: MutableList<Any> = mutableListOf()
-    override val body: CodeBlock.Builder = CodeBlock.builder()
+    internal val body = CodeBlock.builder()
 
     /**
      * Add an annotation to the file.
@@ -464,19 +464,19 @@ private constructor(builder: Builder, private val tagMap: TagMap = builder.build
 
     public fun indent(indent: String): Builder = apply { this.indent = indent }
 
-    override fun addCode(format: String, vararg args: Any?): Builder {
+    override fun addCode(format: String, vararg args: Any?): Builder = apply {
       check(isScript) { "addCode() is only allowed in script files" }
-      return super.addCode(format, *args)
+      body.add(format, *args)
     }
 
-    override fun addNamedCode(format: String, args: Map<String, *>): Builder {
+    override fun addNamedCode(format: String, args: Map<String, *>): Builder = apply {
       check(isScript) { "addNamedCode() is only allowed in script files" }
-      return super.addNamedCode(format, args)
+      body.addNamed(format, args)
     }
 
-    override fun addCode(codeBlock: CodeBlock): Builder {
+    override fun addCode(codeBlock: CodeBlock): Builder = apply {
       check(isScript) { "addCode() is only allowed in script files" }
-      return super.addCode(codeBlock)
+      body.add(codeBlock)
     }
 
     /** Adds a comment to the body of this script file in the order that it was added. */
@@ -485,29 +485,37 @@ private constructor(builder: Builder, private val tagMap: TagMap = builder.build
       body.add("// $format\n", *args)
     }
 
-    override fun beginControlFlow(controlFlow: String, vararg args: Any?): Builder {
+    /**
+     * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
+     *   Shouldn't contain braces or newline characters.
+     */
+    override fun beginControlFlow(controlFlow: String, vararg args: Any?): Builder = apply {
       check(isScript) { "beginControlFlow() is only allowed in script files" }
-      return super.beginControlFlow(controlFlow, *args)
+      body.beginControlFlow(controlFlow, *args)
     }
 
-    override fun nextControlFlow(controlFlow: String, vararg args: Any?): Builder {
+    /**
+     * @param controlFlow the control flow construct and its code, such as "else if (foo == 10)".
+     *   Shouldn't contain braces or newline characters.
+     */
+    override fun nextControlFlow(controlFlow: String, vararg args: Any?): Builder = apply {
       check(isScript) { "nextControlFlow() is only allowed in script files" }
-      return super.nextControlFlow(controlFlow, *args)
+      body.nextControlFlow(controlFlow, *args)
     }
 
-    override fun endControlFlow(): Builder {
+    override fun endControlFlow(): Builder = apply {
       check(isScript) { "endControlFlow() is only allowed in script files" }
-      return super.endControlFlow()
+      body.endControlFlow()
     }
 
-    override fun addStatement(format: String, vararg args: Any?): Builder {
+    override fun addStatement(format: String, vararg args: Any?): Builder = apply {
       check(isScript) { "addStatement() is only allowed in script files" }
-      return super.addStatement(format, *args)
+      body.addStatement(format, *args)
     }
 
-    override fun clearBody(): Builder {
+    override fun clearBody(): Builder = apply {
       check(isScript) { "clearBody() is only allowed in script files" }
-      return super.clearBody()
+      body.clear()
     }
 
     // region Overrides for binary compatibility

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
@@ -47,7 +47,8 @@ private constructor(
   ContextReceivable by contextReceivers,
   ContextParameterizable by contextParams,
   Annotatable,
-  Documentable {
+  Documentable,
+  CodeBlockHolder {
   public val name: String = builder.name
   override val kdoc: CodeBlock = builder.kdoc.build()
   public val returnKdoc: CodeBlock = builder.returnKdoc
@@ -62,7 +63,7 @@ private constructor(
   public val delegateConstructor: String? = builder.delegateConstructor
   public val delegateConstructorArguments: List<CodeBlock> =
     builder.delegateConstructorArguments.toImmutableList()
-  public val body: CodeBlock = builder.body.build()
+  override val body: CodeBlock = builder.body.build()
   private val isExternalGetter = name == GETTER && builder.modifiers.contains(EXTERNAL)
   private val isEmptySetter = name == SETTER && parameters.isEmpty()
 
@@ -318,7 +319,8 @@ private constructor(
     ContextReceivable.Builder<Builder>,
     ContextParameterizable.Builder<Builder>,
     Annotatable.Builder<Builder>,
-    Documentable.Builder<Builder> {
+    Documentable.Builder<Builder>,
+    CodeBlockHolder.Builder<Builder> {
     internal var returnKdoc = CodeBlock.EMPTY
     internal var receiverKdoc = CodeBlock.EMPTY
     internal var receiverType: TypeName? = null
@@ -507,15 +509,15 @@ private constructor(
       modifiers: Iterable<KModifier>,
     ): Builder = addParameter(name, type.asTypeName(), modifiers)
 
-    public fun addCode(format: String, vararg args: Any?): Builder = apply {
+    override fun addCode(format: String, vararg args: Any?): Builder = apply {
       body.add(format, *args)
     }
 
-    public fun addNamedCode(format: String, args: Map<String, *>): Builder = apply {
+    override fun addNamedCode(format: String, args: Map<String, *>): Builder = apply {
       body.addNamed(format, args)
     }
 
-    public fun addCode(codeBlock: CodeBlock): Builder = apply { body.add(codeBlock) }
+    override fun addCode(codeBlock: CodeBlock): Builder = apply { body.add(codeBlock) }
 
     public fun addComment(format: String, vararg args: Any): Builder = apply {
       body.add("// $format\n", *args)
@@ -525,7 +527,7 @@ private constructor(
      * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
      * * Shouldn't contain braces or newline characters.
      */
-    public fun beginControlFlow(controlFlow: String, vararg args: Any?): Builder = apply {
+    override fun beginControlFlow(controlFlow: String, vararg args: Any?): Builder = apply {
       body.beginControlFlow(controlFlow, *args)
     }
 
@@ -533,17 +535,17 @@ private constructor(
      * @param controlFlow the control flow construct and its code, such as "else if (foo == 10)".
      * * Shouldn't contain braces or newline characters.
      */
-    public fun nextControlFlow(controlFlow: String, vararg args: Any): Builder = apply {
+    override fun nextControlFlow(controlFlow: String, vararg args: Any?): Builder = apply {
       body.nextControlFlow(controlFlow, *args)
     }
 
-    public fun endControlFlow(): Builder = apply { body.endControlFlow() }
+    override fun endControlFlow(): Builder = apply { body.endControlFlow() }
 
-    public fun addStatement(format: String, vararg args: Any): Builder = apply {
+    override fun addStatement(format: String, vararg args: Any?): Builder = apply {
       body.addStatement(format, *args)
     }
 
-    public fun clearBody(): Builder = apply { body.clear() }
+    override fun clearBody(): Builder = apply { body.clear() }
 
     // region Overrides for binary compatibility
     @Suppress("RedundantOverride")

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
@@ -327,7 +327,7 @@ private constructor(
     internal var returnType: TypeName = UNIT
     internal var delegateConstructor: String? = null
     internal var delegateConstructorArguments = listOf<CodeBlock>()
-    internal val body = CodeBlock.builder()
+    override val body: CodeBlock.Builder = CodeBlock.builder()
     override val kdoc: CodeBlock.Builder = CodeBlock.builder()
     override val annotations: MutableList<AnnotationSpec> = mutableListOf()
     public val modifiers: MutableList<KModifier> = mutableListOf()
@@ -509,43 +509,9 @@ private constructor(
       modifiers: Iterable<KModifier>,
     ): Builder = addParameter(name, type.asTypeName(), modifiers)
 
-    override fun addCode(format: String, vararg args: Any?): Builder = apply {
-      body.add(format, *args)
-    }
-
-    override fun addNamedCode(format: String, args: Map<String, *>): Builder = apply {
-      body.addNamed(format, args)
-    }
-
-    override fun addCode(codeBlock: CodeBlock): Builder = apply { body.add(codeBlock) }
-
     public fun addComment(format: String, vararg args: Any): Builder = apply {
       body.add("// $format\n", *args)
     }
-
-    /**
-     * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
-     * * Shouldn't contain braces or newline characters.
-     */
-    override fun beginControlFlow(controlFlow: String, vararg args: Any?): Builder = apply {
-      body.beginControlFlow(controlFlow, *args)
-    }
-
-    /**
-     * @param controlFlow the control flow construct and its code, such as "else if (foo == 10)".
-     * * Shouldn't contain braces or newline characters.
-     */
-    override fun nextControlFlow(controlFlow: String, vararg args: Any?): Builder = apply {
-      body.nextControlFlow(controlFlow, *args)
-    }
-
-    override fun endControlFlow(): Builder = apply { body.endControlFlow() }
-
-    override fun addStatement(format: String, vararg args: Any?): Builder = apply {
-      body.addStatement(format, *args)
-    }
-
-    override fun clearBody(): Builder = apply { body.clear() }
 
     // region Overrides for binary compatibility
     @Suppress("RedundantOverride")
@@ -574,6 +540,32 @@ private constructor(
 
     @Suppress("RedundantOverride")
     override fun addKdoc(block: CodeBlock): Builder = super.addKdoc(block)
+
+    @Suppress("RedundantOverride")
+    override fun addCode(format: String, vararg args: Any?): Builder = super.addCode(format, *args)
+
+    @Suppress("RedundantOverride")
+    override fun addCode(codeBlock: CodeBlock): Builder = super.addCode(codeBlock)
+
+    @Suppress("RedundantOverride")
+    override fun addNamedCode(format: String, args: Map<String, *>): Builder =
+      super.addNamedCode(format, args)
+
+    @Suppress("RedundantOverride")
+    override fun addStatement(format: String, vararg args: Any?): Builder =
+      super.addStatement(format, *args)
+
+    @Suppress("RedundantOverride")
+    override fun beginControlFlow(controlFlow: String, vararg args: Any?): Builder =
+      super.beginControlFlow(controlFlow, *args)
+
+    @Suppress("RedundantOverride")
+    override fun nextControlFlow(controlFlow: String, vararg args: Any?): Builder =
+      super.nextControlFlow(controlFlow, *args)
+
+    @Suppress("RedundantOverride") override fun endControlFlow(): Builder = super.endControlFlow()
+
+    @Suppress("RedundantOverride") override fun clearBody(): Builder = super.clearBody()
 
     // endregion
 

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
@@ -327,7 +327,7 @@ private constructor(
     internal var returnType: TypeName = UNIT
     internal var delegateConstructor: String? = null
     internal var delegateConstructorArguments = listOf<CodeBlock>()
-    override val body: CodeBlock.Builder = CodeBlock.builder()
+    internal val body = CodeBlock.builder()
     override val kdoc: CodeBlock.Builder = CodeBlock.builder()
     override val annotations: MutableList<AnnotationSpec> = mutableListOf()
     public val modifiers: MutableList<KModifier> = mutableListOf()
@@ -509,9 +509,43 @@ private constructor(
       modifiers: Iterable<KModifier>,
     ): Builder = addParameter(name, type.asTypeName(), modifiers)
 
+    override fun addCode(format: String, vararg args: Any?): Builder = apply {
+      body.add(format, *args)
+    }
+
+    override fun addNamedCode(format: String, args: Map<String, *>): Builder = apply {
+      body.addNamed(format, args)
+    }
+
+    override fun addCode(codeBlock: CodeBlock): Builder = apply { body.add(codeBlock) }
+
     public fun addComment(format: String, vararg args: Any): Builder = apply {
       body.add("// $format\n", *args)
     }
+
+    /**
+     * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
+     * * Shouldn't contain braces or newline characters.
+     */
+    override fun beginControlFlow(controlFlow: String, vararg args: Any?): Builder = apply {
+      body.beginControlFlow(controlFlow, *args)
+    }
+
+    /**
+     * @param controlFlow the control flow construct and its code, such as "else if (foo == 10)".
+     * * Shouldn't contain braces or newline characters.
+     */
+    override fun nextControlFlow(controlFlow: String, vararg args: Any?): Builder = apply {
+      body.nextControlFlow(controlFlow, *args)
+    }
+
+    override fun endControlFlow(): Builder = apply { body.endControlFlow() }
+
+    override fun addStatement(format: String, vararg args: Any?): Builder = apply {
+      body.addStatement(format, *args)
+    }
+
+    override fun clearBody(): Builder = apply { body.clear() }
 
     // region Overrides for binary compatibility
     @Suppress("RedundantOverride")
@@ -540,32 +574,6 @@ private constructor(
 
     @Suppress("RedundantOverride")
     override fun addKdoc(block: CodeBlock): Builder = super.addKdoc(block)
-
-    @Suppress("RedundantOverride")
-    override fun addCode(format: String, vararg args: Any?): Builder = super.addCode(format, *args)
-
-    @Suppress("RedundantOverride")
-    override fun addCode(codeBlock: CodeBlock): Builder = super.addCode(codeBlock)
-
-    @Suppress("RedundantOverride")
-    override fun addNamedCode(format: String, args: Map<String, *>): Builder =
-      super.addNamedCode(format, args)
-
-    @Suppress("RedundantOverride")
-    override fun addStatement(format: String, vararg args: Any?): Builder =
-      super.addStatement(format, *args)
-
-    @Suppress("RedundantOverride")
-    override fun beginControlFlow(controlFlow: String, vararg args: Any?): Builder =
-      super.beginControlFlow(controlFlow, *args)
-
-    @Suppress("RedundantOverride")
-    override fun nextControlFlow(controlFlow: String, vararg args: Any?): Builder =
-      super.nextControlFlow(controlFlow, *args)
-
-    @Suppress("RedundantOverride") override fun endControlFlow(): Builder = super.endControlFlow()
-
-    @Suppress("RedundantOverride") override fun clearBody(): Builder = super.clearBody()
 
     // endregion
 


### PR DESCRIPTION
Holds a `CodeBlock` body. On `FileSpec` the code methods stay script-only, as before.

Part of #1553

- [x] `docs/changelog.md` has been updated if applicable.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
