### PR TITLE
Keep the package slot for default-package classes in Class.asClassName()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,8 @@ Change Log
 
 ## Unreleased
 
+ * Fix: `Class.asClassName()` no longer drops the package slot of a class in the default package. (#2382)
+
 ## Version 2.4.0
 
 Thanks to [@eyupcanakman][eyupcanakman] and [@arimu1][arimu1] for contributing to this release.

--- a/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/ClassName.kt
+++ b/kotlinpoet/src/jvmMain/kotlin/com/squareup/kotlinpoet/ClassName.kt
@@ -261,7 +261,7 @@ public fun Class<*>.asClassName(): ClassName {
   }
   // Avoid unreliable Class.getPackage(). https://github.com/square/javapoet/issues/295
   val lastDot = c.name.lastIndexOf('.')
-  if (lastDot != -1) names += c.name.substring(0, lastDot)
+  names += if (lastDot != -1) c.name.substring(0, lastDot) else ""
   names.reverse()
   return ClassName(names)
 }

--- a/kotlinpoet/src/jvmTest/java/DefaultPackageClass.java
+++ b/kotlinpoet/src/jvmTest/java/DefaultPackageClass.java
@@ -1,0 +1,3 @@
+public class DefaultPackageClass {
+  public static class Nested {}
+}

--- a/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/ClassNameTest.kt
+++ b/kotlinpoet/src/jvmTest/kotlin/com/squareup/kotlinpoet/ClassNameTest.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.kotlinpoet
 
+import DefaultPackageClass
 import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.containsExactly
@@ -109,6 +110,15 @@ class ClassNameTest {
       .isEqualTo("java.lang.Object")
     assertThat(OuterClass.InnerClass::class.java.asClassName().toString())
       .isEqualTo("com.squareup.kotlinpoet.ClassNameTest.OuterClass.InnerClass")
+  }
+
+  @Test fun classNameFromClassInDefaultPackage() {
+    val className = DefaultPackageClass::class.java.asClassName()
+    assertThat(className.packageName).isEqualTo("")
+    assertThat(className.simpleNames).containsExactly("DefaultPackageClass")
+    assertThat(className.toString()).isEqualTo("DefaultPackageClass")
+    assertThat(DefaultPackageClass.Nested::class.java.asClassName().reflectionName())
+      .isEqualTo("DefaultPackageClass\$Nested")
   }
 
   @Test fun classNameFromKClass() {


### PR DESCRIPTION
`Class<*>.asClassName()` appended the package element only when the binary name contained a dot, so a class in the default package produced a `ClassName` with no package slot. Every accessor reads that list positionally: `packageName` returned the class's own name, `simpleNames` was empty, and `toString()`, `reflectionName()`, `topLevelClassName()` and `peerClass()` threw `IndexOutOfBoundsException`.

The package element is now appended unconditionally, empty for the default package, which is the form `ClassName("", "Foo")` and `bestGuess("Foo")` already produce.

Verified with `classNameFromClassInDefaultPackage`, red on main and green with the change, and `./gradlew build`.

- [x] `docs/changelog.md` has been updated if applicable.
- [x] [CLA](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed.

