### PR TITLE
Add `CodeBlockHolder.Builder.addComment()`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ Change Log
  * New: `value class` validations have been relaxed to support multi-field value classes. (#2329)
  * New: Extract `CodeBlockHolder` interface for constructs that can hold a `CodeBlock` body and their builders. (#1553)
  * New: Add `CodeBlock.Builder.addComment()` for adding `//` comments. (#1690)
+ * New: Add `CodeBlockHolder.Builder.addComment()`. (#1553)
  * Fix: Keep the `//` prefix on wrapped file comment lines. (#1922)
  * Fix: `TypeVariableName.equals`/`hashCode` no longer overflow on recursively bound generics like `Enum<E : Enum<E>>`. (#1737)
  * Fix: `get` and `set` operator function names are no longer escaped with backticks. (#1869)

--- a/kotlinpoet/api/kotlinpoet.api
+++ b/kotlinpoet/api/kotlinpoet.api
@@ -149,6 +149,7 @@ public abstract interface class com/squareup/kotlinpoet/CodeBlockHolder {
 public abstract interface class com/squareup/kotlinpoet/CodeBlockHolder$Builder {
 	public abstract fun addCode (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
 	public abstract fun addCode (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public abstract fun addComment (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
 	public abstract fun addNamedCode (Ljava/lang/String;Ljava/util/Map;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
 	public abstract fun addStatement (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
 	public abstract fun beginControlFlow (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
@@ -273,7 +274,8 @@ public final class com/squareup/kotlinpoet/FileSpec$Builder : com/squareup/kotli
 	public fun addCode (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public synthetic fun addCode (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
 	public fun addCode (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
-	public final fun addComment (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
+	public synthetic fun addComment (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun addComment (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun addDefaultPackageImport (Ljava/lang/String;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public final fun addFileComment (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 	public fun addFunction (Lcom/squareup/kotlinpoet/FunSpec;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
@@ -386,7 +388,8 @@ public final class com/squareup/kotlinpoet/FunSpec$Builder : com/squareup/kotlin
 	public fun addCode (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public synthetic fun addCode (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
 	public fun addCode (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
-	public final fun addComment (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
+	public synthetic fun addComment (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/CodeBlockHolder$Builder;
+	public fun addComment (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public synthetic fun addKdoc (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/Documentable$Builder;
 	public fun addKdoc (Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public synthetic fun addKdoc (Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/Documentable$Builder;

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlockHolder.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlockHolder.kt
@@ -28,6 +28,8 @@ public interface CodeBlockHolder {
 
     public fun addStatement(format: String, vararg args: Any?): T
 
+    public fun addComment(format: String, vararg args: Any?): T
+
     public fun beginControlFlow(controlFlow: String, vararg args: Any?): T
 
     public fun nextControlFlow(controlFlow: String, vararg args: Any?): T

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
@@ -306,7 +306,7 @@ private constructor(builder: Builder, private val tagMap: TagMap = builder.build
      * Adds a file-site comment. This is prefixed to the start of the file and different from
      * [addBodyComment].
      */
-    public fun addFileComment(format: String, vararg args: Any): Builder = apply {
+    public fun addFileComment(format: String, vararg args: Any?): Builder = apply {
       comment.add(format, *args)
     }
 
@@ -315,9 +315,8 @@ private constructor(builder: Builder, private val tagMap: TagMap = builder.build
       ReplaceWith("addFileComment(format, args)"),
       DeprecationLevel.ERROR,
     )
-    override fun addComment(format: String, vararg args: Any?): Builder = apply {
-      comment.add(format, *args)
-    }
+    override fun addComment(format: String, vararg args: Any?): Builder =
+      addFileComment(format, *args)
 
     public fun clearComment(): Builder = apply { comment.clear() }
 

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FileSpec.kt
@@ -315,7 +315,9 @@ private constructor(builder: Builder, private val tagMap: TagMap = builder.build
       ReplaceWith("addFileComment(format, args)"),
       DeprecationLevel.ERROR,
     )
-    public fun addComment(format: String, vararg args: Any): Builder = addFileComment(format, *args)
+    override fun addComment(format: String, vararg args: Any?): Builder = apply {
+      comment.add(format, *args)
+    }
 
     public fun clearComment(): Builder = apply { comment.clear() }
 

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
@@ -526,7 +526,7 @@ private constructor(
 
     override fun addCode(codeBlock: CodeBlock): Builder = apply { body.add(codeBlock) }
 
-    public fun addComment(format: String, vararg args: Any): Builder = apply {
+    override fun addComment(format: String, vararg args: Any?): Builder = apply {
       body.add("// $format\n", *args)
     }
 

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FileSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FileSpecTest.kt
@@ -917,6 +917,24 @@ class FileSpecTest {
   }
 
   @Test
+  fun addCommentThroughCodeBlockHolderBuilder() {
+    val builder =
+      FileSpec.builder("com.squareup.tacos", "Taco").addType(TypeSpec.classBuilder("Taco").build())
+    val holder: CodeBlockHolder.Builder<*> = builder
+    holder.addComment("Generated %L. DO NOT EDIT!", "2015-01-13")
+    assertThat(builder.build().toString())
+      .isEqualTo(
+        """
+        |// Generated 2015-01-13. DO NOT EDIT!
+        |package com.squareup.tacos
+        |
+        |public class Taco
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
   fun topOfFileComment() {
     val source =
       FileSpec.builder("com.squareup.tacos", "Taco")

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -121,6 +121,22 @@ class FunSpecTest {
   }
 
   @Test
+  fun addCommentThroughCodeBlockHolderBuilder() {
+    val builder = FunSpec.builder("main")
+    val holder: CodeBlockHolder.Builder<*> = builder
+    holder.addComment("this is a %L comment", "generated")
+    assertThat(builder.build().toString())
+      .isEqualTo(
+        """
+        |public fun main() {
+        |  // this is a generated comment
+        |}
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
   fun overrideExtendsOthersWorksWithActualTypeParameters() {
     val classElement = getElement(ExtendsOthers::class.java)
     val classType = classElement.asType() as DeclaredType


### PR DESCRIPTION
Adds `addComment()` to `CodeBlockHolder.Builder` so it's available on any code-block builder. `FileSpec.Builder` marks its deprecated `addComment()` as `override`, so it resolves through the interface but still errors on direct calls.

Follow-up to #2340.

- [x] `docs/changelog.md` has been updated if applicable.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
