### PR TITLE
Disallow the deprecated `inline class` syntax

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ Change Log
 
  * New: Support for explicit backing fields. (#2325)
  * New: `value class` validations have been relaxed to support multi-field value classes. (#2329)
+ * New: Disallow the deprecated `inline class` syntax. Use `value` classes instead. (#2330)
  * New: Extract `CodeBlockHolder` interface for constructs that can hold a `CodeBlock` body and their builders. (#1553)
  * Fix: Keep the `//` prefix on wrapped file comment lines. (#1922)
  * Fix: `TypeVariableName.equals`/`hashCode` no longer overflow on recursively bound generics like `Enum<E : Enum<E>>`. (#1737)

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/TypeSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/TypeSpec.kt
@@ -544,8 +544,8 @@ private constructor(
     internal val isCompanion
       get() = kind == Kind.OBJECT && COMPANION in modifiers
 
-    internal val isInlineOrValClass
-      get() = kind == Kind.CLASS && (INLINE in modifiers || VALUE in modifiers)
+    internal val isValueClass
+      get() = kind == Kind.CLASS && VALUE in modifiers
 
     internal val isSimpleClass
       get() = kind == Kind.CLASS && !isEnum && !isAnnotation
@@ -599,9 +599,9 @@ private constructor(
           "expected a constructor but was ${primaryConstructor.name}"
         }
 
-        if (isInlineOrValClass) {
+        if (isValueClass) {
           check(primaryConstructor.parameters.size >= 1) {
-            "value/inline classes must have at least 1 parameter in constructor"
+            "value classes must have at least 1 parameter in constructor"
           }
         }
 
@@ -625,7 +625,7 @@ private constructor(
       check(isSimpleClass || kind == Kind.OBJECT) {
         "only classes can have super classes, not $kind"
       }
-      check(!isInlineOrValClass) { "value/inline classes cannot have super classes" }
+      check(!isValueClass) { "value classes cannot have super classes" }
     }
 
     private fun checkCanHaveInitializerBlocks() {
@@ -841,6 +841,13 @@ private constructor(
     // endregion
 
     public fun build(): TypeSpec {
+      if (kind == Kind.CLASS && INLINE in modifiers) {
+        throw IllegalArgumentException(
+          "KotlinPoet doesn't allow setting the inline modifier on " +
+            "classes. You should use the value modifier instead."
+        )
+      }
+
       if (enumConstants.isNotEmpty()) {
         check(isEnum) { "$name is not an enum and cannot have enum constants" }
       }
@@ -938,28 +945,24 @@ private constructor(
         }
       }
 
-      if (isInlineOrValClass) {
+      if (isValueClass) {
         val primaryConstructor =
-          checkNotNull(primaryConstructor) {
-              "value/inline classes must have a primary constructor"
-            }
+          checkNotNull(primaryConstructor) { "value classes must have a primary constructor" }
             .also {
               check(it.parameters.size >= 1) {
-                "value/inline classes must have at least 1 parameter in constructor"
+                "value classes must have at least 1 parameter in constructor"
               }
             }
 
-        check(propertySpecs.size > 0) { "value/inline classes must have at least 1 property" }
+        check(propertySpecs.size > 0) { "value classes must have at least 1 property" }
 
         for (constructorParamName in primaryConstructor.parameters.map { it.name }) {
           val underlyingProperty = propertySpecs.find { it.name == constructorParamName }
           check(underlyingProperty != null && !underlyingProperty.mutable) {
-            "value/inline classes must only have final read-only (val) property parameters"
+            "value classes must only have final read-only (val) property parameters"
           }
         }
-        check(superclass == Any::class.asTypeName()) {
-          "value/inline classes cannot have super classes"
-        }
+        check(superclass == Any::class.asTypeName()) { "value classes cannot have super classes" }
       }
 
       if (isFunInterface) {

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/ValueTypeSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/ValueTypeSpecTest.kt
@@ -24,32 +24,13 @@ import com.squareup.kotlinpoet.KModifier.INLINE
 import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.jvm.jvmInline
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 
-@RunWith(Parameterized::class)
-class ValueTypeSpecTest(private val useValue: Boolean) {
+class ValueTypeSpecTest {
 
-  companion object {
-    @JvmStatic
-    @Parameterized.Parameters(name = "value={0}")
-    fun data(): Collection<Array<Any>> {
-      return listOf(arrayOf(true), arrayOf(false))
-    }
-  }
-
-  private val modifier = if (useValue) KModifier.VALUE else INLINE
-  private val modifierString = modifier.keyword
-
-  private fun classBuilder() =
-    if (useValue) {
-      TypeSpec.classBuilder("Guacamole").addModifiers(KModifier.VALUE)
-    } else {
-      TypeSpec.classBuilder("Guacamole").addModifiers(modifier)
-    }
+  private fun classBuilder() = TypeSpec.classBuilder("Guacamole").addModifiers(KModifier.VALUE)
 
   @Test
-  fun validInlineClass() {
+  fun validValueClass() {
     val guacamole =
       classBuilder()
         .primaryConstructor(
@@ -61,17 +42,16 @@ class ValueTypeSpecTest(private val useValue: Boolean) {
     assertThat(guacamole.toString())
       .isEqualTo(
         """
-      |public $modifierString class Guacamole(
-      |  public val avacado: kotlin.String,
-      |)
-      |
-      """
+        |public value class Guacamole(
+        |  public val avacado: kotlin.String,
+        |)
+        |"""
           .trimMargin()
       )
   }
 
   @Test
-  fun inlineClassWithInitBlock() {
+  fun valueClassWithInitBlock() {
     val guacamole =
       classBuilder()
         .primaryConstructor(
@@ -84,22 +64,21 @@ class ValueTypeSpecTest(private val useValue: Boolean) {
     assertThat(guacamole.toString())
       .isEqualTo(
         """
-      |public $modifierString class Guacamole(
-      |  public val avacado: kotlin.String,
-      |) {
-      |  init {
-      |  }
-      |}
-      |
-      """
+        |public value class Guacamole(
+        |  public val avacado: kotlin.String,
+        |) {
+        |  init {
+        |  }
+        |}
+        |"""
           .trimMargin()
       )
   }
 
-  class InlineSuperClass
+  class ValueSuperClass
 
   @Test
-  fun inlineClassWithSuperClass() {
+  fun valueClassWithSuperClass() {
     assertFailure {
         classBuilder()
           .primaryConstructor(
@@ -108,40 +87,39 @@ class ValueTypeSpecTest(private val useValue: Boolean) {
           .addProperty(
             PropertySpec.builder("avocado", String::class).initializer("avocado").build()
           )
-          .superclass(InlineSuperClass::class)
+          .superclass(ValueSuperClass::class)
           .build()
       }
       .isInstanceOf<IllegalStateException>()
-      .hasMessage("value/inline classes cannot have super classes")
+      .hasMessage("value classes cannot have super classes")
   }
 
-  interface InlineSuperInterface
+  interface ValueSuperInterface
 
   @Test
-  fun inlineClassInheritsFromInterface() {
+  fun valueClassInheritsFromInterface() {
     val guacamole =
       classBuilder()
         .primaryConstructor(
           FunSpec.constructorBuilder().addParameter("avocado", String::class).build()
         )
         .addProperty(PropertySpec.builder("avocado", String::class).initializer("avocado").build())
-        .addSuperinterface(InlineSuperInterface::class)
+        .addSuperinterface(ValueSuperInterface::class)
         .build()
 
     assertThat(guacamole.toString())
       .isEqualTo(
         """
-      |public $modifierString class Guacamole(
-      |  public val avocado: kotlin.String,
-      |) : com.squareup.kotlinpoet.ValueTypeSpecTest.InlineSuperInterface
-      |
-      """
+        |public value class Guacamole(
+        |  public val avocado: kotlin.String,
+        |) : com.squareup.kotlinpoet.ValueTypeSpecTest.ValueSuperInterface
+        |"""
           .trimMargin()
       )
   }
 
   @Test
-  fun inlineClassWithoutBackingProperty() {
+  fun valueClassWithoutBackingProperty() {
     assertFailure {
         classBuilder()
           .primaryConstructor(
@@ -151,11 +129,11 @@ class ValueTypeSpecTest(private val useValue: Boolean) {
           .build()
       }
       .isInstanceOf<IllegalStateException>()
-      .hasMessage("value/inline classes must only have final read-only (val) property parameters")
+      .hasMessage("value classes must only have final read-only (val) property parameters")
   }
 
   @Test
-  fun inlineClassWithoutProperties() {
+  fun valueClassWithoutProperties() {
     assertFailure {
         classBuilder()
           .primaryConstructor(
@@ -164,11 +142,11 @@ class ValueTypeSpecTest(private val useValue: Boolean) {
           .build()
       }
       .isInstanceOf<IllegalStateException>()
-      .hasMessage("value/inline classes must have at least 1 property")
+      .hasMessage("value classes must have at least 1 property")
   }
 
   @Test
-  fun inlineClassWithMutableProperties() {
+  fun valueClassWithMutableProperties() {
     assertFailure {
         classBuilder()
           .primaryConstructor(
@@ -180,11 +158,11 @@ class ValueTypeSpecTest(private val useValue: Boolean) {
           .build()
       }
       .isInstanceOf<IllegalStateException>()
-      .hasMessage("value/inline classes must only have final read-only (val) property parameters")
+      .hasMessage("value classes must only have final read-only (val) property parameters")
   }
 
   @Test
-  fun inlineClassWithPrivateConstructor() {
+  fun valueClassWithPrivateConstructor() {
     val guacamole =
       classBuilder()
         .primaryConstructor(
@@ -199,20 +177,19 @@ class ValueTypeSpecTest(private val useValue: Boolean) {
     assertThat(guacamole.toString())
       .isEqualTo(
         """
-      |public $modifierString class Guacamole private constructor(
-      |  public val avocado: kotlin.String,
-      |)
-      |
-      """
+        |public value class Guacamole private constructor(
+        |  public val avocado: kotlin.String,
+        |)
+        |"""
           .trimMargin()
       )
   }
 
   @Test
-  fun inlineEnumClass() {
+  fun valueEnumClass() {
     val guacamole =
       TypeSpec.enumBuilder("Foo")
-        .addModifiers(modifier)
+        .addModifiers(KModifier.VALUE)
         .primaryConstructor(FunSpec.constructorBuilder().addParameter("x", Int::class).build())
         .addEnumConstant(
           "A",
@@ -227,16 +204,51 @@ class ValueTypeSpecTest(private val useValue: Boolean) {
     assertThat(guacamole.toString())
       .isEqualTo(
         """
-      |public enum $modifierString class Foo(
-      |  public val x: kotlin.Int,
-      |) {
-      |  A(1),
-      |  B(2),
-      |  ;
-      |}
-      |
-      """
+        |public enum value class Foo(
+        |  public val x: kotlin.Int,
+        |) {
+        |  A(1),
+        |  B(2),
+        |  ;
+        |}
+        |"""
           .trimMargin()
+      )
+  }
+
+  @Test
+  fun inlineForbiddenOnClass() {
+    assertFailure {
+        TypeSpec.classBuilder("Guacamole")
+          .addModifiers(INLINE)
+          .primaryConstructor(
+            FunSpec.constructorBuilder().addParameter("avocado", String::class).build()
+          )
+          .addProperty(
+            PropertySpec.builder("avocado", String::class).initializer("avocado").build()
+          )
+          .build()
+      }
+      .isInstanceOf<IllegalArgumentException>()
+      .hasMessage(
+        "KotlinPoet doesn't allow setting the inline modifier on " +
+          "classes. You should use the value modifier instead."
+      )
+  }
+
+  @Test
+  fun inlineForbiddenOnEnum() {
+    assertFailure {
+        TypeSpec.enumBuilder("Foo")
+          .addModifiers(INLINE)
+          .primaryConstructor(FunSpec.constructorBuilder().addParameter("x", Int::class).build())
+          .addProperty(PropertySpec.builder("x", Int::class).initializer("x").build())
+          .build()
+      }
+      .isInstanceOf<IllegalArgumentException>()
+      .hasMessage(
+        "KotlinPoet doesn't allow setting the inline modifier on " +
+          "classes. You should use the value modifier instead."
       )
   }
 


### PR DESCRIPTION
`TypeSpec.classBuilder("Foo").addModifiers(KModifier.INLINE)` still emits `inline class Foo`, five years after the syntax was deprecated in favor of `value` classes. `build()` now rejects the modifier on classes the same way `PropertySpec` already rejects it on properties. The value-class check messages drop the inline wording too.

Fixes #2330.

- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
