### PR TITLE
Don't escape `get` and `set` operator function names

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ Change Log
  * New: Extract `CodeBlockHolder` interface for constructs that can hold a `CodeBlock` body and their builders. (#1553)
  * Fix: Keep the `//` prefix on wrapped file comment lines. (#1922)
  * Fix: `TypeVariableName.equals`/`hashCode` no longer overflow on recursively bound generics like `Enum<E : Enum<E>>`. (#1737)
+ * Fix: `get` and `set` operator function names are no longer escaped with backticks. (#1869)
 
 ## Version 2.3.0
 

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
@@ -19,6 +19,7 @@ import com.squareup.kotlinpoet.KModifier.ABSTRACT
 import com.squareup.kotlinpoet.KModifier.EXPECT
 import com.squareup.kotlinpoet.KModifier.EXTERNAL
 import com.squareup.kotlinpoet.KModifier.INLINE
+import com.squareup.kotlinpoet.KModifier.OPERATOR
 import com.squareup.kotlinpoet.KModifier.VARARG
 import java.lang.reflect.Type
 import javax.lang.model.element.Element
@@ -163,7 +164,13 @@ private constructor(
           codeWriter.emitCode("%T.", receiverType)
         }
       }
-      codeWriter.emitCode("%N", this)
+      if (OPERATOR in modifiers && (name == "get" || name == "set")) {
+        // %N escapes get/set as soft keywords, but operator overloads must not be escaped.
+        // https://github.com/square/kotlinpoet/issues/1869
+        codeWriter.emitCode("%L", name)
+      } else {
+        codeWriter.emitCode("%N", this)
+      }
     }
 
     if (!isEmptySetter && !isExternalGetter) {

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -228,6 +228,51 @@ class FunSpecTest {
   }
 
   @Test
+  fun operatorGetAndSetNamesAreNotEscaped() {
+    val get =
+      FunSpec.builder("get")
+        .addModifiers(KModifier.OPERATOR)
+        .addParameter("index", Int::class)
+        .returns(Int::class)
+        .addStatement("return values[index]")
+        .build()
+    assertThat(get.toString())
+      .isEqualTo(
+        """
+        |public operator fun get(index: kotlin.Int): kotlin.Int = values[index]
+        |"""
+          .trimMargin()
+      )
+
+    val set =
+      FunSpec.builder("set")
+        .addModifiers(KModifier.OPERATOR)
+        .addParameter("index", Int::class)
+        .addParameter("element", Int::class)
+        .addStatement("values[index] = element")
+        .build()
+    assertThat(set.toString())
+      .isEqualTo(
+        """
+        |public operator fun set(index: kotlin.Int, element: kotlin.Int) {
+        |  values[index] = element
+        |}
+        |"""
+          .trimMargin()
+      )
+
+    // Without the operator modifier, get/set are still escaped as soft keywords.
+    val nonOperatorGet = FunSpec.builder("get").returns(Int::class).addStatement("return 0").build()
+    assertThat(nonOperatorGet.toString())
+      .isEqualTo(
+        """
+        |public fun `get`(): kotlin.Int = 0
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
   fun returnsLongExpression() {
     val funSpec =
       FunSpec.builder("foo")

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/KotlinPoetTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/KotlinPoetTest.kt
@@ -773,7 +773,7 @@ class KotlinPoetTest {
         |import kotlin.String
         |
         |public open class A {
-        |  protected open external infix operator fun `get`(v: String): String
+        |  protected open external infix operator fun get(v: String): String
         |
         |  internal final tailrec inline fun loop(): String = "a"
         |}


### PR DESCRIPTION
`get` and `set` are soft keywords, so KotlinPoet wrapped them in backticks when generating a function name. That also hit the index access operator overloads, so an `operator fun get` came out with a backtick-escaped name instead of the bare `get`. `KOperator` has no entry for these operators, so the operator check in `MemberName` never applied. KotlinPoet now keeps the bare `get`/`set` name for an operator function.

Fixes #1869.

- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
