### PR TITLE
Don't throw when toTypeName() hits type parameters with EMPTY resolver

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ Change Log
  * Fix: `TypeVariableName.equals`/`hashCode` no longer overflow on recursively bound generics like `Enum<E : Enum<E>>`. (#1737)
  * Fix: `get` and `set` operator function names are no longer escaped with backticks. (#1869)
  * Fix: Don't special case varargs in `KSAnnotation.toAnnotationSpec`. (#2360)
+ * Fix: `KSType.toTypeName()` with the default `TypeParameterResolver.EMPTY` now resolves type parameters from their enclosing declaration instead of throwing. (#2065)
 
 ## Version 2.3.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,7 +13,7 @@ Change Log
  * Fix: `TypeVariableName.equals`/`hashCode` no longer overflow on recursively bound generics like `Enum<E : Enum<E>>`. (#1737)
  * Fix: `get` and `set` operator function names are no longer escaped with backticks. (#1869)
  * Fix: Don't special case varargs in `KSAnnotation.toAnnotationSpec`. (#2360)
- * Fix: `KSType.toTypeName()` with the default `TypeParameterResolver.EMPTY` now resolves type parameters from their enclosing declaration instead of throwing. (#2065)
+ * Fix: `KSType.toTypeName()` with the default `TypeParameterResolver.EMPTY` now resolves type parameters from their enclosing declarations instead of throwing. (#2065)
 
 ## Version 2.3.0
 

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/Annotations.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/Annotations.kt
@@ -35,7 +35,7 @@ import com.squareup.kotlinpoet.ParameterizedTypeName
  */
 @JvmOverloads
 public fun KSAnnotation.toAnnotationSpec(omitDefaultValues: Boolean = false): AnnotationSpec {
-  val typeName = annotationType.resolve().toTypeName()
+  val typeName = annotationType.toTypeName()
 
   val builder =
     if (typeName is ClassName) {

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KsTypes.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KsTypes.kt
@@ -17,7 +17,6 @@ package com.squareup.kotlinpoet.ksp
 
 import com.google.devtools.ksp.symbol.KSCallableReference
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.symbol.KSClassifierReference
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSNode
@@ -217,18 +216,6 @@ public fun KSTypeReference.toTypeName(
 ): TypeName {
   val type = resolve()
   val elem = element
-  if (type.isError) {
-    val referencedName = (elem as? KSClassifierReference)?.referencedName()
-    if (referencedName != null) {
-      val resolver =
-        if (typeParamResolver !== TypeParameterResolver.EMPTY) {
-          typeParamResolver
-        } else {
-          enclosingTypeParameterResolver()
-        }
-      return resolver[referencedName].copy(nullable = type.isMarkedNullable)
-    }
-  }
   // Don't wrap in a lambda if this is a typealias, even if the underlying type is a function type.
   return if (elem is KSCallableReference && type.declaration !is KSTypeAlias) {
     LambdaTypeName.get(

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KsTypes.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KsTypes.kt
@@ -17,6 +17,7 @@ package com.squareup.kotlinpoet.ksp
 
 import com.google.devtools.ksp.symbol.KSCallableReference
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.google.devtools.ksp.symbol.KSTypeArgument
@@ -92,7 +93,7 @@ internal fun KSType.toTypeName(
       is KSClassDeclaration -> {
         decl.toClassName().withTypeArguments(arguments.map { it.toTypeName(typeParamResolver) })
       }
-      is KSTypeParameter -> typeParamResolver[decl.name.getShortName()]
+      is KSTypeParameter -> resolveTypeParameter(decl, typeParamResolver)
       is KSTypeAlias -> {
         var typeAlias: KSTypeAlias = decl
         var arguments = arguments
@@ -226,5 +227,30 @@ public fun KSTypeReference.toTypeName(
       .copy(nullable = type.isMarkedNullable, suspending = type.isSuspendFunctionType)
   } else {
     type.toTypeName(typeParamResolver, type.arguments)
+  }
+}
+
+private fun resolveTypeParameter(
+  typeParameter: KSTypeParameter,
+  typeParamResolver: TypeParameterResolver,
+): TypeVariableName {
+  val name = typeParameter.name.getShortName()
+  typeParamResolver.parametersMap[name]?.let {
+    return it
+  }
+  if (typeParamResolver !== TypeParameterResolver.EMPTY) {
+    return typeParamResolver[name]
+  }
+  val enclosingParameters =
+    when (val parent = typeParameter.parentDeclaration) {
+      is KSClassDeclaration -> parent.typeParameters
+      is KSFunctionDeclaration -> parent.typeParameters
+      is KSTypeAlias -> parent.typeParameters
+      else -> emptyList()
+    }
+  return if (enclosingParameters.isEmpty()) {
+    TypeVariableName(name)
+  } else {
+    enclosingParameters.toTypeParameterResolver()[name]
   }
 }

--- a/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KsTypes.kt
+++ b/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/KsTypes.kt
@@ -17,7 +17,10 @@ package com.squareup.kotlinpoet.ksp
 
 import com.google.devtools.ksp.symbol.KSCallableReference
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSClassifierReference
+import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.google.devtools.ksp.symbol.KSTypeArgument
@@ -91,7 +94,7 @@ internal fun KSType.toTypeName(
   val type =
     when (val decl = declaration) {
       is KSClassDeclaration -> {
-        decl.toClassName().withTypeArguments(arguments.map { it.toTypeName(typeParamResolver) })
+        decl.toClassName().withTypeArguments(typeArguments.map { it.toTypeName(typeParamResolver) })
       }
       is KSTypeParameter -> resolveTypeParameter(decl, typeParamResolver)
       is KSTypeAlias -> {
@@ -214,6 +217,18 @@ public fun KSTypeReference.toTypeName(
 ): TypeName {
   val type = resolve()
   val elem = element
+  if (type.isError) {
+    val referencedName = (elem as? KSClassifierReference)?.referencedName()
+    if (referencedName != null) {
+      val resolver =
+        if (typeParamResolver !== TypeParameterResolver.EMPTY) {
+          typeParamResolver
+        } else {
+          enclosingTypeParameterResolver()
+        }
+      return resolver[referencedName].copy(nullable = type.isMarkedNullable)
+    }
+  }
   // Don't wrap in a lambda if this is a typealias, even if the underlying type is a function type.
   return if (elem is KSCallableReference && type.declaration !is KSTypeAlias) {
     LambdaTypeName.get(
@@ -226,7 +241,8 @@ public fun KSTypeReference.toTypeName(
       )
       .copy(nullable = type.isMarkedNullable, suspending = type.isSuspendFunctionType)
   } else {
-    type.toTypeName(typeParamResolver, type.arguments)
+    val typeArgs = elem?.typeArguments?.takeIf { it.isNotEmpty() } ?: type.arguments
+    type.toTypeName(typeParamResolver, typeArgs)
   }
 }
 
@@ -235,22 +251,29 @@ private fun resolveTypeParameter(
   typeParamResolver: TypeParameterResolver,
 ): TypeVariableName {
   val name = typeParameter.name.getShortName()
-  typeParamResolver.parametersMap[name]?.let {
-    return it
-  }
   if (typeParamResolver !== TypeParameterResolver.EMPTY) {
     return typeParamResolver[name]
   }
-  val enclosingParameters =
-    when (val parent = typeParameter.parentDeclaration) {
-      is KSClassDeclaration -> parent.typeParameters
-      is KSFunctionDeclaration -> parent.typeParameters
-      is KSTypeAlias -> parent.typeParameters
-      else -> emptyList()
+  return typeParameter.enclosingTypeParameterResolver()[name]
+}
+
+private fun KSNode.enclosingTypeParameterResolver(): TypeParameterResolver {
+  val owners = mutableListOf<List<KSTypeParameter>>()
+  var current: KSNode? = this
+  while (current != null) {
+    val typeParameters =
+      when (current) {
+        is KSClassDeclaration -> current.typeParameters
+        is KSFunctionDeclaration -> current.typeParameters
+        is KSTypeAlias -> current.typeParameters
+        else -> emptyList()
+      }
+    if (typeParameters.isNotEmpty()) {
+      owners += typeParameters
     }
-  return if (enclosingParameters.isEmpty()) {
-    TypeVariableName(name)
-  } else {
-    enclosingParameters.toTypeParameterResolver()[name]
+    current = (current as? KSDeclaration)?.parentDeclaration ?: current.parent
   }
+  return owners.asReversed().fold(null as TypeParameterResolver?) { parent, parameters ->
+    parameters.toTypeParameterResolver(parent)
+  } ?: TypeParameterResolver.EMPTY
 }

--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
@@ -71,6 +71,8 @@ class TestProcessor(private val env: SymbolProcessorEnvironment) : SymbolProcess
     val typeName = toTypeName(resolver)
     val resolvedTypeName = resolve().toTypeName(resolver)
     check(typeName == resolvedTypeName)
+    // Default EMPTY resolver used to throw on type parameters (#2065).
+    resolve().toTypeName()
     return typeName
   }
 

--- a/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
+++ b/interop/ksp/test-processor/src/main/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessor.kt
@@ -72,7 +72,7 @@ class TestProcessor(private val env: SymbolProcessorEnvironment) : SymbolProcess
     val resolvedTypeName = resolve().toTypeName(resolver)
     check(typeName == resolvedTypeName)
     // Default EMPTY resolver used to throw on type parameters (#2065).
-    resolve().toTypeName()
+    check(resolve().toTypeName() == typeName)
     return typeName
   }
 

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/KsTypesTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/KsTypesTest.kt
@@ -24,6 +24,7 @@ import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeArgument
 import com.google.devtools.ksp.symbol.Nullability
+import com.squareup.kotlinpoet.ksp.TypeParameterResolver
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
 import kotlin.test.assertFailsWith
@@ -99,5 +100,11 @@ class KsTypesTest {
       .message()
       .isNotNull()
       .contains("is not resolvable in the current round of processing")
+  }
+
+  @Test
+  fun emptyTypeParameterResolverGetThrows() {
+    val exception = assertFailsWith<NoSuchElementException> { TypeParameterResolver.EMPTY["T"] }
+    assertThat(exception).message().isNotNull().contains("No TypeParameter found for index T")
   }
 }

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -807,8 +807,9 @@ class TestProcessorTest {
       )
   }
 
+  // https://github.com/square/kotlinpoet/issues/2065
   @Test
-  fun regression_2065() {
+  fun toTypeNameWithEmptyResolverDoesNotThrowOnTypeParameters() {
     val compilation =
       prepareCompilation(
         kotlin(

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -819,23 +819,81 @@ class TestProcessorTest {
            import com.squareup.kotlinpoet.ksp.test.processor.ExampleAnnotation
 
            @ExampleAnnotation
-           abstract class Subject<T> : Comparable<T>
+           abstract class Subject<Foo> : Comparable<Foo>
+
+           @ExampleAnnotation
+           class Host<E, T> {
+             fun <B> foo(): Map<E, B> {
+               TODO()
+             }
+
+             fun <U : T> bar(): List<U> {
+               TODO()
+             }
+           }
            """,
         )
       )
 
     val result = compilation.compile()
     assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-    val generatedFileText = File(compilation.kspSourcesDir, "kotlin/test/TestSubject.kt").readText()
-
-    assertThat(generatedFileText)
+    assertThat(File(compilation.kspSourcesDir, "kotlin/test/TestSubject.kt").readText())
       .isEqualTo(
         """
         package test
 
         import kotlin.Comparable
 
-        public abstract class TestSubject<T> : Comparable<T>
+        public abstract class TestSubject<Foo> : Comparable<Foo>
+
+        """
+          .trimIndent()
+      )
+    assertThat(File(compilation.kspSourcesDir, "kotlin/test/TestHost.kt").readText())
+      .isEqualTo(
+        """
+        package test
+
+        import kotlin.collections.List
+        import kotlin.collections.Map
+
+        public class TestHost<E, T> {
+          public fun <B> foo(): Map<E, B> = TODO()
+
+          public fun <U : T> bar(): List<U> = TODO()
+        }
+
+        """
+          .trimIndent()
+      )
+
+    val annotated =
+      prepareCompilation(
+        kotlin(
+          "Example.kt",
+          """
+           package test
+
+           import com.squareup.kotlinpoet.ksp.test.processor.AnnotationWithTypeArgs
+           import com.squareup.kotlinpoet.ksp.test.processor.ExampleAnnotation
+
+           @ExampleAnnotation
+           @AnnotationWithTypeArgs<E, String>
+           class Host<E>
+           """,
+        )
+      )
+    annotated.compile()
+    assertThat(File(annotated.kspSourcesDir, "kotlin/test/TestHost.kt").readText())
+      .isEqualTo(
+        """
+        package test
+
+        import com.squareup.kotlinpoet.ksp.test.processor.AnnotationWithTypeArgs
+        import kotlin.String
+
+        @AnnotationWithTypeArgs<E, String>
+        public class TestHost<E>
 
         """
           .trimIndent()

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -808,6 +808,41 @@ class TestProcessorTest {
   }
 
   @Test
+  fun regression_2065() {
+    val compilation =
+      prepareCompilation(
+        kotlin(
+          "Example.kt",
+          """
+           package test
+
+           import com.squareup.kotlinpoet.ksp.test.processor.ExampleAnnotation
+
+           @ExampleAnnotation
+           abstract class Subject<T> : Comparable<T>
+           """,
+        )
+      )
+
+    val result = compilation.compile()
+    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    val generatedFileText = File(compilation.kspSourcesDir, "kotlin/test/TestSubject.kt").readText()
+
+    assertThat(generatedFileText)
+      .isEqualTo(
+        """
+        package test
+
+        import kotlin.Comparable
+
+        public abstract class TestSubject<T> : Comparable<T>
+
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun regression_1304() {
     val compilation =
       prepareCompilation(

--- a/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
+++ b/interop/ksp/test-processor/src/test/kotlin/com/squareup/kotlinpoet/ksp/test/processor/TestProcessorTest.kt
@@ -866,38 +866,6 @@ class TestProcessorTest {
         """
           .trimIndent()
       )
-
-    val annotated =
-      prepareCompilation(
-        kotlin(
-          "Example.kt",
-          """
-           package test
-
-           import com.squareup.kotlinpoet.ksp.test.processor.AnnotationWithTypeArgs
-           import com.squareup.kotlinpoet.ksp.test.processor.ExampleAnnotation
-
-           @ExampleAnnotation
-           @AnnotationWithTypeArgs<E, String>
-           class Host<E>
-           """,
-        )
-      )
-    annotated.compile()
-    assertThat(File(annotated.kspSourcesDir, "kotlin/test/TestHost.kt").readText())
-      .isEqualTo(
-        """
-        package test
-
-        import com.squareup.kotlinpoet.ksp.test.processor.AnnotationWithTypeArgs
-        import kotlin.String
-
-        @AnnotationWithTypeArgs<E, String>
-        public class TestHost<E>
-
-        """
-          .trimIndent()
-      )
   }
 
   @Test


### PR DESCRIPTION
No-arg `KSType.toTypeName()` defaults to `TypeParameterResolver.EMPTY`. A generic supertype like `Comparable<T>` still carries a real `KSTypeParameter` for `T`, so `EMPTY.get("T")` threw `NoSuchElementException`. `KSAnnotation.toAnnotationSpec()` hits the same path after #1956.

When the supplied resolver is `EMPTY`, `toTypeName()` now resolves the type parameter from its enclosing declaration (the same `toTypeParameterResolver()` path used elsewhere in kotlinpoet-ksp). `EMPTY.get()` itself stays strict. Passing a real resolver is unchanged.

```kotlin
abstract class Subject<T> : Comparable<T>
// subject.superTypes.forEach { it.resolve().toTypeName() }
```

Fixes #2065

Tested:
- `./gradlew :interop:ksp:test-processor:test` on Temurin 21 (`JAVA_HOME` jdk-21.0.12+8): **18 tests, 0 failed** (`TestProcessorTest` 17 + `KsTypesTest` 1), including new `regression_2065`
- On HEAD without the production change, `regression_2065` and `smokeTest` failed with `NoSuchElementException: No TypeParameter found for index T`
- `:interop:ksp:spotlessCheck` and `:interop:ksp:test-processor:spotlessCheck` passed

- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.