### PR TITLE
Emit context parameters after annotations in FunSpec and PropertySpec

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ Change Log
  * Fix: `TypeVariableName.equals`/`hashCode` no longer overflow on recursively bound generics like `Enum<E : Enum<E>>`. (#1737)
  * Fix: `get` and `set` operator function names are no longer escaped with backticks. (#1869)
  * Fix: Don't special case varargs in `KSAnnotation.toAnnotationSpec`. (#2360)
+ * Fix: Emit context parameters after annotations in `FunSpec` and `PropertySpec`. (#2374)
 
 ## Version 2.3.0
 

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/FunSpec.kt
@@ -96,12 +96,12 @@ private constructor(
     } else {
       codeWriter.emitKdoc(kdoc.ensureEndsWithNewLine())
     }
+    codeWriter.emitAnnotations(annotations, false)
     if (contextParameters.isNotEmpty()) {
       codeWriter.emitContextParameters(contextParameters, suffix = "\n")
     } else {
       codeWriter.emitContextReceivers(contextReceiverTypes, suffix = "\n")
     }
-    codeWriter.emitAnnotations(annotations, false)
     codeWriter.emitModifiers(modifiers, implicitModifiers)
 
     if (!isConstructor && !name.isAccessor) {

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/PropertySpec.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/PropertySpec.kt
@@ -82,12 +82,12 @@ private constructor(
     if (emitKdoc) {
       codeWriter.emitKdoc(kdoc.ensureEndsWithNewLine())
     }
+    codeWriter.emitAnnotations(annotations, inlineAnnotations)
     if (contextParameters.isNotEmpty()) {
       codeWriter.emitContextParameters(contextParameters, suffix = "\n")
     } else {
       codeWriter.emitContextReceivers(contextReceiverTypes, suffix = "\n")
     }
-    codeWriter.emitAnnotations(annotations, inlineAnnotations)
     codeWriter.emitModifiers(propertyModifiers, implicitModifiers)
     codeWriter.emitCode(if (mutable) "var " else "val ")
     if (typeVariables.isNotEmpty()) {

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/FunSpecTest.kt
@@ -653,8 +653,8 @@ class FunSpecTest {
     assertThat(funSpec.toString())
       .isEqualTo(
         """
-        |context(kotlin.String)
         |@com.squareup.kotlinpoet.FunSpecTest.TestAnnotation
+        |context(kotlin.String)
         |public fun foo() {
         |}
         |"""
@@ -778,8 +778,8 @@ class FunSpecTest {
     assertThat(funSpec.toString())
       .isEqualTo(
         """
-        |context(user: kotlin.String)
         |@com.squareup.kotlinpoet.FunSpecTest.TestAnnotation
+        |context(user: kotlin.String)
         |public fun foo() {
         |}
         |"""

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/PropertySpecTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/PropertySpecTest.kt
@@ -748,8 +748,8 @@ class PropertySpecTest {
     assertThat(propertySpec.toString())
       .isEqualTo(
         """
-        |context(kotlin.String)
         |@com.squareup.kotlinpoet.PropertySpecTest.TestAnnotation
+        |context(kotlin.String)
         |val foo: kotlin.Int
         |  get() = length
         |"""
@@ -820,8 +820,8 @@ class PropertySpecTest {
     assertThat(propertySpec.toString())
       .isEqualTo(
         """
-        |context(str: kotlin.String)
         |@com.squareup.kotlinpoet.PropertySpecTest.TestAnnotation
+        |context(str: kotlin.String)
         |val foo: kotlin.Int
         |  get() = str.length
         |"""


### PR DESCRIPTION
Fixes #2372 

---

- [x] `docs/changelog.md` has been updated if applicable.
  - Changes not visible to library consumers, such as build script, documentation, or test code updates, don't need to
    be added to the changelog.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.
