### PR TITLE
Don't special-case varargs in KSAnnotation.toAnnotationSpec

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ Change Log
  * Fix: Keep the `//` prefix on wrapped file comment lines. (#1922)
  * Fix: `TypeVariableName.equals`/`hashCode` no longer overflow on recursively bound generics like `Enum<E : Enum<E>>`. (#1737)
  * Fix: `get` and `set` operator function names are no longer escaped with backticks. (#1869)
+ * Fix: Don't special case varargs in `KSAnnotation.toAnnotationSpec`. (#2360)
 
 ## Version 2.3.0
 

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/Annotations.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/Annotations.kt
@@ -44,43 +44,21 @@ public fun KSAnnotation.toAnnotationSpec(omitDefaultValues: Boolean = false): An
       AnnotationSpec.builder(typeName as ParameterizedTypeName)
     }
 
-  val params =
-    annotationType
-      .resolve()
-      .resolveKSClassDeclaration()
-      ?.primaryConstructor
-      ?.parameters
-      .orEmpty()
-      .associateBy { it.name }
   useSiteTarget?.let { builder.useSiteTarget(it.kpAnalog) }
 
-  var varargValues: List<*>? = null
   for (argument in arguments) {
     val value = argument.value ?: continue
     val name = argument.name!!.getShortName()
-    val type = params[argument.name]
     if (omitDefaultValues) {
       val defaultValue = this.defaultArguments.firstOrNull { it.name?.asString() == name }?.value
       if (isDefaultValue(value, defaultValue)) {
         continue
       }
     }
-    if (type?.isVararg == true) {
-      // Wait to add varargs to end.
-      varargValues = value as List<*>
-    } else {
-      val member = CodeBlock.builder()
-      member.add("%N = ", name)
-      addValueToBlock(value, member, omitDefaultValues)
-      builder.addMember(member.build())
-    }
-  }
-  if (varargValues != null) {
-    for (item in varargValues) {
-      val member = CodeBlock.builder()
-      addValueToBlock(item!!, member, omitDefaultValues)
-      builder.addMember(member.build())
-    }
+    val member = CodeBlock.builder()
+    member.add("%N = ", name)
+    addValueToBlock(value, member, omitDefaultValues)
+    builder.addMember(member.build())
   }
   return builder.build()
 }

--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/exampleAnnotations.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/exampleAnnotations.kt
@@ -86,4 +86,6 @@ enum class AnnotationEnumValue {
 
 annotation class AnnotationWithVararg(val simpleArg: Int, vararg val args: String)
 
+annotation class AnnotationWithVarargFirst(vararg val args: String, val simpleArg: Int)
+
 annotation class AnnotationWithTypeArgs<T, R>

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -669,11 +669,58 @@ class TestProcessorTest {
         import com.squareup.kotlinpoet.ksp.test.processor.AnnotationWithVararg
         import kotlin.OptIn
 
-        @OptIn(MyOptIn::class)
+        @OptIn(markerClass = arrayOf(MyOptIn::class))
         @AnnotationWithVararg(
           simpleArg = 0,
-          "one",
-          "two",
+          args = arrayOf("one", "two"),
+        )
+        public class TestExample
+
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun varargArgumentFirst() {
+    val compilation =
+      prepareCompilation(
+        kotlin(
+          "Example.kt",
+          """
+          package test
+
+          import com.squareup.kotlinpoet.ksp.test.processor.AnnotationWithVarargFirst
+          import com.squareup.kotlinpoet.ksp.test.processor.ExampleAnnotation
+
+          @RequiresOptIn
+          annotation class MyOptIn
+
+          @ExampleAnnotation
+          @OptIn(MyOptIn::class)
+          @AnnotationWithVarargFirst(args = ["one", "two"], simpleArg = 0)
+          interface Example
+          """
+            .trimIndent(),
+        )
+      )
+
+    val result = compilation.compile()
+    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    val generatedFileText = File(compilation.kspSourcesDir, "kotlin/test/TestExample.kt").readText()
+
+    assertThat(generatedFileText)
+      .isEqualTo(
+        """
+        package test
+
+        import com.squareup.kotlinpoet.ksp.test.processor.AnnotationWithVarargFirst
+        import kotlin.OptIn
+
+        @OptIn(markerClass = arrayOf(MyOptIn::class))
+        @AnnotationWithVarargFirst(
+          args = arrayOf("one", "two"),
+          simpleArg = 0,
         )
         public class TestExample
 


### PR DESCRIPTION
Special-casing was introduced in a52451e83ef9efc884b2811699f91f8e50ba855a as a workaround for a Kotlin bug, where arrayOf was not allowed to be used in annotation args (see KT-65844). The bug was fixed in Kotlin 2.0.0, so the workaround isn't needed anymore.

This commit reverts the logic change introduced by the above-mentioned commit, while keeping the tests and adding a new one.

---

Fixes #2359

- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
