### PR TITLE
Replace deprecated Kotlin DSL API

### DIFF
--- a/kotlinpoet/build.gradle.kts
+++ b/kotlinpoet/build.gradle.kts
@@ -89,7 +89,7 @@ kotlin {
       }
     }
 
-    val nonJvmMain by creating {
+    val nonJvmMain = create("nonJvmMain") {
       dependsOn(commonMain.get())
     }
 


### PR DESCRIPTION
Property delegate extensions are deprecated since Gradle 9.6: https://docs.gradle.org/current/userguide/upgrading_version_9.html#kotlin_dsl_delegated_properties


- [N/A - not a consumer-visible change] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [N/A] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
