### PR TITLE
Add `CodeBlock.Builder.addComment()`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@ Change Log
  * New: Support for explicit backing fields. (#2325)
  * New: `value class` validations have been relaxed to support multi-field value classes. (#2329)
  * New: Extract `CodeBlockHolder` interface for constructs that can hold a `CodeBlock` body and their builders. (#1553)
+ * New: Add `CodeBlock.Builder.addComment()` for adding `//` comments. (#1690)
  * Fix: Keep the `//` prefix on wrapped file comment lines. (#1922)
  * Fix: `TypeVariableName.equals`/`hashCode` no longer overflow on recursively bound generics like `Enum<E : Enum<E>>`. (#1737)
 

--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -123,6 +123,7 @@ public final class com/squareup/kotlinpoet/CodeBlock$Builder {
 	public fun <init> ()V
 	public final fun add (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/CodeBlock$Builder;
 	public final fun add (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlock$Builder;
+	public final fun addComment (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlock$Builder;
 	public final fun addNamed (Ljava/lang/String;Ljava/util/Map;)Lcom/squareup/kotlinpoet/CodeBlock$Builder;
 	public final fun addStatement (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlock$Builder;
 	public final fun beginControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlock$Builder;

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlock.kt
@@ -470,6 +470,10 @@ private constructor(internal val formatParts: List<String>, internal val args: L
       add("\n»")
     }
 
+    public fun addComment(format: String, vararg args: Any?): Builder = apply {
+      add("// $format\n", *args)
+    }
+
     public fun add(codeBlock: CodeBlock): Builder = apply {
       formatParts += codeBlock.formatParts
       args.addAll(codeBlock.args)

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/CodeBlockTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/CodeBlockTest.kt
@@ -47,6 +47,20 @@ class CodeBlockTest {
   }
 
   @Test
+  fun addComment() {
+    val codeBlock = CodeBlock.builder().addComment("a comment").build()
+    assertThat(codeBlock.toString()).isEqualTo("// a comment\n")
+  }
+
+  @Test
+  fun addCommentWithPlaceholders() {
+    val codeBlock =
+      CodeBlock.builder().addComment("not yet implemented %L of type %T", "field", STRING).build()
+    assertThat(codeBlock.toString())
+      .isEqualTo("// not yet implemented field of type kotlin.String\n")
+  }
+
+  @Test
   fun doublePrecision() {
     val doubles =
       listOf(


### PR DESCRIPTION
Adds `addComment()` to `CodeBlock.Builder`, mirroring `FunSpec.Builder.addComment()` so a comment can be added when only a `CodeBlock.Builder` is in scope.

Closes #1690

- [x] `docs/changelog.md` has been updated if applicable.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
