### PR TITLE
Fix multiline delegated constructor formatting

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ Change Log
  * Fix: Keep the `//` prefix on wrapped file comment lines. (#1922)
  * Fix: `TypeVariableName.equals`/`hashCode` no longer overflow on recursively bound generics like `Enum<E : Enum<E>>`. (#1737)
  * Fix: `get` and `set` operator function names are no longer escaped with backticks. (#1869)
+ * Fix: Expand multiline delegated constructor arguments with Kotlin-style indentation and trailing commas. (#1762)
 
 ## Version 2.3.0
 

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
@@ -182,9 +182,22 @@ private constructor(
     }
 
     if (delegateConstructor != null) {
-      codeWriter.emitCode(
-        delegateConstructorArguments.joinToCode(prefix = " : $delegateConstructor(", suffix = ")")
-      )
+      val constructorCall =
+        if (delegateConstructorArguments.any { it.hasExplicitNewLine() }) {
+          delegateConstructorArguments.joinToCode(
+            separator = ",\n",
+            prefix = " : $delegateConstructor(\n⇥",
+            suffix = ",\n⇤)",
+          ) {
+            it.trimTrailingNewLine(trimNonLiteralStringArguments = false)
+          }
+        } else {
+          delegateConstructorArguments.joinToCode(
+            prefix = " : $delegateConstructor(",
+            suffix = ")",
+          )
+        }
+      codeWriter.emitCode(constructorCall)
     }
   }
 

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/Util.jvm.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/Util.jvm.kt
@@ -30,26 +30,59 @@ internal actual fun <T> Collection<T>.toImmutableSet(): Set<T> =
 // TODO Waiting for `CodeBlock` migration.
 internal fun CodeBlock.ensureEndsWithNewLine() = trimTrailingNewLine('\n')
 
+internal fun CodeBlock.hasExplicitNewLine(): Boolean {
+  var argIndex = 0
+  for (formatPart in formatParts) {
+    if (!formatPart.isPlaceholder) {
+      if ('\n' in formatPart) return true
+      continue
+    }
+    if (!formatPart.consumesArgument) continue
+
+    val arg = args[argIndex++]
+    if (formatPart != "%L") continue
+    if (arg is CodeBlock && arg.hasExplicitNewLine()) return true
+    if (arg is String && '\n' in arg) return true
+  }
+  return false
+}
+
 // TODO Waiting for `CodeBlock` migration.
-internal fun CodeBlock.trimTrailingNewLine(replaceWith: Char? = null) =
+internal fun CodeBlock.trimTrailingNewLine(
+  replaceWith: Char? = null,
+  trimNonLiteralStringArguments: Boolean = true,
+): CodeBlock =
   if (isEmpty()) {
     this
   } else {
     with(toBuilder()) {
       val lastFormatPart = trim().formatParts.last()
-      if (lastFormatPart.isPlaceholder && args.isNotEmpty()) {
-        val lastArg = args.last()
-        if (lastArg is String) {
-          val trimmedArg = lastArg.trimEnd('\n')
-          args[args.size - 1] =
-            if (replaceWith != null) {
-              trimmedArg + replaceWith
-            } else {
-              trimmedArg
+      val lastFormatPartIndex = formatParts.lastIndexOf(lastFormatPart)
+      if (lastFormatPart.consumesArgument && args.isNotEmpty()) {
+        val lastArgIndex =
+          formatParts.take(lastFormatPartIndex + 1).count { it.consumesArgument } - 1
+        when (val lastArg = args[lastArgIndex]) {
+          is String -> {
+            if (lastFormatPart == "%L" || trimNonLiteralStringArguments) {
+              val trimmedArg = lastArg.trimEnd('\n')
+              args[lastArgIndex] =
+                if (replaceWith != null) {
+                  trimmedArg + replaceWith
+                } else {
+                  trimmedArg
+                }
             }
+          }
+
+          is CodeBlock -> {
+            if (lastFormatPart == "%L") {
+              args[lastArgIndex] =
+                lastArg.trimTrailingNewLine(replaceWith, trimNonLiteralStringArguments)
+            }
+          }
         }
       } else {
-        formatParts[formatParts.lastIndexOf(lastFormatPart)] = lastFormatPart.trimEnd('\n')
+        formatParts[lastFormatPartIndex] = lastFormatPart.trimEnd('\n')
         if (replaceWith != null) {
           formatParts += "$replaceWith"
         }
@@ -57,6 +90,9 @@ internal fun CodeBlock.trimTrailingNewLine(replaceWith: Char? = null) =
       return@with build()
     }
   }
+
+private val String.consumesArgument
+  get() = isPlaceholder && length == 2 && this != "%%"
 
 private val IDENTIFIER_REGEX = IDENTIFIER_REGEX_VALUE.toRegex()
 

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/CodeBlockTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/CodeBlockTest.kt
@@ -612,6 +612,21 @@ class CodeBlockTest {
   }
 
   @Test
+  fun trimTrailingNewLineWithNestedCodeBlock() {
+    val codeBlock = CodeBlock.of("before %L", CodeBlock.of("after\n\n"))
+
+    assertThat(codeBlock.trimTrailingNewLine().toString()).isEqualTo("before after")
+  }
+
+  @Test
+  fun ensureEndsWithNewLineWithReorderedNestedCodeBlockAndPercentLiteral() {
+    val trailingCodeBlock = CodeBlock.of("last\n\n")
+    val codeBlock = CodeBlock.of("%2L %% %1L", trailingCodeBlock, "first")
+
+    assertThat(codeBlock.ensureEndsWithNewLine().toString()).isEqualTo("first % last\n")
+  }
+
+  @Test
   fun ensureEndsWithNewLineWithNoArgs() {
     val codeBlock =
       CodeBlock.builder()

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -1042,6 +1042,30 @@ class FunSpecTest {
   }
 
   @Test
+  fun thisConstructorDelegateWithMultilineArgument() {
+    val argument = buildCodeBlock {
+      beginControlFlow("run")
+      addStatement("value")
+      endControlFlow()
+    }
+    val funSpec =
+      FunSpec.constructorBuilder().callThisConstructor(argument, CodeBlock.of("fallback")).build()
+
+    assertThat(funSpec.toString())
+      .isEqualTo(
+        """
+        |public constructor() : this(
+        |  run {
+        |    value
+        |  },
+        |  fallback,
+        |)
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
   fun superConstructorDelegate() {
     val funSpec =
       FunSpec.constructorBuilder()
@@ -1053,6 +1077,28 @@ class FunSpecTest {
       .isEqualTo(
         """
         |public constructor(list: kotlin.collections.List<kotlin.Int>) : super(list[0], list[1])
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
+  fun superConstructorDelegateWithMultilineArgument() {
+    val argument = buildCodeBlock {
+      beginControlFlow("run")
+      addStatement("value")
+      endControlFlow()
+    }
+    val funSpec = FunSpec.constructorBuilder().callSuperConstructor(argument).build()
+
+    assertThat(funSpec.toString())
+      .isEqualTo(
+        """
+        |public constructor() : super(
+        |  run {
+        |    value
+        |  },
+        |)
         |"""
           .trimMargin()
       )
@@ -1089,6 +1135,88 @@ class FunSpecTest {
         |}
         |"""
           .trimMargin()
+      )
+  }
+
+  @Test
+  fun constructorDelegateWithMultilineArgumentAndBody() {
+    val argument = buildCodeBlock {
+      beginControlFlow("run")
+      addStatement("value")
+      endControlFlow()
+    }
+    val funSpec =
+      FunSpec.constructorBuilder().callThisConstructor(argument).addStatement("println()").build()
+
+    assertThat(funSpec.toString())
+      .isEqualTo(
+        """
+        |public constructor() : this(
+        |  run {
+        |    value
+        |  },
+        |) {
+        |  println()
+        |}
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
+  fun constructorDelegateWithLongSingleLineArgument() {
+    val argument =
+      "aLongSingleLineArgumentThatExceedsTheUsualColumnLimitWithoutContainingAnyNewlines"
+    val funSpec = FunSpec.constructorBuilder().callThisConstructor(CodeBlock.of(argument)).build()
+
+    assertThat(funSpec.toString()).isEqualTo("public constructor() : this($argument)\n")
+  }
+
+  @Test
+  fun constructorDelegateWithNewlinesInStringLiteralArguments() {
+    val funSpec =
+      FunSpec.constructorBuilder()
+        .callThisConstructor(
+          CodeBlock.of("%S", "first\nsecond"),
+          CodeBlock.of("%P", "third\nfourth"),
+        )
+        .build()
+
+    assertThat(funSpec.toString())
+      .isEqualTo(
+        "public constructor() : this(\"\"\"\n" +
+          "|first\n" +
+          "|second\n" +
+          "\"\"\".trimMargin(), \"\"\"\n" +
+          "|third\n" +
+          "|fourth\n" +
+          "\"\"\".trimMargin())\n"
+      )
+  }
+
+  @Test
+  fun multilineConstructorDelegatePreservesTrailingNewlinesInStringLiteralArguments() {
+    val funSpec =
+      FunSpec.constructorBuilder()
+        .callThisConstructor(
+          CodeBlock.of("first\nsecond\n"),
+          CodeBlock.of("%S", "keep\n"),
+          CodeBlock.of("%P", "template\n"),
+        )
+        .build()
+
+    assertThat(funSpec.toString())
+      .isEqualTo(
+        "public constructor() : this(\n" +
+          "  first\n" +
+          "  second,\n" +
+          "  \"\"\"\n" +
+          "  |keep\n" +
+          "  |\"\"\".trimMargin(),\n" +
+          "  \"\"\"\n" +
+          "  |template\n" +
+          "  |\"\"\".trimMargin(),\n" +
+          ")\n"
       )
   }
 


### PR DESCRIPTION
Fixes #1762

## Summary

- expand delegated `this(...)` and `super(...)` calls when an argument contains an explicit structural newline
- indent every expanded argument and emit Kotlin-style trailing commas
- preserve existing one-line calls and `%S`/`%P` string data, including trailing newlines

This independently reimplements the behavior previously reviewed in #2332, which was closed because its author could not complete the Square CLA. No commits were copied.

## Validation

- focused red-then-green delegate-constructor and `CodeBlock` regressions
- `./gradlew spotlessApply :kotlinpoet:spotlessKotlinCheck :kotlinpoet:apiCheck :kotlinpoet:jvmTest`
- `./gradlew clean build` with Zulu OpenJDK 26.0.2
- `git diff --check`
