### PR TITLE
Don't leak an expression body's indent into later declarations

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ Change Log
  * Fix: `get` and `set` operator function names are no longer escaped with backticks. (#1869)
  * Fix: Don't special case varargs in `KSAnnotation.toAnnotationSpec`. (#2360)
  * Fix: Emit context parameters after annotations in `FunSpec` and `PropertySpec`. (#2374)
+ * Fix: An expression body no longer leaks indentation into later declarations. (#1421)
 
 ## Version 2.3.0
 

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlock.kt
@@ -119,8 +119,34 @@ private constructor(internal val formatParts: List<String>, internal val args: L
   /**
    * Returns a copy of the code block without leading and trailing no-arg placeholders (`⇥`, `⇤`,
    * `«`, `»`).
+   *
+   * With [keepBalanced], placeholders are taken back from either end until nothing left in the
+   * block is unmatched, which would otherwise leak the indent or the statement into whatever is
+   * emitted next. A body ending inside `withIndent` loses the `⇤` that closed it, e.g.:
+   * ```
+   * ["return ", "%S", "⇥", ".trim()", "⇤"]
+   *   trim()                    -> ["return ", "%S", "⇥", ".trim()"]
+   *   trim(keepBalanced = true) -> ["return ", "%S", "⇥", ".trim()", "⇤"]
+   * ```
+   *
+   * Both ends move when both are unmatched, e.g.:
+   * ```
+   * ["⇥", "body1", "⇤", "⇥", "body2", "⇤"]
+   *   trim()                    -> ["body1", "⇤", "⇥", "body2"]
+   *   trim(keepBalanced = true) -> ["⇥", "body1", "⇤", "⇥", "body2", "⇤"]
+   * ```
+   *
+   * A block that was already unbalanced before trimming is left to the plain behavior, since taking
+   * one end back cannot balance it and moves the following declaration further out, e.g.:
+   * ```
+   * ["⇥", "return ", "%S", "⇤", "⇥", ".trim()"]
+   *   trim()                    -> ["return ", "%S", "⇤", "⇥", ".trim()"]
+   *   trim(keepBalanced = true) -> ["return ", "%S", "⇤", "⇥", ".trim()"]
+   * ```
+   *
+   * [trimTrailingNewLine] relies on the default, which always drops both runs.
    */
-  internal fun trim(): CodeBlock {
+  internal fun trim(keepBalanced: Boolean = false): CodeBlock {
     var start = 0
     var end = formatParts.size
     while (start < end && formatParts[start] in NO_ARG_PLACEHOLDERS) {
@@ -128,6 +154,79 @@ private constructor(internal val formatParts: List<String>, internal val args: L
     }
     while (start < end && formatParts[end - 1] in NO_ARG_PLACEHOLDERS) {
       end--
+    }
+    if (keepBalanced && (start > 0 || end < formatParts.size)) {
+      // Both stripped runs are placeholders by definition, so they are the first `start` and the
+      // last `formatParts.size - end` entries of this list, and the kept range is what sits
+      // between them. Everything below walks placeholders rather than format parts, which keeps
+      // the balance check to a single pass over the parts.
+      val placeholders = CharArray(formatParts.size)
+      var placeholderCount = 0
+      for (formatPart in formatParts) {
+        if (formatPart.length == 1 && formatPart[0].isSingleCharNoArgPlaceholder) {
+          placeholders[placeholderCount++] = formatPart[0]
+        }
+      }
+      val keptEnd = placeholderCount - (formatParts.size - end)
+      if (isBalanced(placeholders, placeholderCount)) {
+        // Track the lowest point reached, not just the running total. Two unrelated halves can
+        // cancel out to a total of zero and still emit an unindent ahead of its indent.
+        var indentLow = 0
+        var indentTotal = 0
+        var statementLow = 0
+        var statementTotal = 0
+        for (i in start..<keptEnd) {
+          when (placeholders[i]) {
+            '⇥' -> indentTotal++
+            '⇤' -> indentTotal--
+            '«' -> statementTotal++
+            '»' -> statementTotal--
+          }
+          if (indentTotal < indentLow) indentLow = indentTotal
+          if (statementTotal < statementLow) statementLow = statementTotal
+        }
+        var first = start
+        while (first > 0 && (indentLow < 0 || statementLow < 0)) {
+          when (placeholders[first - 1]) {
+            '⇥' -> {
+              indentLow++
+              indentTotal++
+            }
+            '⇤' -> {
+              indentLow--
+              indentTotal--
+            }
+            '«' -> {
+              statementLow++
+              statementTotal++
+            }
+            '»' -> {
+              statementLow--
+              statementTotal--
+            }
+          }
+          first--
+          if (indentLow >= 0 && statementLow >= 0) {
+            start = first
+            break
+          }
+        }
+        var last = keptEnd
+        while (last < placeholderCount && (indentTotal > 0 || statementTotal > 0)) {
+          when (placeholders[last]) {
+            '⇥' -> indentTotal++
+            '⇤' -> indentTotal--
+            '«' -> statementTotal++
+            '»' -> statementTotal--
+          }
+          if (indentTotal < 0 || statementTotal < 0) break
+          last++
+          if (indentTotal == 0 && statementTotal == 0) {
+            end += last - keptEnd
+            break
+          }
+        }
+      }
     }
     return when {
       start > 0 || end < formatParts.size -> CodeBlock(formatParts.subList(start, end), args)
@@ -147,6 +246,21 @@ private constructor(internal val formatParts: List<String>, internal val args: L
     CodeBlock(formatParts.map { it.replace(oldValue, newValue) }, args)
 
   internal fun hasStatements() = formatParts.any { "«" in it }
+
+  private fun isBalanced(placeholders: CharArray, count: Int): Boolean {
+    var indent = 0
+    var statement = 0
+    for (i in 0..<count) {
+      when (placeholders[i]) {
+        '⇥' -> indent++
+        '⇤' -> indent--
+        '«' -> statement++
+        '»' -> statement--
+      }
+      if (indent < 0 || statement < 0) return false
+    }
+    return indent == 0 && statement == 0
+  }
 
   internal fun hasUnmatchedClosingStatement(): Boolean {
     var openCount = 0

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlock.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/CodeBlock.kt
@@ -147,19 +147,19 @@ private constructor(internal val formatParts: List<String>, internal val args: L
    * [trimTrailingNewLine] relies on the default, which always drops both runs.
    */
   internal fun trim(keepBalanced: Boolean = false): CodeBlock {
-    var start = 0
-    var end = formatParts.size
-    while (start < end && formatParts[start] in NO_ARG_PLACEHOLDERS) {
-      start++
+    var keepFrom = 0
+    var keepUntil = formatParts.size
+    while (keepFrom < keepUntil && formatParts[keepFrom] in NO_ARG_PLACEHOLDERS) {
+      keepFrom++
     }
-    while (start < end && formatParts[end - 1] in NO_ARG_PLACEHOLDERS) {
-      end--
+    while (keepFrom < keepUntil && formatParts[keepUntil - 1] in NO_ARG_PLACEHOLDERS) {
+      keepUntil--
     }
-    if (keepBalanced && (start > 0 || end < formatParts.size)) {
-      // Both stripped runs are placeholders by definition, so they are the first `start` and the
-      // last `formatParts.size - end` entries of this list, and the kept range is what sits
-      // between them. Everything below walks placeholders rather than format parts, which keeps
-      // the balance check to a single pass over the parts.
+    if (keepBalanced && (keepFrom > 0 || keepUntil < formatParts.size)) {
+      // Both stripped runs are placeholders by definition, so they are the first `keepFrom` and
+      // the last `formatParts.size - keepUntil` entries of this list, and the kept range is what
+      // sits between them. Everything below walks placeholders rather than format parts, which
+      // keeps the balance check to a single pass over the parts.
       val placeholders = CharArray(formatParts.size)
       var placeholderCount = 0
       for (formatPart in formatParts) {
@@ -167,15 +167,31 @@ private constructor(internal val formatParts: List<String>, internal val args: L
           placeholders[placeholderCount++] = formatPart[0]
         }
       }
-      val keptEnd = placeholderCount - (formatParts.size - end)
-      if (isBalanced(placeholders, placeholderCount)) {
+      val keepPlaceholdersFrom = keepFrom
+      val keepPlaceholdersUntil = placeholderCount - (formatParts.size - keepUntil)
+      fun isBalanced(): Boolean {
+        var indent = 0
+        var statement = 0
+        for (i in 0..<placeholderCount) {
+          when (placeholders[i]) {
+            '⇥' -> indent++
+            '⇤' -> indent--
+            '«' -> statement++
+            '»' -> statement--
+          }
+          if (indent < 0 || statement < 0) return false
+        }
+        return indent == 0 && statement == 0
+      }
+
+      if (isBalanced()) {
         // Track the lowest point reached, not just the running total. Two unrelated halves can
         // cancel out to a total of zero and still emit an unindent ahead of its indent.
         var indentLow = 0
         var indentTotal = 0
         var statementLow = 0
         var statementTotal = 0
-        for (i in start..<keptEnd) {
+        for (i in keepPlaceholdersFrom..<keepPlaceholdersUntil) {
           when (placeholders[i]) {
             '⇥' -> indentTotal++
             '⇤' -> indentTotal--
@@ -185,9 +201,9 @@ private constructor(internal val formatParts: List<String>, internal val args: L
           if (indentTotal < indentLow) indentLow = indentTotal
           if (statementTotal < statementLow) statementLow = statementTotal
         }
-        var first = start
-        while (first > 0 && (indentLow < 0 || statementLow < 0)) {
-          when (placeholders[first - 1]) {
+        var pointer = keepPlaceholdersFrom
+        while (pointer > 0 && (indentLow < 0 || statementLow < 0)) {
+          when (placeholders[pointer - 1]) {
             '⇥' -> {
               indentLow++
               indentTotal++
@@ -205,31 +221,32 @@ private constructor(internal val formatParts: List<String>, internal val args: L
               statementTotal--
             }
           }
-          first--
+          pointer--
           if (indentLow >= 0 && statementLow >= 0) {
-            start = first
+            keepFrom -= keepPlaceholdersFrom - pointer
             break
           }
         }
-        var last = keptEnd
-        while (last < placeholderCount && (indentTotal > 0 || statementTotal > 0)) {
-          when (placeholders[last]) {
+        pointer = keepPlaceholdersUntil
+        while (pointer < placeholderCount && (indentTotal > 0 || statementTotal > 0)) {
+          when (placeholders[pointer]) {
             '⇥' -> indentTotal++
             '⇤' -> indentTotal--
             '«' -> statementTotal++
             '»' -> statementTotal--
           }
           if (indentTotal < 0 || statementTotal < 0) break
-          last++
+          pointer++
           if (indentTotal == 0 && statementTotal == 0) {
-            end += last - keptEnd
+            keepUntil += pointer - keepPlaceholdersUntil
             break
           }
         }
       }
     }
     return when {
-      start > 0 || end < formatParts.size -> CodeBlock(formatParts.subList(start, end), args)
+      keepFrom > 0 || keepUntil < formatParts.size ->
+        CodeBlock(formatParts.subList(keepFrom, keepUntil), args)
       else -> this
     }
   }
@@ -246,21 +263,6 @@ private constructor(internal val formatParts: List<String>, internal val args: L
     CodeBlock(formatParts.map { it.replace(oldValue, newValue) }, args)
 
   internal fun hasStatements() = formatParts.any { "«" in it }
-
-  private fun isBalanced(placeholders: CharArray, count: Int): Boolean {
-    var indent = 0
-    var statement = 0
-    for (i in 0..<count) {
-      when (placeholders[i]) {
-        '⇥' -> indent++
-        '⇤' -> indent--
-        '«' -> statement++
-        '»' -> statement--
-      }
-      if (indent < 0 || statement < 0) return false
-    }
-    return indent == 0 && statement == 0
-  }
 
   internal fun hasUnmatchedClosingStatement(): Boolean {
     var openCount = 0

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
@@ -243,7 +243,7 @@ private constructor(
   }
 
   private fun CodeBlock.asExpressionBody(): CodeBlock? {
-    val codeBlock = this.trim()
+    val codeBlock = this.trim(keepBalanced = true)
 
     // If after trimming there are unmatched closing statement symbols, we can't have an expression
     // body.

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/CodeBlockTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/CodeBlockTest.kt
@@ -495,6 +495,13 @@ class CodeBlockTest {
   }
 
   @Test
+  fun trimKeepsAStatementAndItsIndentTogether() {
+    val codeBlock = CodeBlock.of("«⇥return %S⇤».trim()", "taco")
+
+    assertThat(codeBlock.trim(keepBalanced = true)).isEqualTo(codeBlock)
+  }
+
+  @Test
   fun replaceSimple() {
     assertThat(CodeBlock.of("%%⇥%%").replaceAll("%%", "")).isEqualTo(CodeBlock.of("⇥"))
   }
@@ -626,6 +633,23 @@ class CodeBlockTest {
         |Modeling a kdoc
         |
         |Statement with no args
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
+  fun ensureEndsWithNewLineKeepsArgsWhenBlockEndsInIndent() {
+    val codeBlock =
+      CodeBlock.builder().add("%S", "taco\n").indent().add("\nmore").unindent().build()
+
+    assertThat(codeBlock.ensureEndsWithNewLine().toString())
+      .isEqualTo(
+        """
+        |""${'"'}
+        ||taco
+        ||""${'"'}.trimMargin()
+        |  more
         |"""
           .trimMargin()
       )

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/CodeBlockTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/CodeBlockTest.kt
@@ -495,10 +495,18 @@ class CodeBlockTest {
   }
 
   @Test
-  fun trimKeepsAStatementAndItsIndentTogether() {
+  fun trimKeepsStatementsAndIndentsBalanced() {
     val codeBlock = CodeBlock.of("«⇥return %S⇤».trim()", "taco")
 
     assertThat(codeBlock.trim(keepBalanced = true)).isEqualTo(codeBlock)
+  }
+
+  @Test
+  fun trimLeavesCrossedStatementAndIndentAlone() {
+    val codeBlock = CodeBlock.of("⇥return %S«.trim()⇤⇥»⇤", "taco")
+
+    assertThat(codeBlock.trim(keepBalanced = true))
+      .isEqualTo(CodeBlock.of("return %S«.trim()", "taco"))
   }
 
   @Test

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -506,6 +506,235 @@ class FunSpecTest {
   }
 
   @Test
+  fun expressionBodyEndingInIndentDoesNotIndentFollowingDeclarations() {
+    val spec =
+      FileSpec.builder("com.squareup.tacos", "Taco")
+        .addFunction(
+          FunSpec.builder("foo")
+            .returns(STRING)
+            .addCode(
+              buildCodeBlock {
+                add("return %S", "taco")
+                withIndent { add("\n.trim()") }
+              }
+            )
+            .build()
+        )
+        .addFunction(FunSpec.builder("bar").build())
+        .build()
+
+    assertThat(spec.toString())
+      .isEqualTo(
+        """
+        |package com.squareup.tacos
+        |
+        |import kotlin.String
+        |
+        |public fun foo(): String = "taco"
+        |  .trim()
+        |
+        |public fun bar() {
+        |}
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
+  fun expressionBodyEndingInStatementDoesNotLeakIndent() {
+    val spec =
+      FileSpec.builder("com.squareup.tacos", "Taco")
+        .addFunction(
+          FunSpec.builder("foo")
+            .returns(STRING)
+            .addCode(
+              buildCodeBlock {
+                add("return %S", "taco")
+                addStatement(".trim()")
+              }
+            )
+            .build()
+        )
+        .addFunction(FunSpec.builder("bar").build())
+        .build()
+
+    assertThat(spec.toString())
+      .isEqualTo(
+        """
+        |package com.squareup.tacos
+        |
+        |import kotlin.String
+        |
+        |public fun foo(): String = "taco".trim()
+        |
+        |public fun bar() {
+        |}
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
+  fun expressionBodyEndingInEmptyIndentDoesNotLeakIndent() {
+    val spec =
+      FileSpec.builder("com.squareup.tacos", "Taco")
+        .addFunction(
+          FunSpec.builder("foo")
+            .returns(STRING)
+            .addCode(
+              buildCodeBlock {
+                add("return %S", "taco")
+                withIndent {
+                  addStatement(".trim()")
+                  withIndent {}
+                }
+              }
+            )
+            .build()
+        )
+        .addFunction(FunSpec.builder("bar").build())
+        .build()
+
+    assertThat(spec.toString())
+      .isEqualTo(
+        """
+        |package com.squareup.tacos
+        |
+        |import kotlin.String
+        |
+        |public fun foo(): String = "taco".trim()
+        |
+        |public fun bar() {
+        |}
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
+  fun expressionBodyStartingInIndentDoesNotLeakIndent() {
+    val spec =
+      FileSpec.builder("com.squareup.tacos", "Taco")
+        .addType(
+          TypeSpec.classBuilder("Taco")
+            .addFunction(
+              FunSpec.builder("foo")
+                .returns(STRING)
+                .addCode(
+                  buildCodeBlock {
+                    withIndent { add("return %S", "taco") }
+                    addStatement(".trim()")
+                  }
+                )
+                .build()
+            )
+            .addFunction(FunSpec.builder("bar").build())
+            .build()
+        )
+        .build()
+
+    assertThat(spec.toString())
+      .isEqualTo(
+        """
+        |package com.squareup.tacos
+        |
+        |import kotlin.String
+        |
+        |public class Taco {
+        |  public fun foo(): String {
+        |      return "taco".trim()
+        |  }
+        |
+        |  public fun bar() {
+        |  }
+        |}
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
+  fun expressionBodyWithTwoIndentedSegmentsDoesNotLeakIndent() {
+    val spec =
+      FileSpec.builder("com.squareup.tacos", "Taco")
+        .addFunction(
+          FunSpec.builder("foo")
+            .returns(STRING)
+            .addCode(
+              buildCodeBlock {
+                withIndent { add("return %S", "taco") }
+                addStatement(".a()")
+                withIndent { addStatement(".b()") }
+              }
+            )
+            .build()
+        )
+        .addFunction(FunSpec.builder("bar").build())
+        .build()
+
+    assertThat(spec.toString())
+      .isEqualTo(
+        """
+        |package com.squareup.tacos
+        |
+        |import kotlin.String
+        |
+        |public fun foo(): String {
+        |    return "taco".a()
+        |    .b()
+        |}
+        |
+        |public fun bar() {
+        |}
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
+  fun expressionBodyWithUnbalancedIndentIsLeftAlone() {
+    val spec =
+      FileSpec.builder("com.squareup.tacos", "Taco")
+        .addType(
+          TypeSpec.classBuilder("Taco")
+            .addFunction(
+              FunSpec.builder("foo")
+                .returns(STRING)
+                .addCode(
+                  buildCodeBlock {
+                    indent()
+                    add("return %S", "taco")
+                    unindent()
+                    indent()
+                    add(".trim()")
+                  }
+                )
+                .build()
+            )
+            .addFunction(FunSpec.builder("bar").build())
+            .build()
+        )
+        .build()
+
+    assertThat(spec.toString())
+      .isEqualTo(
+        """
+        |package com.squareup.tacos
+        |
+        |import kotlin.String
+        |
+        |public class Taco {
+        |  public fun foo(): String = "taco".trim()
+        |
+        |  public fun bar() {
+        |  }
+        |}
+        |"""
+          .trimMargin()
+      )
+  }
+
+  @Test
   fun functionWithReturnKDocAndMainKdoc() {
     val funSpec =
       FunSpec.builder("foo")


### PR DESCRIPTION
An expression body that opens or closes an indent leaks it into every declaration after it, so each following function lands two spaces deeper than the last. Deeper nesting throws `cannot unindent` instead.

`CodeBlock.trim()` strips no-arg placeholders from both ends, dropping one half of a pair while its partner stays behind. It now takes them back from either end until nothing is left unmatched.

A block that was already unmatched before trimming is left alone, since taking one end back cannot balance it. Markers that open and close out of order are left alone as well, and building that shape takes raw placeholders rather than the builder.

A body that opens an indent before the returned expression emits as a block body now, since the trimmed block no longer starts with the return. Same code, different shape. Most of the diff is tests.

Fixes #1421.

- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
