### PR TITLE
Keep carriage returns and raw-string newlines in emitted string literals

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,8 @@ Change Log
 
 ## Unreleased
 
+ * Fix: Carriage returns are no longer lost in `%S` and `%P` string literals. (#2380)
+
 ## Version 2.4.0
 
 Thanks to [@eyupcanakman][eyupcanakman] and [@arimu1][arimu1] for contributing to this release.

--- a/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Util.kt
+++ b/kotlinpoet/src/commonMain/kotlin/com/squareup/kotlinpoet/Util.kt
@@ -89,7 +89,8 @@ internal fun stringLiteralWithQuotes(
   isInsideRawString: Boolean = false,
   isConstantContext: Boolean = false,
 ): String {
-  if (!isConstantContext && '\n' in value) {
+  // A raw string reads a bare carriage return as a line terminator, so use the escaped form.
+  if (!isConstantContext && '\n' in value && '\r' !in value) {
     val result = StringBuilder(value.length + 32)
     result.append("\"\"\"\n|")
     var i = 0
@@ -134,6 +135,11 @@ internal fun stringLiteralWithQuotes(
       // Trivial case: $ signs must be escaped.
       if (c == '$' && !isInsideRawString) {
         result.append("\${\'\$\'}")
+        continue
+      }
+      // Line terminators can't appear in a raw string literally, so splice them in as templates.
+      if (isInsideRawString && (c == '\r' || c == '\n')) {
+        result.append(if (c == '\r') "\${'\\r'}" else "\${'\\n'}")
         continue
       }
       // Default case: just let character literal do its work.

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/UtilTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/UtilTest.kt
@@ -71,6 +71,17 @@ class UtilTest {
     stringLiteral("e^{i\\\\pi}+1=0", "e^{i\\pi}+1=0")
     assertThat(stringLiteralWithQuotes("abc();\ndef();", isConstantContext = true))
       .isEqualTo("\"abc();\\ndef();\"")
+    assertThat(stringLiteralWithQuotes("abc();\r\ndef();")).isEqualTo("\"abc();\\r\\ndef();\"")
+    assertThat(stringLiteralWithQuotes("abc();\r\ndef();", isInsideRawString = true))
+      .isEqualTo("\"\"\"abc();\${'\\r'}\${'\\n'}def();\"\"\"")
+    assertThat(
+        stringLiteralWithQuotes(
+          "abc();\ndef();",
+          isInsideRawString = true,
+          isConstantContext = true,
+        )
+      )
+      .isEqualTo("\"\"\"abc();\${'\\n'}def();\"\"\"")
   }
 
   @Test


### PR DESCRIPTION
A carriage return could not survive `stringLiteralWithQuotes`. The margin form writes the value into a `"""` literal, the lexer reads a bare CR as a line terminator, and `trimMargin()` rejoins the lines with `\n`, so a CRLF value came out LF-only. The raw-string form used for `%P` lost it the same way, and in a constant context wrote a bare newline that picked up indentation.

Values carrying a CR now take the escaped form, and a raw string splices both line terminators in as `${'\r'}` and `${'\n'}`, as the file already does for `"` and `$`. Values with newlines only are unchanged.

Verified with the added `UtilTest.stringLiteral` cases, red on main and green with the change, and `./gradlew build`.

- [x] `docs/changelog.md` has been updated if applicable.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.

