### PR TITLE
Emit brackets instead of arrayOf for annotation args

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ Change Log
  * New: Extract `CodeBlockHolder` interface for constructs that can hold a `CodeBlock` body and their builders. (#1553)
  * New: Add `CodeBlock.Builder.addComment()` for adding `//` comments. (#1690)
  * New: Add `CodeBlockHolder.Builder.addComment()`. (#1553)
+ * New: Use `[]` syntax instead of `arrayOf` when emitting annotation arguments. (#2361)
  * Fix: Keep the `//` prefix on wrapped file comment lines. (#1922)
  * Fix: `TypeVariableName.equals`/`hashCode` no longer overflow on recursively bound generics like `Enum<E : Enum<E>>`. (#1737)
  * Fix: `get` and `set` operator function names are no longer escaped with backticks. (#1869)

--- a/interop/kotlin-metadata/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecsTest.kt
+++ b/interop/kotlin-metadata/src/test/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecsTest.kt
@@ -1750,7 +1750,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
         """
         @kotlin.SinceKotlin(version = "1.3")
         @kotlin.`annotation`.Retention(value = kotlin.`annotation`.AnnotationRetention.RUNTIME)
-        @kotlin.`annotation`.Target(allowedTargets = arrayOf(kotlin.`annotation`.AnnotationTarget.CLASS))
+        @kotlin.`annotation`.Target(allowedTargets = [kotlin.`annotation`.AnnotationTarget.CLASS])
         public annotation class Metadata(
           @get:kotlin.jvm.JvmName(name = "k")
           public val kind: kotlin.Int = throw NotImplementedError("Stub!"),
@@ -1787,7 +1787,7 @@ class KotlinPoetMetadataSpecsTest : MultiClassInspectorTest() {
       .isEqualTo(
         """
         @kotlin.`annotation`.Retention(value = kotlin.`annotation`.AnnotationRetention.RUNTIME)
-        @kotlin.`annotation`.Target(allowedTargets = arrayOf(kotlin.`annotation`.AnnotationTarget.CLASS))
+        @kotlin.`annotation`.Target(allowedTargets = [kotlin.`annotation`.AnnotationTarget.CLASS])
         public annotation class Metadata(
           @get:kotlin.jvm.JvmName(name = "k")
           public val kind: kotlin.Int = throw NotImplementedError("Stub!"),

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/Annotations.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/Annotations.kt
@@ -99,25 +99,12 @@ private val AnnotationUseSiteTarget.kpAnalog: UseSiteTarget
 private fun addValueToBlock(value: Any, member: CodeBlock.Builder, omitDefaultValues: Boolean) {
   when (value) {
     is List<*> -> {
-      // Array type
-      val arrayType =
-        when (value.firstOrNull()) {
-          is Boolean -> "booleanArrayOf"
-          is Byte -> "byteArrayOf"
-          is Char -> "charArrayOf"
-          is Short -> "shortArrayOf"
-          is Int -> "intArrayOf"
-          is Long -> "longArrayOf"
-          is Float -> "floatArrayOf"
-          is Double -> "doubleArrayOf"
-          else -> "arrayOf"
-        }
-      member.add("$arrayType(⇥⇥")
+      member.add("[⇥⇥")
       value.forEachIndexed { index, innerValue ->
         if (index > 0) member.add(", ")
         addValueToBlock(innerValue!!, member, omitDefaultValues)
       }
-      member.add("⇤⇤)")
+      member.add("⇤⇤]")
     }
 
     is KSType -> {

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -199,42 +199,42 @@ class TestProcessorTest {
 
         @ComprehensiveAnnotation<String>(
           boolean = true,
-          booleanArray = booleanArrayOf(true),
+          booleanArray = [true],
           byte = 0.toByte(),
-          byteArray = byteArrayOf(0.toByte()),
+          byteArray = [0.toByte()],
           char = 'a',
-          charArray = charArrayOf('a', 'b', 'c'),
+          charArray = ['a', 'b', 'c'],
           short = 0.toShort(),
-          shortArray = shortArrayOf(0.toShort()),
+          shortArray = [0.toShort()],
           int = 0,
-          intArray = intArrayOf(0),
+          intArray = [0],
           long = 0,
-          longArray = longArrayOf(0),
+          longArray = [0],
           float = 0.0f,
-          floatArray = floatArrayOf(0.0f),
+          floatArray = [0.0f],
           double = 0.0,
-          doubleArray = doubleArrayOf(0.0),
+          doubleArray = [0.0],
           string = "Hello",
-          stringArray = arrayOf("Hello"),
+          stringArray = ["Hello"],
           someClass = String::class,
-          someClasses = arrayOf(String::class, Int::class),
+          someClasses = [String::class, Int::class],
           enumValue = AnnotationEnumValue.ONE,
-          enumValueArray = arrayOf(AnnotationEnumValue.ONE, AnnotationEnumValue.TWO),
+          enumValueArray = [AnnotationEnumValue.ONE, AnnotationEnumValue.TWO],
           anotherAnnotation = AnotherAnnotation(input = "Hello"),
-          anotherAnnotationArray = arrayOf(AnotherAnnotation(input = "Hello")),
+          anotherAnnotationArray = [AnotherAnnotation(input = "Hello")],
           defaultingString = "defaultValue",
         )
         @ExampleAnnotationWithDefaults(
-          booleanArray = booleanArrayOf(false),
+          booleanArray = [false],
           byte = 0.toByte(),
           short = 0.toShort(),
           int = 0,
           long = 0,
           float = 0.0f,
-          doubleArray = doubleArrayOf(0.0),
+          doubleArray = [0.0],
           string = "Hello",
-          someClasses = arrayOf(Int::class),
-          enumValueArray = arrayOf(AnnotationEnumValue.ONE, AnnotationEnumValue.TWO),
+          someClasses = [Int::class],
+          enumValueArray = [AnnotationEnumValue.ONE, AnnotationEnumValue.TWO],
         )
         public class TestSmokeTestClass<T, R : Any, E : Enum<E>> {
           @field:AnotherAnnotation(input = "siteTargeting")
@@ -669,10 +669,10 @@ class TestProcessorTest {
         import com.squareup.kotlinpoet.ksp.test.processor.AnnotationWithVararg
         import kotlin.OptIn
 
-        @OptIn(markerClass = arrayOf(MyOptIn::class))
+        @OptIn(markerClass = [MyOptIn::class])
         @AnnotationWithVararg(
           simpleArg = 0,
-          args = arrayOf("one", "two"),
+          args = ["one", "two"],
         )
         public class TestExample
 
@@ -717,9 +717,9 @@ class TestProcessorTest {
         import com.squareup.kotlinpoet.ksp.test.processor.AnnotationWithVarargFirst
         import kotlin.OptIn
 
-        @OptIn(markerClass = arrayOf(MyOptIn::class))
+        @OptIn(markerClass = [MyOptIn::class])
         @AnnotationWithVarargFirst(
-          args = arrayOf("one", "two"),
+          args = ["one", "two"],
           simpleArg = 0,
         )
         public class TestExample

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -169,12 +169,12 @@ private constructor(builder: Builder, private val tagMap: TagMap = builder.build
     override fun visitType(t: TypeMirror, name: String) = builder.add("%T::class", t.asTypeName())
 
     override fun visitArray(values: List<AnnotationValue>, name: String): CodeBlock.Builder {
-      builder.add("arrayOf(⇥⇥")
+      builder.add("[⇥⇥")
       values.forEachIndexed { index, value ->
         if (index > 0) builder.add(", ")
         value.accept(this, name)
       }
-      builder.add("⇤⇤)")
+      builder.add("⇤⇤]")
       return builder
     }
   }
@@ -203,12 +203,12 @@ private constructor(builder: Builder, private val tagMap: TagMap = builder.build
           val member = CodeBlock.builder()
           member.add("%L = ", method.name)
           if (value.javaClass.isArray) {
-            member.add("arrayOf(⇥⇥")
+            member.add("[⇥⇥")
             for (i in 0..<Array.getLength(value)) {
               if (i > 0) member.add(", ")
               member.add(Builder.memberForValue(Array.get(value, i)))
             }
-            member.add("⇤⇤)")
+            member.add("⇤⇤]")
             builder.addMember(member.build())
             continue
           }

--- a/kotlinpoet/src/jvmTest/java/com/squareup/kotlinpoet/JavaAnnotationSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/java/com/squareup/kotlinpoet/JavaAnnotationSpecTest.kt
@@ -46,7 +46,7 @@ class JavaAnnotationSpecTest {
         |import java.lang.Boolean
         |import java.lang.Object
         |
-        |@JavaClassWithArrayValueAnnotation.AnnotationWithArrayValue(value = arrayOf(Object::class, Boolean::class))
+        |@JavaClassWithArrayValueAnnotation.AnnotationWithArrayValue(value = [Object::class, Boolean::class])
         |public class Result
         |"""
           .trimMargin()
@@ -70,7 +70,7 @@ class JavaAnnotationSpecTest {
         |import java.lang.Boolean
         |import java.lang.Object
         |
-        |@JavaClassWithArrayValueAnnotation.AnnotationWithArrayValue(value = arrayOf(Object::class, Boolean::class))
+        |@JavaClassWithArrayValueAnnotation.AnnotationWithArrayValue(value = [Object::class, Boolean::class])
         |public class Result
         """
           .trimMargin()

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/AnnotationSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/AnnotationSpecTest.kt
@@ -114,12 +114,12 @@ class AnnotationSpecTest {
         |  f = 11.1,
         |  j = AnnotationSpecTest.AnnotationA(),
         |  l = Override::class,
-        |  m = arrayOf(9, 8, 1),
+        |  m = [9, 8, 1],
         |  o = AnnotationSpecTest.Breakfast.PANCAKES,
         |  p = 1_701,
         |  q = AnnotationSpecTest.AnnotationC(value = "bar"),
-        |  r = arrayOf(Float::class, Double::class),
-        |  s = arrayOf(AnnotationSpecTest.AnnotationC(value = "bar")),
+        |  r = [Float::class, Double::class],
+        |  s = [AnnotationSpecTest.AnnotationC(value = "bar")],
         |)
         |public class Taco
         |"""
@@ -148,12 +148,12 @@ class AnnotationSpecTest {
         |  f = 11.1,
         |  j = AnnotationSpecTest.AnnotationA(),
         |  l = Override::class,
-        |  m = arrayOf(9, 8, 1),
+        |  m = [9, 8, 1],
         |  o = AnnotationSpecTest.Breakfast.PANCAKES,
         |  p = 1_701,
         |  q = AnnotationSpecTest.AnnotationC(value = "bar"),
-        |  r = arrayOf(Float::class, Double::class),
-        |  s = arrayOf(AnnotationSpecTest.AnnotationC(value = "bar")),
+        |  r = [Float::class, Double::class],
+        |  s = [AnnotationSpecTest.AnnotationC(value = "bar")],
         |)
         |public class IsAnnotated
         |"""
@@ -198,12 +198,12 @@ class AnnotationSpecTest {
         |@AnnotationSpecTest.HasDefaultsAnnotation(
         |  f = 11.1,
         |  l = Override::class,
-        |  m = arrayOf(9, 8, 1),
+        |  m = [9, 8, 1],
         |  o = AnnotationSpecTest.Breakfast.PANCAKES,
         |  p = 1_701,
         |  q = AnnotationSpecTest.AnnotationC(value = "bar"),
-        |  r = arrayOf(Float::class, Double::class),
-        |  s = arrayOf(AnnotationSpecTest.AnnotationC(value = "bar")),
+        |  r = [Float::class, Double::class],
+        |  s = [AnnotationSpecTest.AnnotationC(value = "bar")],
         |)
         |public class Taco
         |"""
@@ -233,19 +233,19 @@ class AnnotationSpecTest {
         |  d = 8,
         |  e = 9.0f,
         |  f = 11.1,
-        |  g = arrayOf('\u0000', '쫾', 'z', '€', 'ℕ', '"', '\'', '\t', '\n'),
+        |  g = ['\u0000', '쫾', 'z', '€', 'ℕ', '"', '\'', '\t', '\n'],
         |  h = true,
         |  i = AnnotationSpecTest.Breakfast.WAFFLES,
         |  j = AnnotationSpecTest.AnnotationA(),
         |  k = "maple",
         |  l = Override::class,
-        |  m = arrayOf(9, 8, 1),
-        |  n = arrayOf(AnnotationSpecTest.Breakfast.WAFFLES, AnnotationSpecTest.Breakfast.PANCAKES),
+        |  m = [9, 8, 1],
+        |  n = [AnnotationSpecTest.Breakfast.WAFFLES, AnnotationSpecTest.Breakfast.PANCAKES],
         |  o = AnnotationSpecTest.Breakfast.PANCAKES,
         |  p = 1_701,
         |  q = AnnotationSpecTest.AnnotationC(value = "bar"),
-        |  r = arrayOf(Float::class, Double::class),
-        |  s = arrayOf(AnnotationSpecTest.AnnotationC(value = "bar")),
+        |  r = [Float::class, Double::class],
+        |  s = [AnnotationSpecTest.AnnotationC(value = "bar")],
         |)
         |public class Taco
         |"""
@@ -377,7 +377,7 @@ class AnnotationSpecTest {
         |import java.lang.Object
         |import kotlin.Boolean
         |
-        |@AnnotationSpecTest.AnnotationWithArrayValue(value = arrayOf(Object::class, Boolean::class))
+        |@AnnotationSpecTest.AnnotationWithArrayValue(value = [Object::class, Boolean::class])
         |public class Result
         """
           .trimMargin()
@@ -401,7 +401,7 @@ class AnnotationSpecTest {
         |import java.lang.Object
         |import kotlin.Boolean
         |
-        |@AnnotationSpecTest.AnnotationWithArrayValue(value = arrayOf(Object::class, Boolean::class))
+        |@AnnotationSpecTest.AnnotationWithArrayValue(value = [Object::class, Boolean::class])
         |public class Result
         """
           .trimMargin()


### PR DESCRIPTION
- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
