### PR TITLE
Fix delegated constructor multiline formatting

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@ Change Log
  * New: Support for explicit backing fields. (#2325)
  * New: `value class` validations have been relaxed to support multi-field value classes. (#2329)
  * Fix: Keep the `//` prefix on wrapped file comment lines. (#1922)
+ * Fix: Indent multiline delegated constructor calls correctly. (#1762)
  * Fix: `TypeVariableName.equals`/`hashCode` no longer overflow on recursively bound generics like `Enum<E : Enum<E>>`. (#1737)
 
 ## Version 2.3.0

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
@@ -175,7 +175,7 @@ private constructor(
 
     if (delegateConstructor != null) {
       codeWriter.emitCode(
-        delegateConstructorArguments.joinToCode(prefix = " : $delegateConstructor(", suffix = ")")
+        delegateConstructorArguments.toDelegateConstructorCode(delegateConstructor)
       )
     }
   }
@@ -693,3 +693,39 @@ private constructor(
     }
   }
 }
+
+private fun List<CodeBlock>.toDelegateConstructorCode(delegateConstructor: String): CodeBlock {
+  if (none(CodeBlock::isMultilineCode)) {
+    return joinToCode(prefix = " : $delegateConstructor(", suffix = ")")
+  }
+
+  return buildCodeBlock {
+    add(" : %L(\n⇥", delegateConstructor)
+    forEachIndexed { index, argument ->
+      if (index > 0) add("\n")
+      add("%L,", argument.trimTrailingNewLine())
+    }
+    add("\n⇤)")
+  }
+}
+
+private fun CodeBlock.isMultilineCode(): Boolean {
+  var argumentIndex = 0
+  for (formatPart in formatParts) {
+    if ('\n' in formatPart) return true
+
+    if (formatPart == "%L") {
+      when (val argument = args[argumentIndex]) {
+        is CodeBlock -> if (argument.isMultilineCode()) return true
+        is String -> if ('\n' in argument) return true
+      }
+    }
+
+    if (formatPart in ARGUMENT_PLACEHOLDERS) {
+      argumentIndex++
+    }
+  }
+  return false
+}
+
+private val ARGUMENT_PLACEHOLDERS = setOf("%L", "%N", "%S", "%P", "%T", "%M")

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.kotlinpoet
 
+import com.squareup.kotlinpoet.CodeBlock.Companion.isPlaceholder
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
 import com.squareup.kotlinpoet.KModifier.EXPECT
 import com.squareup.kotlinpoet.KModifier.EXTERNAL
@@ -695,17 +696,16 @@ private constructor(
 }
 
 private fun List<CodeBlock>.toDelegateConstructorCode(delegateConstructor: String): CodeBlock {
-  if (none(CodeBlock::isMultilineCode)) {
-    return joinToCode(prefix = " : $delegateConstructor(", suffix = ")")
-  }
-
-  return buildCodeBlock {
-    add(" : %L(\n⇥", delegateConstructor)
-    forEachIndexed { index, argument ->
-      if (index > 0) add("\n")
-      add("%L,", argument.trimTrailingNewLine())
+  return if (none(CodeBlock::isMultilineCode)) {
+    joinToCode(prefix = " : $delegateConstructor(", suffix = ")")
+  } else {
+    joinToCode(
+      prefix = " : $delegateConstructor(\n⇥",
+      separator = "\n",
+      suffix = "\n⇤)",
+    ) { argument ->
+      CodeBlock.of("%L,", argument.trimTrailingNewLine())
     }
-    add("\n⇤)")
   }
 }
 
@@ -721,11 +721,9 @@ private fun CodeBlock.isMultilineCode(): Boolean {
       }
     }
 
-    if (formatPart in ARGUMENT_PLACEHOLDERS) {
+    if (formatPart.isPlaceholder) {
       argumentIndex++
     }
   }
   return false
 }
-
-private val ARGUMENT_PLACEHOLDERS = setOf("%L", "%N", "%S", "%P", "%T", "%M")

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/Util.jvm.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/Util.jvm.kt
@@ -31,7 +31,7 @@ internal actual fun <T> Collection<T>.toImmutableSet(): Set<T> =
 internal fun CodeBlock.ensureEndsWithNewLine() = trimTrailingNewLine('\n')
 
 // TODO Waiting for `CodeBlock` migration.
-internal fun CodeBlock.trimTrailingNewLine(replaceWith: Char? = null) =
+internal fun CodeBlock.trimTrailingNewLine(replaceWith: Char? = null): CodeBlock =
   if (isEmpty()) {
     this
   } else {
@@ -39,14 +39,20 @@ internal fun CodeBlock.trimTrailingNewLine(replaceWith: Char? = null) =
       val lastFormatPart = trim().formatParts.last()
       if (lastFormatPart.isPlaceholder && args.isNotEmpty()) {
         val lastArg = args.last()
-        if (lastArg is String) {
-          val trimmedArg = lastArg.trimEnd('\n')
-          args[args.size - 1] =
-            if (replaceWith != null) {
-              trimmedArg + replaceWith
-            } else {
-              trimmedArg
-            }
+        when (lastArg) {
+          is String -> {
+            val trimmedArg = lastArg.trimEnd('\n')
+            args[args.size - 1] =
+              if (replaceWith != null) {
+                trimmedArg + replaceWith
+              } else {
+                trimmedArg
+              }
+          }
+          is CodeBlock -> {
+            args[args.size - 1] = lastArg.trimTrailingNewLine(replaceWith)
+          }
+          else -> Unit
         }
       } else {
         formatParts[formatParts.lastIndexOf(lastFormatPart)] = lastFormatPart.trimEnd('\n')

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/CodeBlockTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/CodeBlockTest.kt
@@ -618,6 +618,25 @@ class CodeBlockTest {
   }
 
   @Test
+  fun ensureEndsWithNewLineWithNestedCodeBlockArg() {
+    val codeBlock =
+      CodeBlock.of(
+        "%L",
+        buildCodeBlock {
+          addStatement("Statement with nested arg")
+        },
+      )
+
+    assertThat(codeBlock.ensureEndsWithNewLine().toString())
+      .isEqualTo(
+        """
+        |Statement with nested arg
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
   fun `N escapes keywords`() {
     val funSpec = FunSpec.builder("object").build()
     assertThat(CodeBlock.of("%N", funSpec).toString()).isEqualTo("`object`")

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -1032,6 +1032,155 @@ class FunSpecTest {
   }
 
   @Test
+  fun thisConstructorDelegateWithMultilineArgument() {
+    val typeSpec =
+      TypeSpec.classBuilder("Test")
+        .primaryConstructor(FunSpec.constructorBuilder().build())
+        .addFunction(
+          FunSpec.constructorBuilder()
+            .addParameter("name", STRING)
+            .callThisConstructor(
+              CodeBlock.of("name"),
+              buildCodeBlock {
+                beginControlFlow("computeValue")
+                addStatement("fallback()")
+                endControlFlow()
+              },
+            )
+            .build()
+        )
+        .build()
+
+    assertThat(typeSpec.toString())
+      .isEqualTo(
+        """
+        |public class Test() {
+        |  public constructor(name: kotlin.String) : this(
+        |    name,
+        |    computeValue {
+        |      fallback()
+        |    },
+        |  )
+        |}
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
+  fun superConstructorDelegateWithMultilineArgument() {
+    val funSpec =
+      FunSpec.constructorBuilder()
+        .addParameter("name", STRING)
+        .callSuperConstructor(
+          buildCodeBlock {
+            beginControlFlow("computeValue")
+            addStatement("fallback()")
+            endControlFlow()
+          }
+        )
+        .build()
+
+    assertThat(funSpec.toString())
+      .isEqualTo(
+        """
+        |public constructor(name: kotlin.String) : super(
+        |  computeValue {
+        |    fallback()
+        |  },
+        |)
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
+  fun thisConstructorDelegateWithMultilineArgumentAndBody() {
+    val typeSpec =
+      TypeSpec.classBuilder("Test")
+        .primaryConstructor(FunSpec.constructorBuilder().build())
+        .addFunction(
+          FunSpec.constructorBuilder()
+            .addParameter("name", STRING)
+            .callThisConstructor(
+              buildCodeBlock {
+                beginControlFlow("computeValue")
+                addStatement("fallback()")
+                endControlFlow()
+              }
+            )
+            .addStatement("println(name)")
+            .build()
+        )
+        .build()
+
+    assertThat(typeSpec.toString())
+      .isEqualTo(
+        """
+        |public class Test() {
+        |  public constructor(name: kotlin.String) : this(
+        |    computeValue {
+        |      fallback()
+        |    },
+        |  ) {
+        |    println(name)
+        |  }
+        |}
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
+  fun thisConstructorDelegateWithNewlineStringLiteralStaysUnexpanded() {
+    val funSpec =
+      FunSpec.constructorBuilder()
+        .addParameter("name", STRING)
+        .callThisConstructor(CodeBlock.of("%S", "alpha\nbeta"))
+        .build()
+
+    assertThat(funSpec.toString())
+      .isEqualTo(
+        """
+        |public constructor(name: kotlin.String) : this(${"\"\"\""}
+        ||alpha
+        ||beta
+        |${"\"\"\""}.trimMargin())
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
+  fun thisConstructorDelegateWithLongSingleLineArgumentStaysOneLine() {
+    val argument = "name" + "Access".repeat(20)
+    val typeSpec =
+      TypeSpec.classBuilder("Test")
+        .primaryConstructor(FunSpec.constructorBuilder().build())
+        .addFunction(
+          FunSpec.constructorBuilder()
+            .addParameter("name", STRING)
+            .callThisConstructor(CodeBlock.of("%L", argument))
+            .build()
+        )
+        .build()
+
+    assertThat(FileSpec.get("com.squareup.test", typeSpec).toString())
+      .isEqualTo(
+        """
+        |package com.squareup.test
+        |
+        |import kotlin.String
+        |
+        |public class Test() {
+        |  public constructor(name: String) : this($argument)
+        |}
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
   fun addingDelegateParametersToNonConstructorForbidden() {
     assertFailure { FunSpec.builder("main").callThisConstructor("a", "b", "c") }
       .isInstanceOf<IllegalStateException>()

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -1035,7 +1035,6 @@ class FunSpecTest {
   fun thisConstructorDelegateWithMultilineArgument() {
     val typeSpec =
       TypeSpec.classBuilder("Test")
-        .primaryConstructor(FunSpec.constructorBuilder().build())
         .addFunction(
           FunSpec.constructorBuilder()
             .addParameter("name", STRING)
@@ -1054,7 +1053,7 @@ class FunSpecTest {
     assertThat(typeSpec.toString())
       .isEqualTo(
         """
-        |public class Test() {
+        |public class Test {
         |  public constructor(name: kotlin.String) : this(
         |    name,
         |    computeValue {
@@ -1071,7 +1070,6 @@ class FunSpecTest {
   fun thisConstructorDelegateWithReorderedIndexedMultilineArgument() {
     val typeSpec =
       TypeSpec.classBuilder("Test")
-        .primaryConstructor(FunSpec.constructorBuilder().build())
         .addFunction(
           FunSpec.constructorBuilder()
             .addParameter("name", STRING)
@@ -1093,7 +1091,7 @@ class FunSpecTest {
     assertThat(typeSpec.toString())
       .isEqualTo(
         """
-        |public class Test() {
+        |public class Test {
         |  public constructor(name: kotlin.String) : this(
         |    name,
         |    computeValue {

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -1068,6 +1068,45 @@ class FunSpecTest {
   }
 
   @Test
+  fun thisConstructorDelegateWithReorderedIndexedMultilineArgument() {
+    val typeSpec =
+      TypeSpec.classBuilder("Test")
+        .primaryConstructor(FunSpec.constructorBuilder().build())
+        .addFunction(
+          FunSpec.constructorBuilder()
+            .addParameter("name", STRING)
+            .callThisConstructor(
+              CodeBlock.of(
+                "%2L,\n%1L",
+                buildCodeBlock {
+                  beginControlFlow("computeValue")
+                  addStatement("fallback()")
+                  endControlFlow()
+                },
+                "name",
+              )
+            )
+            .build()
+        )
+        .build()
+
+    assertThat(typeSpec.toString())
+      .isEqualTo(
+        """
+        |public class Test() {
+        |  public constructor(name: kotlin.String) : this(
+        |    name,
+        |    computeValue {
+        |      fallback()
+        |    },
+        |  )
+        |}
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
   fun superConstructorDelegateWithMultilineArgument() {
     val funSpec =
       FunSpec.constructorBuilder()


### PR DESCRIPTION
Fixes #1762.

## Summary

- Preserve the existing one-line delegated constructor formatting for simple `this(...)` / `super(...)` calls.
- Expand delegated constructor calls to one argument per line when any delegated constructor argument explicitly emits multiline code.
- Cover `this`, `super`, constructor body formatting, newline string literals, and long single-line arguments with exact output tests.

Note: the multiline predicate intentionally targets explicit emitted newlines in `CodeBlock` formatting. String literal contents emitted via `%S` / `%P` are left on the existing path so raw/string-literal newlines do not force expanded delegated-call formatting.

## Test plan

- `./gradlew :kotlinpoet:jvmTest --tests com.squareup.kotlinpoet.FunSpecTest`
- `./gradlew :kotlinpoet:apiCheck`
- `git diff --check`
- `./gradlew clean build`

- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [ ] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
